### PR TITLE
fix(oauth2): token_inactive error returned instead of invalid_grant

### DIFF
--- a/handler/oauth2/flow_refresh.go
+++ b/handler/oauth2/flow_refresh.go
@@ -65,7 +65,7 @@ func (c *RefreshTokenGrantHandler) HandleTokenEndpointRequest(ctx context.Contex
 			return errorsx.WithStack(e)
 		}
 
-		return errorsx.WithStack(oauth2.ErrInactiveToken.WithWrap(err).WithDebug(oauth2.ErrorToDebugRFC6749Error(err).Error()))
+		return errorsx.WithStack(oauth2.ErrInvalidGrant.WithWrap(err).WithDebug(oauth2.ErrorToDebugRFC6749Error(err).Error()))
 	case errors.Is(err, oauth2.ErrNotFound):
 		return errorsx.WithStack(oauth2.ErrInvalidGrant.WithWrap(err).WithDebugf("The refresh token has not been found: %s", oauth2.ErrorToDebugRFC6749Error(err).Error()))
 	default:

--- a/handler/oauth2/flow_refresh_test.go
+++ b/handler/oauth2/flow_refresh_test.go
@@ -396,7 +396,7 @@ func TestRefreshFlow_HandleTokenEndpointRequest(t *testing.T) {
 						err = store.RevokeRefreshToken(context.TODO(), req.ID)
 						require.NoError(t, err)
 					},
-					expectErr: oauth2.ErrInactiveToken,
+					expectErr: oauth2.ErrInvalidGrant,
 				},
 			} {
 				t.Run("case="+c.description, func(t *testing.T) {
@@ -488,7 +488,7 @@ func TestRefreshFlowTransactional_HandleTokenEndpointRequest(t *testing.T) {
 					Return(nil).
 					Times(1)
 			},
-			expectError: oauth2.ErrInactiveToken,
+			expectError: oauth2.ErrInvalidGrant,
 		},
 	} {
 		t.Run(fmt.Sprintf("scenario=%s", testCase.description), func(t *testing.T) {

--- a/integration/refresh_token_grant_test.go
+++ b/integration/refresh_token_grant_test.go
@@ -201,13 +201,13 @@ func TestRefreshTokenFlow(t *testing.T) {
 				tokenSource := oauthClient.TokenSource(context.TODO(), original)
 				_, err := tokenSource.Token()
 				require.Error(t, err)
-				require.Equal(t, http.StatusUnauthorized, err.(*xoauth2.RetrieveError).Response.StatusCode)
+				require.Equal(t, http.StatusBadRequest, err.(*xoauth2.RetrieveError).Response.StatusCode)
 
 				refreshed.Expiry = refreshed.Expiry.Add(-time.Hour * 24)
 				tokenSource = oauthClient.TokenSource(context.TODO(), refreshed)
 				_, err = tokenSource.Token()
 				require.Error(t, err)
-				require.Equal(t, http.StatusUnauthorized, err.(*xoauth2.RetrieveError).Response.StatusCode)
+				require.Equal(t, http.StatusBadRequest, err.(*xoauth2.RetrieveError).Response.StatusCode)
 			},
 		},
 	} {


### PR DESCRIPTION
This fixes an issue where the Refresh Flow handler doesn't return the correct RFC6749 error and status code.