### PR TITLE
feat(handler): revocation explicit refresh token policy

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,7 +6,7 @@ package oauth2
 import (
 	"context"
 
-	"github.com/go-jose/go-jose/v3"
+	jose "github.com/go-jose/go-jose/v3"
 
 	"authelia.com/provider/oauth2/internal/consts"
 )
@@ -80,6 +80,15 @@ type RefreshFlowScopeClient interface {
 	Client
 
 	GetRefreshFlowIgnoreOriginalGrantedScopes(ctx context.Context) (ignoreOriginalGrantedScopes bool)
+}
+
+// RevokeFlowRevokeRefreshTokensExplicitClient is a client which can be customized to only revoke Refresh Tokens
+// explicitly.
+type RevokeFlowRevokeRefreshTokensExplicitClient interface {
+	Client
+
+	// GetRevokeRefreshTokensExplicitly returns true if this client will only revoke refresh tokens explicitly.
+	GetRevokeRefreshTokensExplicitly(ctx context.Context) bool
 }
 
 // ResponseModeClient represents a client capable of handling response_mode

--- a/compose/compose_oauth2.go
+++ b/compose/compose_oauth2.go
@@ -81,6 +81,7 @@ func OAuth2TokenRevocationFactory(config oauth2.Configurator, storage any, strat
 		TokenRevocationStorage: storage.(hoauth2.TokenRevocationStorage),
 		AccessTokenStrategy:    strategy.(hoauth2.AccessTokenStrategy),
 		RefreshTokenStrategy:   strategy.(hoauth2.RefreshTokenStrategy),
+		Config:                 config,
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -210,6 +210,16 @@ type SendDebugMessagesToClientsProvider interface {
 	GetSendDebugMessagesToClients(ctx context.Context) bool
 }
 
+// RevokeRefreshTokensExplicitlyProvider returns the provider for configuring the Refresh Token Explicit Revocation policy.
+type RevokeRefreshTokensExplicitlyProvider interface {
+	// GetRevokeRefreshTokensExplicitly returns true if a refresh token should only be revoked explicitly.
+	GetRevokeRefreshTokensExplicitly(ctx context.Context) bool
+
+	// GetEnforceRevokeFlowRevokeRefreshTokensExplicitClient returns true if a
+	// RevokeFlowRevokeRefreshTokensExplicitClient returning false should be enforced.
+	GetEnforceRevokeFlowRevokeRefreshTokensExplicitClient(ctx context.Context) bool
+}
+
 // JWKSFetcherStrategyProvider returns the provider for configuring the JWKS fetcher strategy.
 type JWKSFetcherStrategyProvider interface {
 	// GetJWKSFetcherStrategy returns the JWKS fetcher strategy.

--- a/config_default.go
+++ b/config_default.go
@@ -95,6 +95,13 @@ type Config struct {
 	// codes or other information. Proceed with caution!
 	SendDebugMessagesToClients bool
 
+	// RevokeRefreshTokensExplicitly determines if Refresh Tokens should only be revoked explicitly.
+	RevokeRefreshTokensExplicitly bool
+
+	// EnforceRevokeFlowRevokeRefreshTokensExplicitClient determines if a RevokeFlowRevokeRefreshTokensExplicitClient
+	// should be prioritized even if it returns false.
+	EnforceRevokeFlowRevokeRefreshTokensExplicitClient bool
+
 	// ScopeStrategy sets the scope strategy that should be supported, for example oauth2.WildcardScopeStrategy.
 	ScopeStrategy ScopeStrategy
 
@@ -281,6 +288,14 @@ func (c *Config) GetResponseModeHandlerExtension(ctx context.Context) ResponseMo
 
 func (c *Config) GetSendDebugMessagesToClients(ctx context.Context) bool {
 	return c.SendDebugMessagesToClients
+}
+
+func (c *Config) GetRevokeRefreshTokensExplicitly(ctx context.Context) bool {
+	return c.RevokeRefreshTokensExplicitly
+}
+
+func (c *Config) GetEnforceRevokeFlowRevokeRefreshTokensExplicitClient(ctx context.Context) bool {
+	return c.EnforceRevokeFlowRevokeRefreshTokensExplicitClient
 }
 
 func (c *Config) GetIDTokenIssuer(ctx context.Context) string {

--- a/fosite.go
+++ b/fosite.go
@@ -120,6 +120,7 @@ type Configurator interface {
 	ClientAuthenticationStrategyProvider
 	ResponseModeHandlerExtensionProvider
 	SendDebugMessagesToClientsProvider
+	RevokeRefreshTokensExplicitlyProvider
 	JWKSFetcherStrategyProvider
 	ClientAuthenticationStrategyProvider
 	ResponseModeHandlerExtensionProvider


### PR DESCRIPTION
This allows defining a policy either globally or per client or a combination of both which allows access tokens to be revoked individually without revoking the refresh token.