### PR TITLE
fix: jwt strategy retains original iat and nbf claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ following list of differences:
         request
   - [ ] Response Type None
   - [ ] Client Secret Validation Interface
+  - [ ] Clock Drift Support
+  - [ ] Injectable Clock Configurator
+  - [ ] Support `s_hash`
 - Removal of the following dependencies:
   - [x] `go.opentelemetry.io/otel/trace`
   - [x] `github.com/ecordell/optgen`

--- a/handler/oauth2/strategy_jwt.go
+++ b/handler/oauth2/strategy_jwt.go
@@ -115,12 +115,14 @@ func (h *DefaultJWTStrategy) generate(ctx context.Context, tokenType oauth2.Toke
 		return "", "", errors.New("GetTokenClaims() must not be nil")
 	} else {
 		claims := jwtSession.GetJWTClaims().
+			Sanitize().
 			With(
 				jwtSession.GetExpiresAt(tokenType),
 				requester.GetGrantedScopes(),
 				requester.GetGrantedAudience(),
 			).
 			WithDefaults(
+				time.Now().UTC(),
 				time.Now().UTC(),
 				h.Config.GetAccessTokenIssuer(ctx),
 			).

--- a/token/jwt/claims_jwt.go
+++ b/token/jwt/claims_jwt.go
@@ -30,12 +30,15 @@ type JWTClaimsDefaults struct {
 }
 
 type JWTClaimsContainer interface {
+	// Sanitize should clear the IssuedAt and NotBefore values.
+	Sanitize() JWTClaimsContainer
+
 	// With returns a copy of itself with expiresAt, scope, audience set to the given values.
 	With(expiry time.Time, scope, audience []string) JWTClaimsContainer
 
 	// WithDefaults returns a copy of itself with issuedAt and issuer set to the given default values. If those
 	// values are already set in the claims, they will not be updated.
-	WithDefaults(iat time.Time, issuer string) JWTClaimsContainer
+	WithDefaults(iat, nbf time.Time, issuer string) JWTClaimsContainer
 
 	// WithScopeField configures how a scope field should be represented in JWT.
 	WithScopeField(scopeField JWTScopeFieldEnum) JWTClaimsContainer
@@ -65,9 +68,20 @@ func (c *JWTClaims) With(expiry time.Time, scope, audience []string) JWTClaimsCo
 	return c
 }
 
-func (c *JWTClaims) WithDefaults(iat time.Time, issuer string) JWTClaimsContainer {
+func (c *JWTClaims) Sanitize() JWTClaimsContainer {
+	c.IssuedAt = time.Time{}
+	c.NotBefore = time.Time{}
+
+	return c
+}
+
+func (c *JWTClaims) WithDefaults(iat, nbf time.Time, issuer string) JWTClaimsContainer {
 	if c.IssuedAt.IsZero() {
 		c.IssuedAt = iat
+	}
+
+	if c.NotBefore.IsZero() {
+		c.NotBefore = nbf
 	}
 
 	if c.Issuer == "" {


### PR DESCRIPTION
This fixes an issue with the claims 'iat' and 'nbf' would retain their original values.