### PR TITLE
feat(jarm): jwt-secured authorization response mode

### DIFF
--- a/authorize_helper.go
+++ b/authorize_helper.go
@@ -198,9 +198,10 @@ func WriteAuthorizeFormPostResponse(redirectURL string, parameters url.Values, t
 	})
 }
 
-func GetPostFormHTMLTemplate(ctx context.Context, f *Fosite) *template.Template {
-	if t := f.Config.GetFormPostHTMLTemplate(ctx); t != nil {
+func GetPostFormHTMLTemplate(ctx context.Context, c FormPostHTMLTemplateProvider) *template.Template {
+	if t := c.GetFormPostHTMLTemplate(ctx); t != nil {
 		return t
 	}
+
 	return DefaultFormPostTemplate
 }

--- a/authorize_request.go
+++ b/authorize_request.go
@@ -12,10 +12,14 @@ import (
 type ResponseModeType string
 
 const (
-	ResponseModeDefault  = ResponseModeType("")
-	ResponseModeFormPost = ResponseModeType(consts.ResponseModeFormPost)
-	ResponseModeQuery    = ResponseModeType(consts.ResponseModeQuery)
-	ResponseModeFragment = ResponseModeType(consts.ResponseModeFragment)
+	ResponseModeDefault     = ResponseModeType("")
+	ResponseModeFormPost    = ResponseModeType(consts.ResponseModeFormPost)
+	ResponseModeQuery       = ResponseModeType(consts.ResponseModeQuery)
+	ResponseModeFragment    = ResponseModeType(consts.ResponseModeFragment)
+	ResponseModeFormPostJWT = ResponseModeType(consts.ResponseModeFormPostJWT)
+	ResponseModeQueryJWT    = ResponseModeType(consts.ResponseModeQueryJWT)
+	ResponseModeFragmentJWT = ResponseModeType(consts.ResponseModeFragmentJWT)
+	ResponseModeJWT         = ResponseModeType(consts.ResponseModeJWT)
 )
 
 // AuthorizeRequest is an implementation of AuthorizeRequester

--- a/authorize_write.go
+++ b/authorize_write.go
@@ -10,52 +10,16 @@ import (
 	"authelia.com/provider/oauth2/internal/consts"
 )
 
-func (f *Fosite) WriteAuthorizeResponse(ctx context.Context, rw http.ResponseWriter, ar AuthorizeRequester, resp AuthorizeResponder) {
-	// Set custom headers, e.g. "X-MySuperCoolCustomHeader" or "X-DONT-CACHE-ME"...
-	wh := rw.Header()
-	rh := resp.GetHeader()
-	for k := range rh {
-		wh.Set(k, rh.Get(k))
-	}
+func (f *Fosite) WriteAuthorizeResponse(ctx context.Context, rw http.ResponseWriter, requester AuthorizeRequester, responder AuthorizeResponder) {
+	for _, handler := range f.ResponseModeHandlers(ctx) {
+		if handler.ResponseModes().Has(requester.GetResponseMode()) {
+			handler.WriteAuthorizeResponse(ctx, rw, requester, responder)
 
-	wh.Set(consts.HeaderCacheControl, consts.CacheControlNoStore)
-	wh.Set(consts.HeaderPragma, consts.PragmaNoCache)
-
-	redir := ar.GetRedirectURI()
-	switch rm := ar.GetResponseMode(); rm {
-	case ResponseModeFormPost:
-		//form_post
-		rw.Header().Add(consts.HeaderContentType, consts.ContentTypeTextHTML)
-		WriteAuthorizeFormPostResponse(redir.String(), resp.GetParameters(), GetPostFormHTMLTemplate(ctx, f), rw)
-		return
-	case ResponseModeQuery, ResponseModeDefault:
-		// Explicit grants
-		q := redir.Query()
-		rq := resp.GetParameters()
-		for k := range rq {
-			q.Set(k, rq.Get(k))
-		}
-		redir.RawQuery = q.Encode()
-		sendRedirect(redir.String(), rw)
-		return
-	case ResponseModeFragment:
-		// Implicit grants
-		// The endpoint URI MUST NOT include a fragment component.
-		redir.Fragment = ""
-
-		u := redir.String()
-		fr := resp.GetParameters()
-		if len(fr) > 0 {
-			u = u + "#" + fr.Encode()
-		}
-		sendRedirect(u, rw)
-		return
-	default:
-		if f.ResponseModeHandler(ctx).ResponseModes().Has(rm) {
-			f.ResponseModeHandler(ctx).WriteAuthorizeResponse(ctx, rw, ar, resp)
 			return
 		}
 	}
+
+	f.handleWriteAuthorizeErrorJSON(ctx, rw, ErrServerError.WithHint("The Authorization Server was unable to process the requested Response Mode."))
 }
 
 // https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1

--- a/client.go
+++ b/client.go
@@ -6,7 +6,7 @@ package oauth2
 import (
 	"context"
 
-	jose "github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v3"
 
 	"authelia.com/provider/oauth2/internal/consts"
 )
@@ -89,6 +89,16 @@ type RevokeFlowRevokeRefreshTokensExplicitClient interface {
 
 	// GetRevokeRefreshTokensExplicitly returns true if this client will only revoke refresh tokens explicitly.
 	GetRevokeRefreshTokensExplicitly(ctx context.Context) bool
+}
+
+// JARMClient is a client which supports JARM.
+type JARMClient interface {
+	Client
+
+	GetAuthorizationSignedResponseKeyID() (kid string)
+	GetAuthorizationSignedResponseAlg() (alg string)
+	GetAuthorizationEncryptedResponseAlg() (alg string)
+	GetAuthorizationEncryptedResponseEncryptionAlg() (alg string)
 }
 
 // ResponseModeClient represents a client capable of handling response_mode

--- a/config.go
+++ b/config.go
@@ -106,6 +106,23 @@ type JWTScopeFieldProvider interface {
 	GetJWTScopeField(ctx context.Context) jwt.JWTScopeFieldEnum
 }
 
+// JWTSecuredAuthorizeResponseModeIssuerProvider returns the provider for configuring the JARM issuer.
+type JWTSecuredAuthorizeResponseModeIssuerProvider interface {
+	// GetJWTSecuredAuthorizeResponseModeIssuer returns the JARM issuer.
+	GetJWTSecuredAuthorizeResponseModeIssuer(ctx context.Context) string
+}
+
+// JWTSecuredAuthorizeResponseModeSignerProvider returns the provider for configuring the JARM signer.
+type JWTSecuredAuthorizeResponseModeSignerProvider interface {
+	// GetJWTSecuredAuthorizeResponseModeSigner returns the JARM signer.
+	GetJWTSecuredAuthorizeResponseModeSigner(ctx context.Context) jwt.Signer
+}
+
+// JWTSecuredAuthorizeResponseModeLifespanProvider returns the provider for configuring the JWT Secured Authorize Response Mode token lifespan.
+type JWTSecuredAuthorizeResponseModeLifespanProvider interface {
+	GetJWTSecuredAuthorizeResponseModeLifespan(ctx context.Context) time.Duration
+}
+
 // AllowedPromptsProvider returns the provider for configuring the allowed prompts.
 type AllowedPromptsProvider interface {
 	// GetAllowedPrompts returns the allowed prompts.
@@ -238,10 +255,10 @@ type ClientAuthenticationStrategyProvider interface {
 	GetClientAuthenticationStrategy(ctx context.Context) ClientAuthenticationStrategy
 }
 
-// ResponseModeHandlerExtensionProvider returns the provider for configuring the response mode handler extension.
-type ResponseModeHandlerExtensionProvider interface {
-	// GetResponseModeHandlerExtension returns the response mode handler extension.
-	GetResponseModeHandlerExtension(ctx context.Context) ResponseModeHandler
+// ResponseModeHandlerProvider returns the provider for configuring the response mode handlers.
+type ResponseModeHandlerProvider interface {
+	// GetResponseModeHandlers returns the response mode handlers in order of execution.
+	GetResponseModeHandlers(ctx context.Context) []ResponseModeHandler
 }
 
 // MessageCatalogProvider returns the provider for configuring the message catalog.

--- a/config_default.go
+++ b/config_default.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 	"time"
 
-	retryablehttp "github.com/hashicorp/go-retryablehttp"
+	"github.com/hashicorp/go-retryablehttp"
 
 	"authelia.com/provider/oauth2/i18n"
 	"authelia.com/provider/oauth2/internal/consts"
@@ -23,45 +23,48 @@ const (
 )
 
 var (
-	_ AuthorizeCodeLifespanProvider                = (*Config)(nil)
-	_ RefreshTokenLifespanProvider                 = (*Config)(nil)
-	_ AccessTokenLifespanProvider                  = (*Config)(nil)
-	_ ScopeStrategyProvider                        = (*Config)(nil)
-	_ AudienceStrategyProvider                     = (*Config)(nil)
-	_ RedirectSecureCheckerProvider                = (*Config)(nil)
-	_ RefreshTokenScopesProvider                   = (*Config)(nil)
-	_ DisableRefreshTokenValidationProvider        = (*Config)(nil)
-	_ AccessTokenIssuerProvider                    = (*Config)(nil)
-	_ JWTScopeFieldProvider                        = (*Config)(nil)
-	_ AllowedPromptsProvider                       = (*Config)(nil)
-	_ OmitRedirectScopeParamProvider               = (*Config)(nil)
-	_ MinParameterEntropyProvider                  = (*Config)(nil)
-	_ SanitationAllowedProvider                    = (*Config)(nil)
-	_ EnforcePKCEForPublicClientsProvider          = (*Config)(nil)
-	_ EnablePKCEPlainChallengeMethodProvider       = (*Config)(nil)
-	_ EnforcePKCEProvider                          = (*Config)(nil)
-	_ GrantTypeJWTBearerCanSkipClientAuthProvider  = (*Config)(nil)
-	_ GrantTypeJWTBearerIDOptionalProvider         = (*Config)(nil)
-	_ GrantTypeJWTBearerIssuedDateOptionalProvider = (*Config)(nil)
-	_ GetJWTMaxDurationProvider                    = (*Config)(nil)
-	_ IDTokenLifespanProvider                      = (*Config)(nil)
-	_ IDTokenIssuerProvider                        = (*Config)(nil)
-	_ JWKSFetcherStrategyProvider                  = (*Config)(nil)
-	_ ClientAuthenticationStrategyProvider         = (*Config)(nil)
-	_ SendDebugMessagesToClientsProvider           = (*Config)(nil)
-	_ ResponseModeHandlerExtensionProvider         = (*Config)(nil)
-	_ MessageCatalogProvider                       = (*Config)(nil)
-	_ FormPostHTMLTemplateProvider                 = (*Config)(nil)
-	_ TokenURLProvider                             = (*Config)(nil)
-	_ GetSecretsHashingProvider                    = (*Config)(nil)
-	_ HTTPClientProvider                           = (*Config)(nil)
-	_ HMACHashingProvider                          = (*Config)(nil)
-	_ AuthorizeEndpointHandlersProvider            = (*Config)(nil)
-	_ TokenEndpointHandlersProvider                = (*Config)(nil)
-	_ TokenIntrospectionHandlersProvider           = (*Config)(nil)
-	_ RevocationHandlersProvider                   = (*Config)(nil)
-	_ PushedAuthorizeRequestHandlersProvider       = (*Config)(nil)
-	_ PushedAuthorizeRequestConfigProvider         = (*Config)(nil)
+	_ AuthorizeCodeLifespanProvider                   = (*Config)(nil)
+	_ RefreshTokenLifespanProvider                    = (*Config)(nil)
+	_ AccessTokenLifespanProvider                     = (*Config)(nil)
+	_ ScopeStrategyProvider                           = (*Config)(nil)
+	_ AudienceStrategyProvider                        = (*Config)(nil)
+	_ RedirectSecureCheckerProvider                   = (*Config)(nil)
+	_ RefreshTokenScopesProvider                      = (*Config)(nil)
+	_ DisableRefreshTokenValidationProvider           = (*Config)(nil)
+	_ AccessTokenIssuerProvider                       = (*Config)(nil)
+	_ JWTScopeFieldProvider                           = (*Config)(nil)
+	_ JWTSecuredAuthorizeResponseModeIssuerProvider   = (*Config)(nil)
+	_ JWTSecuredAuthorizeResponseModeSignerProvider   = (*Config)(nil)
+	_ JWTSecuredAuthorizeResponseModeLifespanProvider = (*Config)(nil)
+	_ AllowedPromptsProvider                          = (*Config)(nil)
+	_ OmitRedirectScopeParamProvider                  = (*Config)(nil)
+	_ MinParameterEntropyProvider                     = (*Config)(nil)
+	_ SanitationAllowedProvider                       = (*Config)(nil)
+	_ EnforcePKCEForPublicClientsProvider             = (*Config)(nil)
+	_ EnablePKCEPlainChallengeMethodProvider          = (*Config)(nil)
+	_ EnforcePKCEProvider                             = (*Config)(nil)
+	_ GrantTypeJWTBearerCanSkipClientAuthProvider     = (*Config)(nil)
+	_ GrantTypeJWTBearerIDOptionalProvider            = (*Config)(nil)
+	_ GrantTypeJWTBearerIssuedDateOptionalProvider    = (*Config)(nil)
+	_ GetJWTMaxDurationProvider                       = (*Config)(nil)
+	_ IDTokenLifespanProvider                         = (*Config)(nil)
+	_ IDTokenIssuerProvider                           = (*Config)(nil)
+	_ JWKSFetcherStrategyProvider                     = (*Config)(nil)
+	_ ClientAuthenticationStrategyProvider            = (*Config)(nil)
+	_ SendDebugMessagesToClientsProvider              = (*Config)(nil)
+	_ ResponseModeHandlerProvider                     = (*Config)(nil)
+	_ MessageCatalogProvider                          = (*Config)(nil)
+	_ FormPostHTMLTemplateProvider                    = (*Config)(nil)
+	_ TokenURLProvider                                = (*Config)(nil)
+	_ GetSecretsHashingProvider                       = (*Config)(nil)
+	_ HTTPClientProvider                              = (*Config)(nil)
+	_ HMACHashingProvider                             = (*Config)(nil)
+	_ AuthorizeEndpointHandlersProvider               = (*Config)(nil)
+	_ TokenEndpointHandlersProvider                   = (*Config)(nil)
+	_ TokenIntrospectionHandlersProvider              = (*Config)(nil)
+	_ RevocationHandlersProvider                      = (*Config)(nil)
+	_ PushedAuthorizeRequestHandlersProvider          = (*Config)(nil)
+	_ PushedAuthorizeRequestConfigProvider            = (*Config)(nil)
 )
 
 type Config struct {
@@ -161,8 +164,8 @@ type Config struct {
 	// ClientAuthenticationStrategy indicates the Strategy to authenticate client requests
 	ClientAuthenticationStrategy ClientAuthenticationStrategy
 
-	// ResponseModeHandlerExtension provides a handler for custom response modes
-	ResponseModeHandlerExtension ResponseModeHandler
+	// ResponseModeHandlers provides the handlers for performing response mode formatting.
+	ResponseModeHandlers []ResponseModeHandler
 
 	// MessageCatalog is the message bundle used for i18n
 	MessageCatalog i18n.MessageCatalog
@@ -179,6 +182,16 @@ type Config struct {
 
 	// JWTScopeClaimKey defines the claim key to be used to set the scope in. Valid fields are "scope" or "scp" or both.
 	JWTScopeClaimKey jwt.JWTScopeFieldEnum
+
+	// JWTSecuredAuthorizeResponseModeIssuer sets the default issuer for the JWT Secured Authorization Response Mode.
+	JWTSecuredAuthorizeResponseModeIssuer string
+
+	// JWTSecuredAuthorizeResponseModeLifespan sets the default lifetime for the tokens issued in the
+	// JWT Secured Authorization Response Mode. Defaults to 10 minutes.
+	JWTSecuredAuthorizeResponseModeLifespan time.Duration
+
+	// JWTSecuredAuthorizeResponseModeSigner is the signer for JWT Secured Authorization Response Mode. Has no default.
+	JWTSecuredAuthorizeResponseModeSigner jwt.Signer
 
 	// AccessTokenIssuer is the issuer to be used when generating access tokens.
 	AccessTokenIssuer string
@@ -260,6 +273,7 @@ func (c *Config) GetHTTPClient(ctx context.Context) *retryablehttp.Client {
 	if c.HTTPClient == nil {
 		return retryablehttp.NewClient()
 	}
+
 	return c.HTTPClient
 }
 
@@ -267,6 +281,7 @@ func (c *Config) GetSecretsHasher(ctx context.Context) Hasher {
 	if c.ClientSecretsHasher == nil {
 		c.ClientSecretsHasher = &BCrypt{Config: c}
 	}
+
 	return c.ClientSecretsHasher
 }
 
@@ -282,8 +297,12 @@ func (c *Config) GetMessageCatalog(ctx context.Context) i18n.MessageCatalog {
 	return c.MessageCatalog
 }
 
-func (c *Config) GetResponseModeHandlerExtension(ctx context.Context) ResponseModeHandler {
-	return c.ResponseModeHandlerExtension
+func (c *Config) GetResponseModeHandlers(ctx context.Context) []ResponseModeHandler {
+	if len(c.ResponseModeHandlers) == 0 {
+		c.ResponseModeHandlers = []ResponseModeHandler{&DefaultResponseModeHandler{Config: c}}
+	}
+
+	return c.ResponseModeHandlers
 }
 
 func (c *Config) GetSendDebugMessagesToClients(ctx context.Context) bool {
@@ -350,6 +369,14 @@ func (c *Config) GetJWTScopeField(ctx context.Context) jwt.JWTScopeFieldEnum {
 	return c.JWTScopeClaimKey
 }
 
+func (c *Config) GetJWTSecuredAuthorizeResponseModeIssuer(ctx context.Context) string {
+	return c.IDTokenIssuer
+}
+
+func (c *Config) GetJWTSecuredAuthorizeResponseModeSigner(ctx context.Context) jwt.Signer {
+	return c.JWTSecuredAuthorizeResponseModeSigner
+}
+
 func (c *Config) GetAllowedPrompts(_ context.Context) []string {
 	return c.AllowedPromptValues
 }
@@ -359,6 +386,7 @@ func (c *Config) GetScopeStrategy(_ context.Context) ScopeStrategy {
 	if c.ScopeStrategy == nil {
 		c.ScopeStrategy = WildcardScopeStrategy
 	}
+
 	return c.ScopeStrategy
 }
 
@@ -367,6 +395,7 @@ func (c *Config) GetAudienceStrategy(_ context.Context) AudienceMatchingStrategy
 	if c.AudienceMatchingStrategy == nil {
 		c.AudienceMatchingStrategy = DefaultAudienceMatchingStrategy
 	}
+
 	return c.AudienceMatchingStrategy
 }
 
@@ -375,6 +404,7 @@ func (c *Config) GetAuthorizeCodeLifespan(_ context.Context) time.Duration {
 	if c.AuthorizeCodeLifespan == 0 {
 		return time.Minute * 15
 	}
+
 	return c.AuthorizeCodeLifespan
 }
 
@@ -383,6 +413,7 @@ func (c *Config) GetIDTokenLifespan(_ context.Context) time.Duration {
 	if c.IDTokenLifespan == 0 {
 		return time.Hour
 	}
+
 	return c.IDTokenLifespan
 }
 
@@ -391,6 +422,7 @@ func (c *Config) GetAccessTokenLifespan(_ context.Context) time.Duration {
 	if c.AccessTokenLifespan == 0 {
 		return time.Hour
 	}
+
 	return c.AccessTokenLifespan
 }
 
@@ -399,6 +431,7 @@ func (c *Config) GetVerifiableCredentialsNonceLifespan(_ context.Context) time.D
 	if c.VerifiableCredentialsNonceLifespan == 0 {
 		return time.Hour
 	}
+
 	return c.VerifiableCredentialsNonceLifespan
 }
 
@@ -408,7 +441,17 @@ func (c *Config) GetRefreshTokenLifespan(_ context.Context) time.Duration {
 	if c.RefreshTokenLifespan == 0 {
 		return time.Hour * 24 * 30
 	}
+
 	return c.RefreshTokenLifespan
+}
+
+// GetJWTSecuredAuthorizeResponseModeLifespan returns how long a JWT issued by the JWT Secured Authorize Response Mode should be valid. Defaults to 10 minutes.
+func (c *Config) GetJWTSecuredAuthorizeResponseModeLifespan(_ context.Context) time.Duration {
+	if c.JWTSecuredAuthorizeResponseModeLifespan == 0 {
+		return time.Minute * 10
+	}
+
+	return c.JWTSecuredAuthorizeResponseModeLifespan
 }
 
 // GetBCryptCost returns the bcrypt cost factor. Defaults to 12.
@@ -416,6 +459,7 @@ func (c *Config) GetBCryptCost(_ context.Context) int {
 	if c.HashCost == 0 {
 		return DefaultBCryptWorkFactor
 	}
+
 	return c.HashCost
 }
 
@@ -424,6 +468,7 @@ func (c *Config) GetJWKSFetcherStrategy(_ context.Context) JWKSFetcherStrategy {
 	if c.JWKSFetcherStrategy == nil {
 		c.JWKSFetcherStrategy = NewDefaultJWKSFetcherStrategy()
 	}
+
 	return c.JWKSFetcherStrategy
 }
 
@@ -432,6 +477,7 @@ func (c *Config) GetTokenEntropy(_ context.Context) int {
 	if c.TokenEntropy == 0 {
 		return 32
 	}
+
 	return c.TokenEntropy
 }
 
@@ -440,6 +486,7 @@ func (c *Config) GetRedirectSecureChecker(_ context.Context) func(context.Contex
 	if c.RedirectSecureChecker == nil {
 		return IsRedirectURISecure
 	}
+
 	return c.RedirectSecureChecker
 }
 
@@ -448,6 +495,7 @@ func (c *Config) GetRefreshTokenScopes(_ context.Context) []string {
 	if c.RefreshTokenScopes == nil {
 		return []string{consts.ScopeOffline, consts.ScopeOfflineAccess}
 	}
+
 	return c.RefreshTokenScopes
 }
 
@@ -455,9 +503,9 @@ func (c *Config) GetRefreshTokenScopes(_ context.Context) []string {
 func (c *Config) GetMinParameterEntropy(_ context.Context) int {
 	if c.MinParameterEntropy == 0 {
 		return MinParameterEntropy
-	} else {
-		return c.MinParameterEntropy
 	}
+
+	return c.MinParameterEntropy
 }
 
 // GetJWTMaxDuration specified the maximum amount of allowed `exp` time for a JWT. It compares
@@ -468,6 +516,7 @@ func (c *Config) GetJWTMaxDuration(_ context.Context) time.Duration {
 	if c.GrantTypeJWTBearerMaxDuration == 0 {
 		return time.Hour * 24
 	}
+
 	return c.GrantTypeJWTBearerMaxDuration
 }
 

--- a/errors.go
+++ b/errors.go
@@ -534,6 +534,15 @@ func (e *RFC6749Error) computeHintField() {
 	e.HintField = i18n.GetMessageOrDefault(e.catalog, e.hintIDField, e.lang, e.HintField, e.hintArgs...)
 }
 
+func ErrorToRFC6749ErrorFallback(err error, fallback *RFC6749Error) *RFC6749Error {
+	var e *RFC6749Error
+	if errors.As(err, &e) {
+		return e
+	}
+
+	return fallback.WithWrap(err).WithDebug(err.Error())
+}
+
 // ErrorToDebugRFC6749Error converts the provided error to a *DebugRFC6749Error provided it is not nil and can be
 // cast as a *RFC6749Error.
 func ErrorToDebugRFC6749Error(err error) (rfc error) {

--- a/fosite.go
+++ b/fosite.go
@@ -10,8 +10,6 @@ import (
 
 const MinParameterEntropy = 8
 
-var defaultResponseModeHandler = &DefaultResponseModeHandler{}
-
 // AuthorizeEndpointHandlers is a list of AuthorizeEndpointHandler
 type AuthorizeEndpointHandlers []AuthorizeEndpointHandler
 
@@ -101,6 +99,9 @@ type Configurator interface {
 	OmitRedirectScopeParamProvider
 	SanitationAllowedProvider
 	JWTScopeFieldProvider
+	JWTSecuredAuthorizeResponseModeIssuerProvider
+	JWTSecuredAuthorizeResponseModeSignerProvider
+	JWTSecuredAuthorizeResponseModeLifespanProvider
 	AccessTokenIssuerProvider
 	DisableRefreshTokenValidationProvider
 	RefreshTokenScopesProvider
@@ -118,12 +119,11 @@ type Configurator interface {
 	MinParameterEntropyProvider
 	HMACHashingProvider
 	ClientAuthenticationStrategyProvider
-	ResponseModeHandlerExtensionProvider
+	ResponseModeHandlerProvider
 	SendDebugMessagesToClientsProvider
 	RevokeRefreshTokensExplicitlyProvider
 	JWKSFetcherStrategyProvider
 	ClientAuthenticationStrategyProvider
-	ResponseModeHandlerExtensionProvider
 	MessageCatalogProvider
 	FormPostHTMLTemplateProvider
 	TokenURLProvider
@@ -155,9 +155,7 @@ func (f *Fosite) GetMinParameterEntropy(ctx context.Context) int {
 	return MinParameterEntropy
 }
 
-func (f *Fosite) ResponseModeHandler(ctx context.Context) ResponseModeHandler {
-	if ext := f.Config.GetResponseModeHandlerExtension(ctx); ext != nil {
-		return ext
-	}
-	return defaultResponseModeHandler
+// ResponseModeHandlers returns the configured ResponseModeHandler implementations for this instance.
+func (f *Fosite) ResponseModeHandlers(ctx context.Context) []ResponseModeHandler {
+	return f.Config.GetResponseModeHandlers(ctx)
 }

--- a/handler/rfc7523/handler_test.go
+++ b/handler/rfc7523/handler_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	jose "github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v3"
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"

--- a/internal/reflection/field.go
+++ b/internal/reflection/field.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 )
 
-func GetField(obj interface{}, name string) (interface{}, error) {
+func GetField(obj any, name string) (any, error) {
 	if !hasValidType(obj, []reflect.Kind{reflect.Struct, reflect.Ptr}) {
 		return nil, errors.New("Cannot use GetField on a non-struct interface")
 	}
@@ -20,7 +20,7 @@ func GetField(obj interface{}, name string) (interface{}, error) {
 	return field.Interface(), nil
 }
 
-func hasValidType(obj interface{}, types []reflect.Kind) bool {
+func hasValidType(obj any, types []reflect.Kind) bool {
 	for _, t := range types {
 		if reflect.TypeOf(obj).Kind() == t {
 			return true
@@ -30,7 +30,7 @@ func hasValidType(obj interface{}, types []reflect.Kind) bool {
 	return false
 }
 
-func reflectValue(obj interface{}) reflect.Value {
+func reflectValue(obj any) reflect.Value {
 	var val reflect.Value
 
 	if reflect.TypeOf(obj).Kind() == reflect.Ptr {

--- a/response_handler.go
+++ b/response_handler.go
@@ -5,10 +5,179 @@ package oauth2
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"net/url"
+
+	"authelia.com/provider/oauth2/internal/consts"
+	"authelia.com/provider/oauth2/internal/errorsx"
+	"authelia.com/provider/oauth2/token/jarm"
 )
 
-// ResponseModeHandler provides a contract for handling custom response modes
+type DefaultResponseModeHandler struct {
+	Config ResponseModeHandlerConfigurator
+}
+
+var (
+	_ ResponseModeHandler = (*DefaultResponseModeHandler)(nil)
+)
+
+// ResponseModes returns the response modes this fosite.ResponseModeHandler is responsible for.
+func (h *DefaultResponseModeHandler) ResponseModes() ResponseModeTypes {
+	return ResponseModeTypes{
+		ResponseModeDefault,
+		ResponseModeQuery,
+		ResponseModeFragment,
+		ResponseModeFormPost,
+		ResponseModeJWT,
+		ResponseModeQueryJWT,
+		ResponseModeFragmentJWT,
+		ResponseModeFormPostJWT,
+	}
+}
+
+// WriteAuthorizeResponse writes authorization responses.
+func (h *DefaultResponseModeHandler) WriteAuthorizeResponse(ctx context.Context, rw http.ResponseWriter, requester AuthorizeRequester, responder AuthorizeResponder) {
+	header := rw.Header()
+
+	header.Set(consts.HeaderCacheControl, consts.CacheControlNoStore)
+	header.Set(consts.HeaderPragma, consts.PragmaNoCache)
+
+	rheader := responder.GetHeader()
+
+	for k := range rheader {
+		header.Set(k, rheader.Get(k))
+	}
+
+	h.handleWriteAuthorizeResponse(ctx, rw, requester, responder.GetParameters())
+}
+
+// WriteAuthorizeError writes authorization errors.
+func (h *DefaultResponseModeHandler) WriteAuthorizeError(ctx context.Context, rw http.ResponseWriter, requester AuthorizeRequester, e error) {
+	rfc := ErrorToRFC6749Error(e).
+		WithLegacyFormat(h.Config.GetUseLegacyErrorFormat(ctx)).
+		WithExposeDebug(h.Config.GetSendDebugMessagesToClients(ctx)).
+		WithLocalizer(h.Config.GetMessageCatalog(ctx), getLangFromRequester(requester))
+
+	if !requester.IsRedirectURIValid() {
+		h.handleWriteAuthorizeErrorJSON(ctx, rw, rfc)
+
+		return
+	}
+
+	parameters := rfc.ToValues()
+
+	if state := requester.GetState(); len(state) != 0 {
+		parameters.Set(consts.FormParameterState, state)
+	}
+
+	h.handleWriteAuthorizeResponse(ctx, rw, requester, parameters)
+}
+
+func (h *DefaultResponseModeHandler) handleWriteAuthorizeResponse(ctx context.Context, rw http.ResponseWriter, requester AuthorizeRequester, parameters url.Values) {
+	redirectURI := requester.GetRedirectURI()
+	redirectURI.Fragment = ""
+
+	var (
+		form     url.Values
+		err      error
+		location string
+	)
+
+	rm := requester.GetResponseMode()
+
+	if rm == ResponseModeJWT {
+		if requester.GetResponseTypes().ExactOne(consts.ResponseTypeAuthorizationCodeFlow) {
+			rm = ResponseModeQueryJWT
+		} else {
+			rm = ResponseModeFragmentJWT
+		}
+	}
+
+	switch rm {
+	case ResponseModeFormPost, ResponseModeFormPostJWT:
+		if form, err = h.EncodeResponseForm(ctx, rm, requester, parameters); err != nil {
+			h.handleWriteAuthorizeErrorJSON(ctx, rw, ErrServerError.WithWrap(err).WithDebug(err.Error()))
+
+			return
+		}
+
+		rw.Header().Set(consts.HeaderContentType, consts.ContentTypeTextHTML)
+		WriteAuthorizeFormPostResponse(redirectURI.String(), form, GetPostFormHTMLTemplate(ctx, h.Config), rw)
+
+		return
+	case ResponseModeQuery, ResponseModeDefault, ResponseModeQueryJWT, ResponseModeJWT:
+		for key, values := range redirectURI.Query() {
+			for _, value := range values {
+				parameters.Add(key, value)
+			}
+		}
+
+		if form, err = h.EncodeResponseForm(ctx, rm, requester, parameters); err != nil {
+			h.handleWriteAuthorizeErrorJSON(ctx, rw, ErrServerError.WithWrap(err).WithDebug(err.Error()))
+
+			return
+		}
+
+		redirectURI.RawQuery = form.Encode()
+
+		location = redirectURI.String()
+	case ResponseModeFragment, ResponseModeFragmentJWT:
+		if form, err = h.EncodeResponseForm(ctx, rm, requester, parameters); err != nil {
+			h.handleWriteAuthorizeErrorJSON(ctx, rw, ErrServerError.WithWrap(err).WithDebug(err.Error()))
+
+			return
+		}
+
+		location = redirectURI.String() + "#" + form.Encode()
+	}
+
+	rw.Header().Set(consts.HeaderLocation, location)
+	rw.WriteHeader(http.StatusSeeOther)
+}
+
+// EncodeResponseForm encodes the response form if necessary.
+func (h *DefaultResponseModeHandler) EncodeResponseForm(ctx context.Context, rm ResponseModeType, requester AuthorizeRequester, parameters url.Values) (form url.Values, err error) {
+	switch rm {
+	case ResponseModeFormPostJWT, ResponseModeQueryJWT, ResponseModeFragmentJWT:
+		client := requester.GetClient()
+
+		jclient, ok := client.(JARMClient)
+		if !ok {
+			return nil, errorsx.WithStack(ErrServerError.WithDebug("The client is not capable of handling the JWT-Secured Authorization Response Mode."))
+		}
+
+		return jarm.EncodeParameters(jarm.Generate(ctx, h.Config, jclient, requester.GetSession(), parameters))
+	default:
+		return parameters, nil
+	}
+}
+
+func (h *DefaultResponseModeHandler) handleWriteAuthorizeErrorJSON(ctx context.Context, rw http.ResponseWriter, rfc *RFC6749Error) {
+	rw.Header().Set(consts.HeaderContentType, consts.ContentTypeApplicationJSON)
+
+	var (
+		data []byte
+		err  error
+	)
+
+	if data, err = json.Marshal(rfc); err != nil {
+		if h.Config.GetSendDebugMessagesToClients(ctx) {
+			errorMessage := EscapeJSONString(err.Error())
+			http.Error(rw, fmt.Sprintf(`{"error":"server_error","error_description":"%s"}`, errorMessage), http.StatusInternalServerError)
+		} else {
+			http.Error(rw, `{"error":"server_error"}`, http.StatusInternalServerError)
+		}
+
+		return
+	}
+
+	rw.WriteHeader(rfc.CodeField)
+	_, _ = rw.Write(data)
+}
+
+// ResponseModeHandler provides a contract for handling response modes.
 type ResponseModeHandler interface {
 	// ResponseModes returns a set of supported response modes handled
 	// by the interface implementation.
@@ -20,17 +189,17 @@ type ResponseModeHandler interface {
 
 	// WriteAuthorizeResponse writes successful responses
 	//
-	// Following headers are expected to be set by default:
+	// The following headers are expected to be set by implementations of this interface:
 	// header.Set(consts.HeaderCacheControl, consts.CacheControlNoStore)
 	// header.Set(consts.HeaderPragma, consts.PragmaNoCache)
-	WriteAuthorizeResponse(ctx context.Context, rw http.ResponseWriter, ar AuthorizeRequester, resp AuthorizeResponder)
+	WriteAuthorizeResponse(ctx context.Context, rw http.ResponseWriter, requester AuthorizeRequester, responder AuthorizeResponder)
 
 	// WriteAuthorizeError writes error responses
 	//
-	// Following headers are expected to be set by default:
+	// The following headers are expected to be set by implementations of this interface:
 	// header.Set(consts.HeaderCacheControl, consts.CacheControlNoStore)
 	// header.Set(consts.HeaderPragma, consts.PragmaNoCache)
-	WriteAuthorizeError(ctx context.Context, rw http.ResponseWriter, ar AuthorizeRequester, err error)
+	WriteAuthorizeError(ctx context.Context, rw http.ResponseWriter, requester AuthorizeRequester, err error)
 }
 
 type ResponseModeTypes []ResponseModeType
@@ -44,16 +213,12 @@ func (rs ResponseModeTypes) Has(item ResponseModeType) bool {
 	return false
 }
 
-func NewDefaultResponseModeHandler() *DefaultResponseModeHandler {
-	return new(DefaultResponseModeHandler)
-}
-
-type DefaultResponseModeHandler struct{}
-
-func (d *DefaultResponseModeHandler) ResponseModes() ResponseModeTypes { return nil }
-
-func (d *DefaultResponseModeHandler) WriteAuthorizeResponse(ctx context.Context, rw http.ResponseWriter, ar AuthorizeRequester, resp AuthorizeResponder) {
-}
-
-func (d *DefaultResponseModeHandler) WriteAuthorizeError(ctx context.Context, rw http.ResponseWriter, ar AuthorizeRequester, err error) {
+type ResponseModeHandlerConfigurator interface {
+	FormPostHTMLTemplateProvider
+	JWTSecuredAuthorizeResponseModeIssuerProvider
+	JWTSecuredAuthorizeResponseModeSignerProvider
+	JWTSecuredAuthorizeResponseModeLifespanProvider
+	MessageCatalogProvider
+	SendDebugMessagesToClientsProvider
+	UseLegacyErrorFormatProvider
 }

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	jose "github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v3"
 
 	"authelia.com/provider/oauth2"
 	"authelia.com/provider/oauth2/internal"

--- a/token/jarm/generate.go
+++ b/token/jarm/generate.go
@@ -1,0 +1,83 @@
+package jarm
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"time"
+
+	"github.com/google/uuid"
+
+	"authelia.com/provider/oauth2/internal/consts"
+	"authelia.com/provider/oauth2/token/jwt"
+)
+
+// EncodeParameters takes the result from jarm.Generate and turns it into parameters in the form of url.Values.
+func EncodeParameters(token, _ string, tErr error) (parameters url.Values, err error) {
+	if tErr != nil {
+		return nil, tErr
+	}
+
+	return url.Values{consts.FormParameterResponse: []string{token}}, nil
+}
+
+// Generate generates the token and signature for a JARM response.
+func Generate(ctx context.Context, config Configurator, client Client, session any, in url.Values) (token, signature string, err error) {
+	headers := map[string]any{}
+
+	if alg := client.GetAuthorizationSignedResponseAlg(); len(alg) > 0 {
+		headers[consts.JSONWebTokenHeaderAlgorithm] = alg
+	}
+
+	if kid := client.GetAuthorizationSignedResponseKeyID(); len(kid) > 0 {
+		headers[consts.JSONWebTokenHeaderKeyIdentifier] = kid
+	}
+
+	var issuer string
+
+	issuer = config.GetJWTSecuredAuthorizeResponseModeIssuer(ctx)
+
+	if len(issuer) == 0 {
+		var (
+			src   jwt.MapClaims
+			value any
+			ok    bool
+		)
+
+		switch s := session.(type) {
+		case nil:
+			return "", "", errors.New("The JARM response modes require the Authorize Requester session to be set but it wasn't.")
+		case OpenIDSession:
+			src = s.IDTokenClaims().ToMapClaims()
+		case JWTSessionContainer:
+			src = s.GetJWTClaims().ToMapClaims()
+		default:
+			return "", "", errors.New("The JARM response modes require the Authorize Requester session to implement either the openid.Session or oauth2.JWTSessionContainer interfaces but it doesn't.")
+		}
+
+		if value, ok = src[consts.ClaimIssuer]; ok {
+			issuer, _ = value.(string)
+		}
+	}
+
+	claims := &jwt.JARMClaims{
+		JTI:       uuid.New().String(),
+		Issuer:    issuer,
+		IssuedAt:  time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(config.GetJWTSecuredAuthorizeResponseModeLifespan(ctx)),
+		Audience:  []string{client.GetID()},
+		Extra:     map[string]any{},
+	}
+
+	for param := range in {
+		claims.Extra[param] = in.Get(param)
+	}
+
+	var signer jwt.Signer
+
+	if signer = config.GetJWTSecuredAuthorizeResponseModeSigner(ctx); signer == nil {
+		return "", "", errors.New("The JARM response modes require the JWTSecuredAuthorizeResponseModeSignerProvider to return a jwt.Signer but it didn't.")
+	}
+
+	return signer.Generate(ctx, claims.ToMapClaims(), &jwt.Headers{Extra: headers})
+}

--- a/token/jarm/types.go
+++ b/token/jarm/types.go
@@ -1,0 +1,32 @@
+package jarm
+
+import (
+	"context"
+	"time"
+
+	"authelia.com/provider/oauth2/token/jwt"
+)
+
+type Configurator interface {
+	GetJWTSecuredAuthorizeResponseModeIssuer(ctx context.Context) string
+	GetJWTSecuredAuthorizeResponseModeSigner(ctx context.Context) jwt.Signer
+	GetJWTSecuredAuthorizeResponseModeLifespan(ctx context.Context) time.Duration
+}
+
+type Client interface {
+	GetID() string
+	GetAuthorizationSignedResponseKeyID() (kid string)
+	GetAuthorizationSignedResponseAlg() (alg string)
+	GetAuthorizationEncryptedResponseAlg() (alg string)
+	GetAuthorizationEncryptedResponseEncryptionAlg() (alg string)
+}
+
+type OpenIDSession interface {
+	IDTokenHeaders() *jwt.Headers
+	IDTokenClaims() *jwt.IDTokenClaims
+}
+
+type JWTSessionContainer interface {
+	GetJWTHeader() *jwt.Headers
+	GetJWTClaims() jwt.JWTClaimsContainer
+}

--- a/token/jwt/claims.go
+++ b/token/jwt/claims.go
@@ -77,3 +77,28 @@ func Copy(elements map[string]any) (result map[string]any) {
 
 	return result
 }
+
+// StringSliceFromMap asserts a map any value to a []string provided it has a good type.
+func StringSliceFromMap(value any) (values []string, ok bool) {
+	switch v := value.(type) {
+	case nil:
+		return nil, true
+	case []string:
+		return v, true
+	case string:
+		return []string{v}, true
+	case []any:
+		for _, item := range v {
+			switch iv := item.(type) {
+			case string:
+				values = append(values, iv)
+			default:
+				return nil, false
+			}
+		}
+
+		return values, true
+	default:
+		return nil, false
+	}
+}

--- a/token/jwt/claims_jarm.go
+++ b/token/jwt/claims_jarm.go
@@ -1,0 +1,107 @@
+package jwt
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+
+	"authelia.com/provider/oauth2/internal/consts"
+)
+
+// JARMClaims represent a token's claims.
+type JARMClaims struct {
+	Issuer    string
+	Audience  []string
+	JTI       string
+	IssuedAt  time.Time
+	ExpiresAt time.Time
+	Extra     map[string]any
+}
+
+// ToMap will transform the headers to a map structure
+func (c *JARMClaims) ToMap() map[string]any {
+	var ret = Copy(c.Extra)
+
+	if c.Issuer != "" {
+		ret[consts.ClaimIssuer] = c.Issuer
+	} else {
+		delete(ret, consts.ClaimIssuer)
+	}
+
+	if c.JTI != "" {
+		ret[consts.ClaimJWTID] = c.JTI
+	} else {
+		ret[consts.ClaimJWTID] = uuid.New().String()
+	}
+
+	if len(c.Audience) > 0 {
+		ret[consts.ClaimAudience] = c.Audience
+	} else {
+		ret[consts.ClaimAudience] = []string{}
+	}
+
+	if !c.IssuedAt.IsZero() {
+		ret[consts.ClaimIssuedAt] = c.IssuedAt.Unix()
+	} else {
+		delete(ret, consts.ClaimIssuedAt)
+	}
+
+	if !c.ExpiresAt.IsZero() {
+		ret[consts.ClaimExpirationTime] = c.ExpiresAt.Unix()
+	} else {
+		delete(ret, consts.ClaimExpirationTime)
+	}
+
+	return ret
+}
+
+// FromMap will set the claims based on a mapping
+func (c *JARMClaims) FromMap(m map[string]any) {
+	c.Extra = make(map[string]any)
+	for k, v := range m {
+		switch k {
+		case consts.ClaimIssuer:
+			if s, ok := v.(string); ok {
+				c.Issuer = s
+			}
+		case consts.ClaimJWTID:
+			if s, ok := v.(string); ok {
+				c.JTI = s
+			}
+		case consts.ClaimAudience:
+			if aud, ok := StringSliceFromMap(v); ok {
+				c.Audience = aud
+			}
+		case consts.ClaimIssuedAt:
+			c.IssuedAt = toTime(v, c.IssuedAt)
+		case consts.ClaimExpirationTime:
+			c.ExpiresAt = toTime(v, c.ExpiresAt)
+		default:
+			c.Extra[k] = v
+		}
+	}
+}
+
+// Add will add a key-value pair to the extra field
+func (c *JARMClaims) Add(key string, value any) {
+	if c.Extra == nil {
+		c.Extra = make(map[string]any)
+	}
+
+	c.Extra[key] = value
+}
+
+// Get will get a value from the extra field based on a given key
+func (c JARMClaims) Get(key string) any {
+	return c.ToMap()[key]
+}
+
+// ToMapClaims will return a jwt-go MapClaims representation
+func (c JARMClaims) ToMapClaims() MapClaims {
+	return c.ToMap()
+}
+
+// FromMapClaims will populate claims from a jwt-go MapClaims representation
+func (c *JARMClaims) FromMapClaims(mc MapClaims) {
+	c.FromMap(mc)
+}

--- a/token/jwt/claims_jarm_test.go
+++ b/token/jwt/claims_jarm_test.go
@@ -1,0 +1,63 @@
+// Copyright © 2023 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package jwt_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"authelia.com/provider/oauth2/internal/consts"
+	. "authelia.com/provider/oauth2/token/jwt"
+)
+
+var jarmClaims = &JARMClaims{
+	Issuer:    "authelia",
+	Audience:  []string{"tests"},
+	JTI:       "abcdef",
+	IssuedAt:  time.Now().UTC().Round(time.Second),
+	ExpiresAt: time.Now().UTC().Add(time.Hour).Round(time.Second),
+	Extra: map[string]any{
+		"foo": "bar",
+		"baz": "bar",
+	},
+}
+
+var jarmClaimsMap = map[string]any{
+	consts.ClaimIssuer:         jwtClaims.Issuer,
+	consts.ClaimAudience:       jwtClaims.Audience,
+	consts.ClaimJWTID:          jwtClaims.JTI,
+	consts.ClaimIssuedAt:       jwtClaims.IssuedAt.Unix(),
+	consts.ClaimExpirationTime: jwtClaims.ExpiresAt.Unix(),
+	"foo":                      jwtClaims.Extra["foo"],
+	"baz":                      jwtClaims.Extra["baz"],
+}
+
+func TestJARMClaimAddGetString(t *testing.T) {
+	jarmClaims.Add("foo", "bar")
+	assert.Equal(t, "bar", jarmClaims.Get("foo"))
+}
+
+func TestJARMClaimsToMapSetsID(t *testing.T) {
+	assert.NotEmpty(t, (&JARMClaims{}).ToMap()[consts.ClaimJWTID])
+}
+
+func TestJARMAssert(t *testing.T) {
+	assert.Nil(t, (&JARMClaims{ExpiresAt: time.Now().UTC().Add(time.Hour)}).
+		ToMapClaims().Valid())
+	assert.NotNil(t, (&JARMClaims{ExpiresAt: time.Now().UTC().Add(-2 * time.Hour)}).
+		ToMapClaims().Valid())
+}
+
+func TestJARMtClaimsToMap(t *testing.T) {
+	assert.Equal(t, jarmClaimsMap, jarmClaims.ToMap())
+}
+
+func TestJARMClaimsFromMap(t *testing.T) {
+	var claims JARMClaims
+
+	claims.FromMap(jarmClaimsMap)
+	assert.Equal(t, jarmClaims, &claims)
+}

--- a/token/jwt/claims_jwt.go
+++ b/token/jwt/claims_jwt.go
@@ -175,10 +175,8 @@ func (c *JWTClaims) FromMap(m map[string]any) {
 				c.Issuer = s
 			}
 		case consts.ClaimAudience:
-			if s, ok := v.(string); ok {
-				c.Audience = []string{s}
-			} else if s, ok := v.([]string); ok {
-				c.Audience = s
+			if aud, ok := StringSliceFromMap(v); ok {
+				c.Audience = aud
 			}
 		case consts.ClaimIssuedAt:
 			c.IssuedAt = toTime(v, c.IssuedAt)

--- a/token/jwt/claims_jwt_test.go
+++ b/token/jwt/claims_jwt_test.go
@@ -48,7 +48,7 @@ func TestClaimAddGetString(t *testing.T) {
 }
 
 func TestClaimsToMapSetsID(t *testing.T) {
-	assert.NotEmpty(t, (&JWTClaims{}).ToMap()["jti"])
+	assert.NotEmpty(t, (&JWTClaims{}).ToMap()[consts.ClaimJWTID])
 }
 
 func TestAssert(t *testing.T) {

--- a/token/jwt/claims_map_test.go
+++ b/token/jwt/claims_map_test.go
@@ -96,7 +96,7 @@ func Test_mapClaims_string_aud_no_claim(t *testing.T) {
 
 func Test_mapClaims_string_aud_no_claim_not_required(t *testing.T) {
 	mapClaims := MapClaims{}
-	want := false
+	want := true
 	got := mapClaims.VerifyAudience("foo", false)
 
 	if want != got {


### PR DESCRIPTION
This implements the JARM specification. See https://openid.net/specs/oauth-v2-jarm.html. In addition it refactors the Response Mode Handlers to entirely be served by a new Configurator Provider.