### PR TITLE
fix(openid): narrow state hash conditions

### DIFF
--- a/handler/openid/flow_hybrid_test.go
+++ b/handler/openid/flow_hybrid_test.go
@@ -236,7 +236,7 @@ func TestHybrid_HandleAuthorizeEndpointRequest(t *testing.T) {
 			setup: func(t *testing.T, request *oauth2.AuthorizeRequest, response *oauth2.AuthorizeResponse) OpenIDConnectHybridHandler {
 				request.Form.Set(consts.FormParameterNonce, "some-foobar-nonce-win")
 				request.Form.Set(consts.FormParameterState, "some-foobar-state-win")
-				request.ResponseTypes = oauth2.Arguments{consts.ResponseTypeAuthorizationCodeFlow, consts.ResponseTypeImplicitFlowToken, consts.ResponseTypeImplicitFlowIDToken}
+				request.ResponseTypes = oauth2.Arguments{consts.ResponseTypeAuthorizationCodeFlow, consts.ResponseTypeImplicitFlowIDToken}
 				request.State = "some-foobar-state-win"
 				request.GrantedScope = oauth2.Arguments{consts.ScopeOpenID}
 


### PR DESCRIPTION
This ensures the state hash is only included with the 'code id_token' response type as it's the only response type that benefits from it. See the FAPI 1.0 and FAPI 2.0 specs for more information:
 - https://openid.net/specs/openid-financial-api-part-2-1_0.html#id-token-as-detached-signature-2
 - https://openid.bitbucket.io/fapi/fapi-2_0-security-profile.html#section-5.6