### PR TITLE
feat(rfc8693): add rfc8693 implementation

### DIFF
--- a/config.go
+++ b/config.go
@@ -335,6 +335,12 @@ type RFC8628UserAuthorizeEndpointHandlersProvider interface {
 	GetRFC8628UserAuthorizeEndpointHandlers(ctx context.Context) RFC8628UserAuthorizeEndpointHandlers
 }
 
+type RFC8693ConfigProvider interface {
+	GetTokenTypes(ctx context.Context) map[string]RFC8693TokenType
+
+	GetDefaultRequestedTokenType(ctx context.Context) string
+}
+
 // UseLegacyErrorFormatProvider returns the provider for configuring whether to use the legacy error format.
 //
 // Deprecated: Do not use this flag anymore.

--- a/config_default.go
+++ b/config_default.go
@@ -208,6 +208,10 @@ type Config struct {
 
 	// IsPushedAuthorizeEnforced enforces pushed authorization request for /authorize
 	IsPushedAuthorizeEnforced bool
+
+	RFC8693TokenTypes map[string]RFC8693TokenType
+
+	DefaultRequestedTokenType string
 }
 
 func (c *Config) GetGlobalSecret(ctx context.Context) ([]byte, error) {
@@ -557,6 +561,14 @@ func (c *Config) EnforcePushedAuthorize(ctx context.Context) bool {
 	return c.IsPushedAuthorizeEnforced
 }
 
+func (c *Config) GetTokenTypes(ctx context.Context) map[string]RFC8693TokenType {
+	return c.RFC8693TokenTypes
+}
+
+func (c *Config) GetDefaultRequestedTokenType(ctx context.Context) string {
+	return c.DefaultRequestedTokenType
+}
+
 func (c *Config) GetRFC8628UserVerificationURL(_ context.Context) string {
 	return c.RFC8628UserVerificationURL
 }
@@ -612,6 +624,7 @@ var (
 	_ RevocationHandlersProvider                      = (*Config)(nil)
 	_ PushedAuthorizeRequestHandlersProvider          = (*Config)(nil)
 	_ PushedAuthorizeRequestConfigProvider            = (*Config)(nil)
+	_ RFC8693ConfigProvider                           = (*Config)(nil)
 	_ DeviceAuthorizeConfigProvider                   = (*Config)(nil)
 	_ DeviceAuthorizeEndpointHandlersProvider         = (*Config)(nil)
 	_ RFC8628UserAuthorizeEndpointHandlersProvider    = (*Config)(nil)

--- a/fosite.go
+++ b/fosite.go
@@ -159,6 +159,9 @@ type Configurator interface {
 	TokenEndpointHandlersProvider
 	TokenIntrospectionHandlersProvider
 	RevocationHandlersProvider
+	PushedAuthorizeRequestHandlersProvider
+	PushedAuthorizeRequestConfigProvider
+	RFC8693ConfigProvider
 	DeviceAuthorizeEndpointHandlersProvider
 	RFC8628UserAuthorizeEndpointHandlersProvider
 	DeviceAuthorizeConfigProvider

--- a/handler/oauth2/flow_generic_code_token.go
+++ b/handler/oauth2/flow_generic_code_token.go
@@ -199,7 +199,7 @@ func (c *GenericCodeTokenEndpointHandler) PopulateTokenEndpointResponse(ctx cont
 	}
 
 	responder.SetAccessToken(access)
-	responder.SetTokenType("bearer")
+	responder.SetTokenType(oauth2.BearerAccessToken)
 	atLifespan := oauth2.GetEffectiveLifespan(requester.GetClient(), oauth2.GrantTypeAuthorizationCode, oauth2.AccessToken, c.Config.GetAccessTokenLifespan(ctx))
 	responder.SetExpiresIn(getExpiresIn(requester, oauth2.AccessToken, atLifespan, time.Now().UTC()))
 	responder.SetScopes(requester.GetGrantedScopes())

--- a/handler/oauth2/revocation.go
+++ b/handler/oauth2/revocation.go
@@ -81,15 +81,15 @@ type RevocationTokenLookupFunc func(ctx context.Context, token string) (requeste
 
 func (r *TokenRevocationHandler) getRevokeRefreshTokensExplicitly(ctx context.Context, client oauth2.Client) bool {
 	var (
-		rfrrtec oauth2.RevokeFlowRevokeRefreshTokensExplicitClient
-		ok      bool
+		c  oauth2.RevokeFlowRevokeRefreshTokensExplicitClient
+		ok bool
 	)
 
-	if rfrrtec, ok = client.(oauth2.RevokeFlowRevokeRefreshTokensExplicitClient); !ok {
+	if c, ok = client.(oauth2.RevokeFlowRevokeRefreshTokensExplicitClient); !ok {
 		return r.Config.GetRevokeRefreshTokensExplicitly(ctx)
 	}
 
-	if ok = rfrrtec.GetRevokeRefreshTokensExplicitly(ctx); ok || r.Config.GetEnforceRevokeFlowRevokeRefreshTokensExplicitClient(ctx) {
+	if ok = c.GetRevokeRefreshTokensExplicitly(ctx); ok || r.Config.GetEnforceRevokeFlowRevokeRefreshTokensExplicitClient(ctx) {
 		return ok
 	}
 

--- a/handler/openid/flow_device_authorization_test.go
+++ b/handler/openid/flow_device_authorization_test.go
@@ -29,7 +29,7 @@ func TestOpenIDConnectDeviceAuthorizeHandler_PopulateRFC8628UserAuthorizeEndpoin
 	}
 	j := &DefaultStrategy{
 		Signer: &jwt.DefaultSigner{
-			GetPrivateKey: func(ctx context.Context) (interface{}, error) {
+			GetPrivateKey: func(ctx context.Context) (any, error) {
 				return key, nil
 			},
 		},
@@ -130,7 +130,7 @@ func TestOpenIDConnectDeviceAuthorizeHandler_PopulateTokenEndpointResponse(t *te
 	}
 	j := &DefaultStrategy{
 		Signer: &jwt.DefaultSigner{
-			GetPrivateKey: func(ctx context.Context) (interface{}, error) {
+			GetPrivateKey: func(ctx context.Context) (any, error) {
 				return key, nil
 			},
 		},

--- a/handler/openid/strategy.go
+++ b/handler/openid/strategy.go
@@ -8,8 +8,13 @@ import (
 	"time"
 
 	"authelia.com/provider/oauth2"
+	"authelia.com/provider/oauth2/token/jwt"
 )
 
 type OpenIDConnectTokenStrategy interface {
 	GenerateIDToken(ctx context.Context, lifespan time.Duration, requester oauth2.Requester) (token string, err error)
+}
+
+type TokenValidationStrategy interface {
+	ValidateIDToken(ctx context.Context, requester oauth2.Requester, token string) (jwt.MapClaims, error)
 }

--- a/handler/rfc8693/access_token_type_handler.go
+++ b/handler/rfc8693/access_token_type_handler.go
@@ -1,0 +1,207 @@
+package rfc8693
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"authelia.com/provider/oauth2"
+	hoauth2 "authelia.com/provider/oauth2/handler/oauth2"
+	"authelia.com/provider/oauth2/internal/consts"
+	"authelia.com/provider/oauth2/internal/errorsx"
+	"authelia.com/provider/oauth2/storage"
+)
+
+type AccessTokenTypeHandler struct {
+	Config               oauth2.RFC8693ConfigProvider
+	AccessTokenLifespan  time.Duration
+	RefreshTokenLifespan time.Duration
+	RefreshTokenScopes   []string
+	hoauth2.CoreStrategy
+	ScopeStrategy oauth2.ScopeStrategy
+	Storage
+}
+
+// HandleTokenEndpointRequest implements https://tools.ietf.org/html/rfc6749#section-4.3.2
+func (c *AccessTokenTypeHandler) HandleTokenEndpointRequest(ctx context.Context, request oauth2.AccessRequester) error {
+	if !c.CanHandleTokenEndpointRequest(ctx, request) {
+		return errorsx.WithStack(oauth2.ErrUnknownRequest)
+	}
+
+	session, _ := request.GetSession().(Session)
+	if session == nil {
+		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to perform token exchange because the session is not of the right type."))
+	}
+
+	form := request.GetRequestForm()
+	if form.Get(consts.FormParameterSubjectTokenType) != consts.TokenTypeRFC8693AccessToken && form.Get(consts.FormParameterActorTokenType) != consts.TokenTypeRFC8693AccessToken {
+		return nil
+	}
+
+	if form.Get(consts.FormParameterActorTokenType) == consts.TokenTypeRFC8693AccessToken {
+		token := form.Get(consts.FormParameterActorToken)
+		if _, unpacked, err := c.validate(ctx, request, token); err != nil {
+			return err
+		} else {
+			session.SetActorToken(unpacked)
+		}
+	}
+
+	if form.Get(consts.FormParameterSubjectTokenType) == consts.TokenTypeRFC8693AccessToken {
+		token := form.Get(consts.FormParameterSubjectToken)
+		if subjectTokenSession, unpacked, err := c.validate(ctx, request, token); err != nil {
+			return err
+		} else {
+			session.SetSubjectToken(unpacked)
+			session.SetSubject(subjectTokenSession.GetSubject())
+		}
+	}
+
+	return nil
+}
+
+// PopulateTokenEndpointResponse implements https://tools.ietf.org/html/rfc6749#section-4.3.3
+func (c *AccessTokenTypeHandler) PopulateTokenEndpointResponse(ctx context.Context, request oauth2.AccessRequester, responder oauth2.AccessResponder) error {
+	if !c.CanHandleTokenEndpointRequest(ctx, request) {
+		return errorsx.WithStack(oauth2.ErrUnknownRequest)
+	}
+
+	session, _ := request.GetSession().(Session)
+	if session == nil {
+		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to perform token exchange because the session is not of the right type."))
+	}
+
+	form := request.GetRequestForm()
+	requestedTokenType := form.Get(consts.FormParameterRequestedTokenType)
+	if requestedTokenType == "" {
+		requestedTokenType = c.Config.GetDefaultRequestedTokenType(ctx)
+	}
+
+	if requestedTokenType != consts.TokenTypeRFC8693AccessToken {
+		return nil
+	}
+
+	if err := c.issue(ctx, request, responder); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CanSkipClientAuth indicates if client auth can be skipped
+func (c *AccessTokenTypeHandler) CanSkipClientAuth(ctx context.Context, requester oauth2.AccessRequester) bool {
+	return false
+}
+
+// CanHandleTokenEndpointRequest indicates if the token endpoint request can be handled
+func (c *AccessTokenTypeHandler) CanHandleTokenEndpointRequest(ctx context.Context, requester oauth2.AccessRequester) bool {
+	// grant_type REQUIRED.
+	// Value MUST be set to "password".
+	return requester.GetGrantTypes().ExactOne(consts.GrantTypeOAuthTokenExchange)
+}
+
+func (c *AccessTokenTypeHandler) validate(ctx context.Context, request oauth2.AccessRequester, token string) (oauth2.Session, map[string]any, error) {
+	session, _ := request.GetSession().(Session)
+	if session == nil {
+		return nil, nil, errorsx.WithStack(oauth2.ErrServerError.WithDebug(
+			"Failed to perform token exchange because the session is not of the right type."))
+	}
+
+	client := request.GetClient()
+
+	sig := c.CoreStrategy.AccessTokenSignature(ctx, token)
+	or, err := c.Storage.GetAccessTokenSession(ctx, sig, request.GetSession())
+	if err != nil {
+		return nil, nil, errors.WithStack(oauth2.ErrInvalidRequest.WithHint("Token is not valid or has expired.").WithDebugError(err))
+	} else if err := c.CoreStrategy.ValidateAccessToken(ctx, or, token); err != nil {
+		return nil, nil, err
+	}
+
+	subjectTokenClientID := or.GetClient().GetID()
+	// forbid original subjects client to exchange its own token
+	if client.GetID() == subjectTokenClientID {
+		return nil, nil, errors.WithStack(oauth2.ErrRequestForbidden.WithHint("Clients are not allowed to perform a token exchange on their own tokens."))
+	}
+
+	// Check if the client is allowed to exchange this token
+	if subjectTokenClient, ok := or.GetClient().(Client); ok {
+		allowed := subjectTokenClient.TokenExchangeAllowed(client)
+		if !allowed {
+			return nil, nil, errors.WithStack(oauth2.ErrRequestForbidden.WithHintf(
+				"The OAuth 2.0 client is not permitted to exchange a subject token issued to client %s", subjectTokenClientID))
+		}
+	}
+
+	// Scope check
+	for _, scope := range request.GetRequestedScopes() {
+		if !c.ScopeStrategy(or.GetGrantedScopes(), scope) {
+			return nil, nil, errors.WithStack(oauth2.ErrInvalidScope.WithHintf("The subject token is not granted '%s' and so this scope cannot be requested.", scope))
+		}
+	}
+
+	// Convert to flat session with only access token claims
+	claims := session.AccessTokenClaimsMap()
+	claims[consts.ClaimClientIdentifier] = or.GetClient().GetID()
+	claims[consts.ClaimScope] = or.GetGrantedScopes()
+	claims[consts.ClaimAudience] = or.GetGrantedAudience()
+
+	return or.GetSession(), claims, nil
+}
+
+func (c *AccessTokenTypeHandler) issue(ctx context.Context, request oauth2.AccessRequester, response oauth2.AccessResponder) error {
+	request.GetSession().SetExpiresAt(oauth2.AccessToken, time.Now().UTC().Add(c.AccessTokenLifespan))
+
+	token, signature, err := c.CoreStrategy.GenerateAccessToken(ctx, request)
+	if err != nil {
+		return err
+	} else if err := c.Storage.CreateAccessTokenSession(ctx, signature, request.Sanitize([]string{})); err != nil {
+		return err
+	}
+
+	issueRefreshToken := c.canIssueRefreshToken(request)
+	if issueRefreshToken {
+		request.GetSession().SetExpiresAt(oauth2.RefreshToken, time.Now().UTC().Add(c.RefreshTokenLifespan).Round(time.Second))
+		refresh, refreshSignature, err := c.CoreStrategy.GenerateRefreshToken(ctx, request)
+		if err != nil {
+			return errors.WithStack(oauth2.ErrServerError.WithDebugError(err))
+		}
+
+		if refreshSignature != "" {
+			if err := c.Storage.CreateRefreshTokenSession(ctx, refreshSignature, request.Sanitize([]string{})); err != nil {
+				if rollBackTxnErr := storage.MaybeRollbackTx(ctx, c.Storage); rollBackTxnErr != nil {
+					err = rollBackTxnErr
+				}
+				return errors.WithStack(oauth2.ErrServerError.WithDebugError(err))
+			}
+		}
+
+		response.SetExtra(consts.FormParameterRefreshToken, refresh)
+	}
+
+	response.SetAccessToken(token)
+	response.SetTokenType(oauth2.BearerAccessToken)
+	response.SetExpiresIn(c.getExpiresIn(request, oauth2.AccessToken, c.AccessTokenLifespan, time.Now().UTC()))
+	response.SetScopes(request.GetGrantedScopes())
+
+	return nil
+}
+
+func (c *AccessTokenTypeHandler) canIssueRefreshToken(request oauth2.Requester) bool {
+	// Require one of the refresh token scopes, if set.
+	if len(c.RefreshTokenScopes) > 0 && !request.GetGrantedScopes().HasOneOf(c.RefreshTokenScopes...) {
+		return false
+	}
+	// Do not issue a refresh token to clients that cannot use the refresh token grant type.
+	if !request.GetClient().GetGrantTypes().Has(consts.GrantTypeRefreshToken) {
+		return false
+	}
+	return true
+}
+
+func (c *AccessTokenTypeHandler) getExpiresIn(r oauth2.Requester, key oauth2.TokenType, defaultLifespan time.Duration, now time.Time) time.Duration {
+	if r.GetSession().GetExpiresAt(key).IsZero() {
+		return defaultLifespan
+	}
+	return time.Duration(r.GetSession().GetExpiresAt(key).UnixNano() - now.UnixNano())
+}

--- a/handler/rfc8693/actor_token_validation_handler.go
+++ b/handler/rfc8693/actor_token_validation_handler.go
@@ -1,0 +1,63 @@
+package rfc8693
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"authelia.com/provider/oauth2"
+	"authelia.com/provider/oauth2/internal/consts"
+	"authelia.com/provider/oauth2/internal/errorsx"
+)
+
+type ActorTokenValidationHandler struct{}
+
+// HandleTokenEndpointRequest implements https://tools.ietf.org/html/rfc6749#section-4.3.2
+func (c *ActorTokenValidationHandler) HandleTokenEndpointRequest(ctx context.Context, request oauth2.AccessRequester) error {
+	if !c.CanHandleTokenEndpointRequest(ctx, request) {
+		return errorsx.WithStack(oauth2.ErrUnknownRequest)
+	}
+
+	client := request.GetClient()
+	session, _ := request.GetSession().(Session)
+	if session == nil {
+		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to perform token exchange because the session is not of the right type."))
+	}
+
+	// Validate that the actor or client is allowed to make this request
+	subjectTokenObject := session.GetSubjectToken()
+	if mayAct, _ := subjectTokenObject[consts.ClaimAuthorizedActor].(map[string]any); mayAct != nil {
+		actorTokenObject := session.GetActorToken()
+		if actorTokenObject == nil {
+			actorTokenObject = map[string]any{
+				consts.ClaimSubject:          client.GetID(),
+				consts.ClaimClientIdentifier: client.GetID(),
+			}
+		}
+
+		for k, v := range mayAct {
+			if actorTokenObject[k] != v {
+				return errors.WithStack(oauth2.ErrInvalidRequest.WithHint("The actor or client is not authorized to act on behalf of the subject."))
+			}
+		}
+	}
+
+	return nil
+}
+
+// PopulateTokenEndpointResponse implements https://tools.ietf.org/html/rfc6749#section-4.3.3
+func (c *ActorTokenValidationHandler) PopulateTokenEndpointResponse(ctx context.Context, request oauth2.AccessRequester, responder oauth2.AccessResponder) error {
+	return nil
+}
+
+// CanSkipClientAuth indicates if client auth can be skipped
+func (c *ActorTokenValidationHandler) CanSkipClientAuth(ctx context.Context, requester oauth2.AccessRequester) bool {
+	return false
+}
+
+// CanHandleTokenEndpointRequest indicates if the token endpoint request can be handled
+func (c *ActorTokenValidationHandler) CanHandleTokenEndpointRequest(ctx context.Context, requester oauth2.AccessRequester) bool {
+	// grant_type REQUIRED.
+	// Value MUST be set to "password".
+	return requester.GetGrantTypes().ExactOne(consts.GrantTypeOAuthTokenExchange)
+}

--- a/handler/rfc8693/client.go
+++ b/handler/rfc8693/client.go
@@ -1,0 +1,15 @@
+package rfc8693
+
+import "authelia.com/provider/oauth2"
+
+type Client interface {
+	// GetSupportedSubjectTokenTypes indicates the token types allowed for subject_token
+	GetSupportedSubjectTokenTypes() []string
+	// GetSupportedActorTokenTypes indicates the token types allowed for subject_token
+	GetSupportedActorTokenTypes() []string
+	// GetSupportedRequestTokenTypes indicates the token types allowed for requested_token_type
+	GetSupportedRequestTokenTypes() []string
+	// TokenExchangeAllowed checks if the subject token client allows the specified client
+	// to perform the exchange
+	TokenExchangeAllowed(client oauth2.Client) bool
+}

--- a/handler/rfc8693/custom_jwt_type_handler.go
+++ b/handler/rfc8693/custom_jwt_type_handler.go
@@ -1,0 +1,235 @@
+package rfc8693
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+
+	"authelia.com/provider/oauth2"
+	"authelia.com/provider/oauth2/handler/openid"
+	"authelia.com/provider/oauth2/internal/consts"
+	"authelia.com/provider/oauth2/internal/errorsx"
+	"authelia.com/provider/oauth2/token/jwt"
+)
+
+type CustomJWTTypeHandler struct {
+	Config      oauth2.RFC8693ConfigProvider
+	JWTStrategy jwt.Signer
+	Storage
+}
+
+// HandleTokenEndpointRequest implements https://tools.ietf.org/html/rfc6749#section-4.3.2
+func (c *CustomJWTTypeHandler) HandleTokenEndpointRequest(ctx context.Context, request oauth2.AccessRequester) error {
+	if !c.CanHandleTokenEndpointRequest(ctx, request) {
+		return errorsx.WithStack(oauth2.ErrUnknownRequest)
+	}
+
+	session, _ := request.GetSession().(Session)
+	if session == nil {
+		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to perform token exchange because the session is not of the right type."))
+	}
+
+	form := request.GetRequestForm()
+	tokenTypes := c.Config.GetTokenTypes(ctx)
+	actorTokenType := tokenTypes[form.Get(consts.FormParameterActorTokenType)]
+	subjectTokenType := tokenTypes[form.Get(consts.FormParameterSubjectTokenType)]
+	if actorTokenType != nil && actorTokenType.GetType(ctx) == consts.TokenTypeRFC8693JWT {
+		token := form.Get(consts.FormParameterActorToken)
+		if unpacked, err := c.validate(ctx, request, actorTokenType, token); err != nil {
+			return err
+		} else {
+			session.SetActorToken(unpacked)
+		}
+	}
+
+	if subjectTokenType != nil && subjectTokenType.GetType(ctx) == consts.TokenTypeRFC8693JWT {
+		token := form.Get(consts.FormParameterSubjectToken)
+		if unpacked, err := c.validate(ctx, request, subjectTokenType, token); err != nil {
+			return err
+		} else {
+			session.SetSubjectToken(unpacked)
+			// Get the subject and populate session
+			if subject, err := c.Storage.GetSubjectForTokenExchange(ctx, request, unpacked); err != nil {
+				return err
+			} else {
+				session.SetSubject(subject)
+			}
+		}
+	}
+
+	return nil
+}
+
+// PopulateTokenEndpointResponse implements https://tools.ietf.org/html/rfc6749#section-4.3.3
+func (c *CustomJWTTypeHandler) PopulateTokenEndpointResponse(ctx context.Context, request oauth2.AccessRequester, responder oauth2.AccessResponder) error {
+	if !c.CanHandleTokenEndpointRequest(ctx, request) {
+		return errorsx.WithStack(oauth2.ErrUnknownRequest)
+	}
+
+	session, _ := request.GetSession().(Session)
+	if session == nil {
+		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to perform token exchange because the session is not of the right type."))
+	}
+
+	form := request.GetRequestForm()
+	requestedTokenType := form.Get(consts.FormParameterRequestedTokenType)
+	if requestedTokenType == "" {
+		requestedTokenType = c.Config.GetDefaultRequestedTokenType(ctx)
+	}
+
+	tokenTypes := c.Config.GetTokenTypes(ctx)
+	tokenType := tokenTypes[requestedTokenType]
+	if tokenType == nil || tokenType.GetType(ctx) != consts.TokenTypeRFC8693JWT {
+		return nil
+	}
+
+	if err := c.issue(ctx, request, tokenType, responder); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CanSkipClientAuth indicates if client auth can be skipped
+func (c *CustomJWTTypeHandler) CanSkipClientAuth(ctx context.Context, requester oauth2.AccessRequester) bool {
+	return false
+}
+
+// CanHandleTokenEndpointRequest indicates if the token endpoint request can be handled
+func (c *CustomJWTTypeHandler) CanHandleTokenEndpointRequest(ctx context.Context, requester oauth2.AccessRequester) bool {
+	// grant_type REQUIRED.
+	// Value MUST be set to "password".
+	return requester.GetGrantTypes().ExactOne(consts.GrantTypeOAuthTokenExchange)
+}
+
+func (c *CustomJWTTypeHandler) validate(ctx context.Context, _ oauth2.AccessRequester, tokenType oauth2.RFC8693TokenType, token string) (map[string]any, error) {
+	jwtType, _ := tokenType.(*JWTType)
+	if jwtType == nil {
+		return nil, errorsx.WithStack(
+			oauth2.ErrServerError.WithDebugf(
+				"Token type '%s' is supposed to be of type JWT but is not castable to 'JWTType'", tokenType.GetName(ctx)))
+	}
+
+	// Parse the token
+	ftoken, err := jwt.ParseWithClaims(token, jwt.MapClaims{}, jwtType.ValidateFunc)
+	if err != nil {
+		return nil, errorsx.WithStack(oauth2.ErrInvalidRequest.WithHint("Unable to parse the JSON web token").WithWrap(err).WithDebugError(err))
+	}
+
+	window := jwtType.JWTLifetimeToleranceWindow
+	if window == 0 {
+		window = 1 * time.Hour
+	}
+	claims := ftoken.Claims
+
+	if issued, exists := claims[consts.ClaimIssuedAt]; exists {
+		if time.Unix(toInt64(issued), 0).Add(window).Before(time.Now()) {
+			return nil, errorsx.WithStack(oauth2.ErrInvalidRequest.WithHint("Claim 'iat' from token is too far in the past."))
+		}
+	}
+
+	if _, exists := claims[consts.ClaimExpirationTime]; !exists { // Validate 'exp' is mandatory
+		return nil, errorsx.WithStack(oauth2.ErrInvalidRequest.WithHint("Claim 'exp' from token is missing."))
+	}
+	expiry := toInt64(claims[consts.ClaimExpirationTime])
+	if time.Now().Add(window).Before(time.Unix(expiry, 0)) {
+		return nil, errorsx.WithStack(oauth2.ErrInvalidRequest.WithHint("Claim 'exp' from token is too far in the future."))
+	}
+
+	if !claims.VerifyIssuer(jwtType.Issuer, true) {
+		return nil, errorsx.WithStack(oauth2.ErrInvalidRequest.WithHintf("Claim 'iss' from token must match the '%s'.", jwtType.Issuer))
+	}
+
+	// Validate the JTI is unique if required
+	if jwtType.ValidateJTI {
+		jti, _ := claims[consts.ClaimJWTID].(string)
+		if jti == "" {
+			return nil, errorsx.WithStack(oauth2.ErrInvalidRequest.WithHint("Claim 'jti' from token is missing."))
+		}
+
+		if c.Storage.SetTokenExchangeCustomJWT(ctx, jti, time.Unix(expiry, 0)) != nil {
+			return nil, errorsx.WithStack(oauth2.ErrInvalidRequest.WithHint("Claim 'jti' from the token must be used only once."))
+		}
+	}
+
+	return map[string]any(claims), nil
+}
+
+func (c *CustomJWTTypeHandler) issue(ctx context.Context, request oauth2.AccessRequester, tokenType oauth2.RFC8693TokenType, response oauth2.AccessResponder) error {
+	jwtType, _ := tokenType.(*JWTType)
+	if jwtType == nil {
+		return errorsx.WithStack(
+			oauth2.ErrServerError.WithDebugf(
+				"Token type '%s' is supposed to be of type JWT but is not castable to 'JWTType'", tokenType.GetName(ctx)))
+	}
+
+	sess, ok := request.GetSession().(openid.Session)
+	if !ok {
+		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate JWT because session must be of type fosite/handler/openid.Session."))
+	}
+
+	claims := sess.IDTokenClaims()
+	if claims.Subject == "" {
+		claims.Subject = request.GetClient().GetID()
+	}
+
+	if claims.ExpiresAt.IsZero() {
+		claims.ExpiresAt = time.Now().UTC().Add(jwtType.Expiry)
+	}
+
+	if claims.Issuer == "" {
+		claims.Issuer = jwtType.Issuer
+	}
+
+	if len(request.GetRequestedAudience()) > 0 {
+		claims.Audience = append(claims.Audience, request.GetRequestedAudience()...)
+	}
+
+	if len(claims.Audience) == 0 {
+		aud := jwtType.JWTIssueConfig.Audience
+		if len(aud) == 0 {
+			aud = append(aud, request.GetClient().GetID())
+		}
+
+		claims.Audience = append(claims.Audience, aud...)
+	}
+
+	if claims.JTI == "" {
+		claims.JTI = uuid.New().String()
+	}
+
+	claims.IssuedAt = time.Now().UTC()
+
+	token, _, err := c.JWTStrategy.Generate(ctx, claims.ToMapClaims(), sess.IDTokenHeaders())
+	if err != nil {
+		return err
+	}
+
+	response.SetAccessToken(token)
+	response.SetTokenType("N_A")
+	response.SetExpiresIn(time.Duration(claims.ExpiresAt.UnixNano() - time.Now().UTC().UnixNano()))
+	return nil
+}
+
+// type conversion according to jwt.MapClaims.toInt64 - ignore error
+func toInt64(claim any) int64 {
+	switch t := claim.(type) {
+	case float64:
+		return int64(t)
+	case int64:
+		return t
+	case json.Number:
+		v, err := t.Int64()
+		if err == nil {
+			return v
+		}
+		vf, err := t.Float64()
+		if err != nil {
+			return 0
+		}
+		return int64(vf)
+	}
+	return 0
+}

--- a/handler/rfc8693/flow_token_exchange.go
+++ b/handler/rfc8693/flow_token_exchange.go
@@ -1,0 +1,191 @@
+package rfc8693
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"authelia.com/provider/oauth2"
+	"authelia.com/provider/oauth2/internal/consts"
+	"authelia.com/provider/oauth2/internal/errorsx"
+)
+
+// TokenExchangeGrantHandler is the grant handler for RFC8693
+type TokenExchangeGrantHandler struct {
+	Config                   oauth2.RFC8693ConfigProvider
+	ScopeStrategy            oauth2.ScopeStrategy
+	AudienceMatchingStrategy oauth2.AudienceMatchingStrategy
+}
+
+// HandleTokenEndpointRequest implements https://tools.ietf.org/html/rfc6749#section-4.3.2
+func (c *TokenExchangeGrantHandler) HandleTokenEndpointRequest(ctx context.Context, request oauth2.AccessRequester) error {
+	if !c.CanHandleTokenEndpointRequest(ctx, request) {
+		return errorsx.WithStack(oauth2.ErrUnknownRequest)
+	}
+
+	client := request.GetClient()
+	if client.IsPublic() {
+		return errors.WithStack(oauth2.ErrInvalidGrant.WithHint("The OAuth 2.0 Client is marked as public and is thus not allowed to use authorization grant \"urn:ietf:params:oauth:grant-type:token-exchange\"."))
+	}
+
+	// Check whether client is allowed to use token exchange
+	if !client.GetGrantTypes().Has("urn:ietf:params:oauth:grant-type:token-exchange") {
+		return errors.WithStack(oauth2.ErrUnauthorizedClient.WithHintf(
+			"The OAuth 2.0 Client is not allowed to use authorization grant '%s'.", "urn:ietf:params:oauth:grant-type:token-exchange"))
+	}
+
+	session, _ := request.GetSession().(Session)
+	if session == nil {
+		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to perform token exchange because the session is not of the right type."))
+	}
+
+	form := request.GetRequestForm()
+	configTypesSupported := c.Config.GetTokenTypes(ctx)
+	var supportedSubjectTypes, supportedActorTypes, supportedRequestTypes oauth2.Arguments
+	if teClient, ok := client.(Client); ok {
+		supportedRequestTypes = teClient.GetSupportedRequestTokenTypes()
+		supportedActorTypes = teClient.GetSupportedActorTokenTypes()
+		supportedSubjectTypes = teClient.GetSupportedSubjectTokenTypes()
+	}
+
+	// From https://tools.ietf.org/html/rfc8693#section-2.1:
+	//
+	//	subject_token
+	//		REQUIRED.  A security token that represents the identity of the
+	//		party on behalf of whom the request is being made.  Typically, the
+	//		subject of this token will be the subject of the security token
+	//		issued in response to the request.
+	subjectToken := form.Get(consts.FormParameterSubjectToken)
+	if subjectToken == "" {
+		return errors.WithStack(oauth2.ErrInvalidRequest.WithHintf("Mandatory parameter '%s' is missing.", "subject_token"))
+	}
+
+	// From https://tools.ietf.org/html/rfc8693#section-2.1:
+	//
+	//	subject_token_type
+	//		REQUIRED.  An identifier, as described in Section 3, that
+	//		indicates the type of the security token in the "subject_token"
+	//		parameter.
+	subjectTokenType := form.Get(consts.FormParameterSubjectTokenType)
+	if subjectTokenType == "" {
+		return errors.WithStack(oauth2.ErrInvalidRequest.WithHintf("Mandatory parameter '%s' is missing.", consts.FormParameterSubjectTokenType))
+	}
+
+	if tt := configTypesSupported[subjectTokenType]; tt == nil {
+		return errorsx.WithStack(oauth2.ErrInvalidRequest.WithHintf("The '%s' token type is not supported as a '%s'.", subjectTokenType, consts.FormParameterSubjectTokenType))
+	}
+
+	if len(supportedSubjectTypes) > 0 && !supportedSubjectTypes.Has(subjectTokenType) {
+		return errorsx.WithStack(oauth2.ErrInvalidRequest.WithHintf(
+			"The OAuth 2.0 client is not allowed to use '%s' as '%s'.", subjectTokenType, consts.FormParameterSubjectTokenType))
+	}
+
+	// From https://tools.ietf.org/html/rfc8693#section-2.1:
+	//
+	//	actor_token
+	//		OPTIONAL . A security token that represents the identity of the acting party.
+	//		Typically, this will be the party that is authorized to use the requested security
+	//		token and act on behalf of the subject.
+	actorToken := form.Get(consts.FormParameterActorToken)
+	actorTokenType := form.Get(consts.FormParameterActorTokenType)
+	if actorToken != "" {
+		// From https://tools.ietf.org/html/rfc8693#section-2.1:
+		//
+		//	actor_token_type
+		//		An identifier, as described in Section 3, that indicates the type of the security token
+		//		in the actor_token parameter. This is REQUIRED when the actor_token parameter is present
+		//		in the request but MUST NOT be included otherwise.
+		if actorTokenType == "" {
+			return errors.WithStack(oauth2.ErrInvalidRequest.WithHintf("The '%s' is empty even though the '%s' is not empty.", consts.FormParameterActorTokenType, consts.FormParameterActorToken))
+		}
+
+		if tt := configTypesSupported[actorTokenType]; tt == nil {
+			return errorsx.WithStack(oauth2.ErrInvalidRequest.WithHintf(
+				"The '%s' token type is not supported as a '%s'.", actorTokenType, consts.FormParameterActorTokenType))
+		}
+
+		if len(supportedActorTypes) > 0 && !supportedActorTypes.Has(actorTokenType) {
+			return errorsx.WithStack(oauth2.ErrInvalidRequest.WithHintf(
+				"The OAuth 2.0 client is not allowed to use '%s' as '%s'.", actorTokenType, consts.FormParameterActorTokenType))
+		}
+	} else if actorTokenType != "" {
+		return errors.WithStack(oauth2.ErrInvalidRequest.WithHintf("The '%s' is not empty even though the '%s' is empty.", consts.FormParameterActorTokenType, consts.FormParameterActorToken))
+	}
+
+	// check if supported
+	requestedTokenType := form.Get(consts.FormParameterRequestedTokenType)
+	if requestedTokenType == "" {
+		requestedTokenType = c.Config.GetDefaultRequestedTokenType(ctx)
+	}
+
+	if tt := configTypesSupported[requestedTokenType]; tt == nil {
+		return errorsx.WithStack(oauth2.ErrInvalidRequest.WithHintf(
+			"The '%s' token type is not supported as a '%s'.", requestedTokenType, consts.FormParameterRequestedTokenType))
+	}
+
+	if len(supportedRequestTypes) > 0 && !supportedRequestTypes.Has(requestedTokenType) {
+		return errorsx.WithStack(oauth2.ErrInvalidRequest.WithHintf("The OAuth 2.0 client is not allowed to use '%s' as '%s'.", requestedTokenType, consts.FormParameterRequestedTokenType))
+	}
+
+	// Check scope
+	for _, scope := range request.GetRequestedScopes() {
+		if !c.ScopeStrategy(client.GetScopes(), scope) {
+			return errors.WithStack(oauth2.ErrInvalidScope.WithHintf("The OAuth 2.0 Client is not allowed to request scope '%s'.", scope))
+		}
+	}
+
+	// Check audience
+	if err := c.AudienceMatchingStrategy(client.GetAudience(), request.GetRequestedAudience()); err != nil {
+		// TODO: Need to convert to using invalid_target
+		return err
+	}
+
+	return nil
+}
+
+// PopulateTokenEndpointResponse implements https://tools.ietf.org/html/rfc6749#section-4.3.3
+func (c *TokenExchangeGrantHandler) PopulateTokenEndpointResponse(ctx context.Context, request oauth2.AccessRequester, responder oauth2.AccessResponder) error {
+	if !c.CanHandleTokenEndpointRequest(ctx, request) {
+		return errorsx.WithStack(oauth2.ErrUnknownRequest)
+	}
+
+	session, _ := request.GetSession().(Session)
+	if session == nil {
+		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to perform token exchange because the session is not of the right type."))
+	}
+
+	form := request.GetRequestForm()
+	requestedTokenType := form.Get(consts.FormParameterRequestedTokenType)
+	if requestedTokenType == "" {
+		requestedTokenType = c.Config.GetDefaultRequestedTokenType(ctx)
+	}
+
+	configTypesSupported := c.Config.GetTokenTypes(ctx)
+	if tt := configTypesSupported[requestedTokenType]; tt == nil {
+		return errorsx.WithStack(oauth2.ErrInvalidRequest.WithHintf(
+			"The '%s' token type is not supported as a '%s'.", requestedTokenType, consts.FormParameterRequestedTokenType))
+	}
+
+	// chain `act` if necessary
+	subjectTokenObject := session.GetSubjectToken()
+	if mayAct, _ := subjectTokenObject[consts.ClaimAuthorizedActor].(map[string]any); mayAct != nil {
+		if subjectActor, _ := subjectTokenObject[consts.ClaimActor].(map[string]any); subjectActor != nil {
+			mayAct[consts.ClaimActor] = subjectActor
+		}
+
+		session.SetAct(mayAct)
+	}
+
+	return nil
+}
+
+// CanSkipClientAuth indicates if client auth can be skipped
+func (c *TokenExchangeGrantHandler) CanSkipClientAuth(ctx context.Context, requester oauth2.AccessRequester) bool {
+	return false
+}
+
+// CanHandleTokenEndpointRequest indicates if the token endpoint request can be handled
+func (c *TokenExchangeGrantHandler) CanHandleTokenEndpointRequest(ctx context.Context, requester oauth2.AccessRequester) bool {
+	// grant_type REQUIRED.
+	return requester.GetGrantTypes().ExactOne(consts.GrantTypeOAuthTokenExchange)
+}

--- a/handler/rfc8693/id_token_type_handler.go
+++ b/handler/rfc8693/id_token_type_handler.go
@@ -1,0 +1,145 @@
+package rfc8693
+
+import (
+	"context"
+
+	"authelia.com/provider/oauth2"
+	"authelia.com/provider/oauth2/handler/openid"
+	"authelia.com/provider/oauth2/internal/consts"
+	"authelia.com/provider/oauth2/internal/errorsx"
+	"authelia.com/provider/oauth2/token/jwt"
+)
+
+type IDTokenTypeHandler struct {
+	Config             oauth2.Configurator
+	JWTStrategy        jwt.Signer
+	IssueStrategy      openid.OpenIDConnectTokenStrategy
+	ValidationStrategy openid.TokenValidationStrategy
+	Storage
+}
+
+// HandleTokenEndpointRequest implements https://tools.ietf.org/html/rfc6749#section-4.3.2
+func (c *IDTokenTypeHandler) HandleTokenEndpointRequest(ctx context.Context, request oauth2.AccessRequester) error {
+	if !c.CanHandleTokenEndpointRequest(ctx, request) {
+		return errorsx.WithStack(oauth2.ErrUnknownRequest)
+	}
+
+	session, _ := request.GetSession().(Session)
+	if session == nil {
+		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to perform token exchange because the session is not of the right type."))
+	}
+
+	form := request.GetRequestForm()
+	if form.Get(consts.FormParameterSubjectTokenType) != consts.TokenTypeRFC8693IDToken && form.Get(consts.FormParameterActorTokenType) != consts.TokenTypeRFC8693IDToken {
+		return nil
+	}
+
+	if form.Get(consts.FormParameterActorTokenType) == consts.TokenTypeRFC8693IDToken {
+		token := form.Get(consts.FormParameterActorToken)
+		if unpacked, err := c.validate(ctx, request, token); err != nil {
+			return err
+		} else {
+			session.SetActorToken(unpacked)
+		}
+	}
+
+	if form.Get(consts.FormParameterSubjectTokenType) == consts.TokenTypeRFC8693IDToken {
+		token := form.Get(consts.FormParameterSubjectToken)
+		if unpacked, err := c.validate(ctx, request, token); err != nil {
+			return err
+		} else {
+			// Get the subject and populate session
+			session.SetSubject(unpacked[consts.ClaimSubject].(string))
+			session.SetSubjectToken(unpacked)
+		}
+	}
+
+	return nil
+}
+
+// PopulateTokenEndpointResponse implements https://tools.ietf.org/html/rfc6749#section-4.3.3
+func (c *IDTokenTypeHandler) PopulateTokenEndpointResponse(ctx context.Context, request oauth2.AccessRequester, responder oauth2.AccessResponder) error {
+	if !c.CanHandleTokenEndpointRequest(ctx, request) {
+		return errorsx.WithStack(oauth2.ErrUnknownRequest)
+	}
+
+	session, _ := request.GetSession().(Session)
+	if session == nil {
+		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to perform token exchange because the session is not of the right type."))
+	}
+
+	form := request.GetRequestForm()
+	requestedTokenType := form.Get(consts.FormParameterRequestedTokenType)
+	if requestedTokenType == "" {
+		if config, ok := c.Config.(oauth2.RFC8693ConfigProvider); ok {
+			requestedTokenType = config.GetDefaultRequestedTokenType(ctx)
+		}
+	}
+
+	if requestedTokenType != consts.TokenTypeRFC8693IDToken {
+		return nil
+	}
+
+	if err := c.issue(ctx, request, responder); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CanSkipClientAuth indicates if client auth can be skipped
+func (c *IDTokenTypeHandler) CanSkipClientAuth(ctx context.Context, requester oauth2.AccessRequester) bool {
+	return false
+}
+
+// CanHandleTokenEndpointRequest indicates if the token endpoint request can be handled
+func (c *IDTokenTypeHandler) CanHandleTokenEndpointRequest(ctx context.Context, requester oauth2.AccessRequester) bool {
+	// grant_type REQUIRED.
+	// Value MUST be set to "password".
+	return requester.GetGrantTypes().ExactOne(consts.GrantTypeOAuthTokenExchange)
+}
+
+func (c *IDTokenTypeHandler) validate(ctx context.Context, request oauth2.AccessRequester, token string) (map[string]any, error) {
+	claims, err := c.ValidationStrategy.ValidateIDToken(ctx, request, token)
+	if err != nil {
+		return nil, errorsx.WithStack(oauth2.ErrInvalidRequest.WithHint("Unable to parse the id_token").WithWrap(err).WithDebugError(err))
+	}
+
+	expectedIssuer := ""
+	if config, ok := c.Config.(oauth2.AccessTokenIssuerProvider); ok {
+		expectedIssuer = config.GetAccessTokenIssuer(ctx)
+	}
+
+	if !claims.VerifyIssuer(expectedIssuer, true) {
+		return nil, errorsx.WithStack(oauth2.ErrInvalidRequest.WithHintf("Claim 'iss' from token must match the '%s'.", expectedIssuer))
+	}
+
+	if _, ok := claims[consts.ClaimSubject].(string); !ok {
+		return nil, errorsx.WithStack(oauth2.ErrInvalidRequest.WithHint("Claim 'sub' is missing."))
+	}
+
+	return map[string]any(claims), nil
+}
+
+func (c *IDTokenTypeHandler) issue(ctx context.Context, request oauth2.AccessRequester, response oauth2.AccessResponder) error {
+	sess, ok := request.GetSession().(openid.Session)
+	if !ok {
+		return errorsx.WithStack(oauth2.ErrServerError.WithDebug(
+			"Failed to generate id token because session must be of type fosite/handler/openid.Session."))
+	}
+
+	claims := sess.IDTokenClaims()
+	if claims.Subject == "" {
+		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate id token because subject is an empty string."))
+	}
+
+	token, err := c.IssueStrategy.GenerateIDToken(ctx, c.Config.GetIDTokenLifespan(ctx), request)
+	if err != nil {
+		return err
+	}
+
+	response.SetAccessToken(token)
+	response.SetTokenType("N_A")
+
+	return nil
+}

--- a/handler/rfc8693/refresh_token_type_handler.go
+++ b/handler/rfc8693/refresh_token_type_handler.go
@@ -1,0 +1,179 @@
+package rfc8693
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"authelia.com/provider/oauth2"
+	hoauth2 "authelia.com/provider/oauth2/handler/oauth2"
+	"authelia.com/provider/oauth2/internal/consts"
+	"authelia.com/provider/oauth2/internal/errorsx"
+	"authelia.com/provider/oauth2/storage"
+)
+
+type RefreshTokenTypeHandler struct {
+	Config               oauth2.RFC8693ConfigProvider
+	RefreshTokenLifespan time.Duration
+	RefreshTokenScopes   []string
+	hoauth2.CoreStrategy
+	ScopeStrategy oauth2.ScopeStrategy
+	Storage
+}
+
+// HandleTokenEndpointRequest implements https://tools.ietf.org/html/rfc6749#section-4.3.2
+func (c *RefreshTokenTypeHandler) HandleTokenEndpointRequest(ctx context.Context, request oauth2.AccessRequester) error {
+	if !c.CanHandleTokenEndpointRequest(ctx, request) {
+		return errorsx.WithStack(oauth2.ErrUnknownRequest)
+	}
+
+	session, _ := request.GetSession().(Session)
+	if session == nil {
+		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to perform token exchange because the session is not of the right type."))
+	}
+
+	form := request.GetRequestForm()
+	if form.Get(consts.FormParameterSubjectTokenType) != consts.TokenTypeRFC8693RefreshToken && form.Get(consts.FormParameterActorTokenType) != consts.TokenTypeRFC8693RefreshToken {
+		return nil
+	}
+
+	if form.Get(consts.FormParameterActorTokenType) == consts.TokenTypeRFC8693RefreshToken {
+		token := form.Get(consts.FormParameterActorToken)
+		if _, unpacked, err := c.validate(ctx, request, token); err != nil {
+			return err
+		} else {
+			session.SetActorToken(unpacked)
+		}
+	}
+
+	if form.Get(consts.FormParameterSubjectTokenType) == consts.TokenTypeRFC8693RefreshToken {
+		token := form.Get(consts.FormParameterSubjectToken)
+		if subjectTokenSession, unpacked, err := c.validate(ctx, request, token); err != nil {
+			return err
+		} else {
+			session.SetSubjectToken(unpacked)
+			session.SetSubject(subjectTokenSession.GetSubject())
+		}
+	}
+
+	return nil
+}
+
+// PopulateTokenEndpointResponse implements https://tools.ietf.org/html/rfc6749#section-4.3.3
+func (c *RefreshTokenTypeHandler) PopulateTokenEndpointResponse(ctx context.Context, request oauth2.AccessRequester, responder oauth2.AccessResponder) error {
+	if !c.CanHandleTokenEndpointRequest(ctx, request) {
+		return errorsx.WithStack(oauth2.ErrUnknownRequest)
+	}
+
+	session, _ := request.GetSession().(Session)
+	if session == nil {
+		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to perform token exchange because the session is not of the right type."))
+	}
+
+	form := request.GetRequestForm()
+	requestedTokenType := form.Get(consts.FormParameterRequestedTokenType)
+	if requestedTokenType == "" {
+		requestedTokenType = c.Config.GetDefaultRequestedTokenType(ctx)
+	}
+
+	if requestedTokenType != consts.TokenTypeRFC8693RefreshToken {
+		return nil
+	}
+
+	if err := c.issue(ctx, request, responder); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CanSkipClientAuth indicates if client auth can be skipped
+func (c *RefreshTokenTypeHandler) CanSkipClientAuth(ctx context.Context, requester oauth2.AccessRequester) bool {
+	return false
+}
+
+// CanHandleTokenEndpointRequest indicates if the token endpoint request can be handled
+func (c *RefreshTokenTypeHandler) CanHandleTokenEndpointRequest(ctx context.Context, requester oauth2.AccessRequester) bool {
+	return requester.GetGrantTypes().ExactOne(consts.GrantTypeOAuthTokenExchange)
+}
+
+func (c *RefreshTokenTypeHandler) validate(ctx context.Context, request oauth2.AccessRequester, token string) (oauth2.Session, map[string]any, error) {
+	session, _ := request.GetSession().(Session)
+	if session == nil {
+		return nil, nil, errorsx.WithStack(oauth2.ErrServerError.WithDebug(
+			"Failed to perform token exchange because the session is not of the right type."))
+	}
+
+	client := request.GetClient()
+
+	sig := c.CoreStrategy.RefreshTokenSignature(ctx, token)
+	or, err := c.Storage.GetRefreshTokenSession(ctx, sig, request.GetSession())
+	if err != nil {
+		return nil, nil, errors.WithStack(oauth2.ErrInvalidRequest.WithHint("Token is not valid or has expired.").WithDebugError(err))
+	} else if err := c.CoreStrategy.ValidateRefreshToken(ctx, or, token); err != nil {
+		return nil, nil, err
+	}
+
+	tokenClientID := or.GetClient().GetID()
+	// forbid original subjects client to exchange its own token
+	if client.GetID() == tokenClientID {
+		return nil, nil, errors.WithStack(
+			oauth2.ErrRequestForbidden.WithHint("Clients are not allowed to perform a token exchange on their own tokens."))
+	}
+
+	// Check if the client is allowed to exchange this token
+	if subjectTokenClient, ok := or.GetClient().(Client); ok {
+		allowed := subjectTokenClient.TokenExchangeAllowed(client)
+		if !allowed {
+			return nil, nil, errors.WithStack(oauth2.ErrRequestForbidden.WithHintf(
+				"The OAuth 2.0 client is not permitted to exchange a subject token issued to client %s", tokenClientID))
+		}
+	}
+
+	// Scope check
+	for _, scope := range request.GetRequestedScopes() {
+		if !c.ScopeStrategy(or.GetGrantedScopes(), scope) {
+			return nil, nil, errors.WithStack(oauth2.ErrInvalidScope.WithHintf("The subject token is not granted '%s' and so this scope cannot be requested.", scope))
+		}
+	}
+
+	// Convert to flat session with only access token claims
+	tokenObject := session.AccessTokenClaimsMap()
+	tokenObject[consts.ClaimClientIdentifier] = or.GetClient().GetID()
+	tokenObject[consts.ClaimScope] = or.GetGrantedScopes()
+	tokenObject[consts.ClaimAudience] = or.GetGrantedAudience()
+
+	return or.GetSession(), tokenObject, nil
+}
+
+func (c *RefreshTokenTypeHandler) issue(ctx context.Context, request oauth2.AccessRequester, response oauth2.AccessResponder) error {
+	request.GetSession().SetExpiresAt(oauth2.RefreshToken, time.Now().UTC().Add(c.RefreshTokenLifespan).Round(time.Second))
+	refresh, refreshSignature, err := c.CoreStrategy.GenerateRefreshToken(ctx, request)
+	if err != nil {
+		return errors.WithStack(oauth2.ErrServerError.WithDebugError(err))
+	}
+
+	if refreshSignature != "" {
+		if err := c.Storage.CreateRefreshTokenSession(ctx, refreshSignature, request.Sanitize([]string{})); err != nil {
+			if rollBackTxnErr := storage.MaybeRollbackTx(ctx, c.Storage); rollBackTxnErr != nil {
+				err = rollBackTxnErr
+			}
+			return errors.WithStack(oauth2.ErrServerError.WithDebugError(err))
+		}
+	}
+
+	response.SetAccessToken(refresh)
+	response.SetTokenType("N_A")
+	response.SetExpiresIn(c.getExpiresIn(request, oauth2.RefreshToken, c.RefreshTokenLifespan, time.Now().UTC()))
+	response.SetScopes(request.GetGrantedScopes())
+
+	return nil
+}
+
+func (c *RefreshTokenTypeHandler) getExpiresIn(r oauth2.Requester, key oauth2.TokenType, defaultLifespan time.Duration, now time.Time) time.Duration {
+	if r.GetSession().GetExpiresAt(key).IsZero() {
+		return defaultLifespan
+	}
+	return time.Duration(r.GetSession().GetExpiresAt(key).UnixNano() - now.UnixNano())
+}

--- a/handler/rfc8693/session.go
+++ b/handler/rfc8693/session.go
@@ -1,0 +1,65 @@
+package rfc8693
+
+import (
+	"authelia.com/provider/oauth2/handler/openid"
+	"authelia.com/provider/oauth2/internal/consts"
+)
+
+// Session is required to support token exchange
+type Session interface {
+	// SetSubject sets the session's subject.
+	SetSubject(subject string)
+
+	SetActorToken(token map[string]any)
+
+	GetActorToken() map[string]any
+
+	SetSubjectToken(token map[string]any)
+
+	GetSubjectToken() map[string]any
+
+	SetAct(act map[string]any)
+
+	AccessTokenClaimsMap() map[string]any
+}
+
+type DefaultSession struct {
+	*openid.DefaultSession
+
+	ActorToken   map[string]any `json:"-"`
+	SubjectToken map[string]any `json:"-"`
+	Extra        map[string]any `json:"extra,omitempty"`
+}
+
+func (s *DefaultSession) SetActorToken(token map[string]any) {
+	s.ActorToken = token
+}
+
+func (s *DefaultSession) GetActorToken() map[string]any {
+	return s.ActorToken
+}
+
+func (s *DefaultSession) SetSubjectToken(token map[string]any) {
+	s.SubjectToken = token
+}
+
+func (s *DefaultSession) GetSubjectToken() map[string]any {
+	return s.SubjectToken
+}
+
+func (s *DefaultSession) SetAct(act map[string]any) {
+	s.Extra[consts.ClaimActor] = act
+}
+
+func (s *DefaultSession) AccessTokenClaimsMap() map[string]any {
+	tokenObject := map[string]any{
+		consts.ClaimSubject:  s.GetSubject(),
+		consts.ClaimUsername: s.GetUsername(),
+	}
+
+	for k, v := range s.Extra {
+		tokenObject[k] = v
+	}
+
+	return tokenObject
+}

--- a/handler/rfc8693/storage.go
+++ b/handler/rfc8693/storage.go
@@ -1,0 +1,23 @@
+package rfc8693
+
+import (
+	"context"
+	"time"
+
+	"authelia.com/provider/oauth2"
+	hoauth2 "authelia.com/provider/oauth2/handler/oauth2"
+)
+
+type Storage interface {
+	hoauth2.CoreStorage
+
+	// SetTokenExchangeCustomJWT marks a JTI as known for the given
+	// expiry time. It should atomically check if the JTI
+	// already exists and fail the request, if found.
+	SetTokenExchangeCustomJWT(ctx context.Context, jti string, exp time.Time) error
+
+	// GetSubjectForTokenExchange computes the session subject and is used for token types where there is no way
+	// to know the subject value. For some token types, such as access and refresh tokens, the subject is well-defined
+	// and this function is not called.
+	GetSubjectForTokenExchange(ctx context.Context, requester oauth2.Requester, subjectToken map[string]any) (string, error)
+}

--- a/handler/rfc8693/token_exchange_test.go
+++ b/handler/rfc8693/token_exchange_test.go
@@ -1,0 +1,284 @@
+package rfc8693_test
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"authelia.com/provider/oauth2"
+	hoauth2 "authelia.com/provider/oauth2/handler/oauth2"
+	"authelia.com/provider/oauth2/handler/openid"
+	"authelia.com/provider/oauth2/handler/rfc8693"
+	. "authelia.com/provider/oauth2/handler/rfc8693"
+	"authelia.com/provider/oauth2/internal/consts"
+	"authelia.com/provider/oauth2/internal/gen"
+	"authelia.com/provider/oauth2/storage"
+	"authelia.com/provider/oauth2/token/hmac"
+	"authelia.com/provider/oauth2/token/jwt"
+)
+
+// expose key to verify id_token
+var key = gen.MustRSAKey()
+
+func TestAccessTokenExchangeImpersonation(t *testing.T) {
+	store := storage.NewExampleStore()
+	jwtName := "urn:custom:jwt"
+
+	jwtSigner := &jwt.DefaultSigner{
+		GetPrivateKey: func(_ context.Context) (any, error) {
+			return key, nil
+		},
+	}
+
+	customJWTType := &JWTType{
+		Name: jwtName,
+		JWTValidationConfig: JWTValidationConfig{
+			ValidateJTI: true,
+			ValidateFunc: jwt.Keyfunc(func(t *jwt.Token) (any, error) {
+				return key.PublicKey, nil
+			}),
+			JWTLifetimeToleranceWindow: 15 * time.Minute,
+		},
+		JWTIssueConfig: JWTIssueConfig{
+			Audience: []string{"https://resource1.com"},
+		},
+		Issuer: "https://customory.com",
+	}
+
+	config := &oauth2.Config{
+		ScopeStrategy:            oauth2.HierarchicScopeStrategy,
+		AudienceMatchingStrategy: oauth2.DefaultAudienceMatchingStrategy,
+		GlobalSecret:             []byte("some-secret-thats-random-some-secret-thats-random-"),
+		RFC8693TokenTypes: map[string]oauth2.RFC8693TokenType{
+			consts.TokenTypeRFC8693AccessToken: &DefaultTokenType{
+				Name: consts.TokenTypeRFC8693AccessToken,
+			},
+			consts.TokenTypeRFC8693IDToken: &DefaultTokenType{
+				Name: consts.TokenTypeRFC8693IDToken,
+			},
+			consts.TokenTypeRFC8693RefreshToken: &DefaultTokenType{
+				Name: consts.TokenTypeRFC8693RefreshToken,
+			},
+			customJWTType.GetName(context.TODO()): customJWTType,
+		},
+		DefaultRequestedTokenType: consts.TokenTypeRFC8693AccessToken,
+	}
+
+	coreStrategy := &hoauth2.HMACSHAStrategy{
+		Enigma: &hmac.HMACStrategy{Config: config},
+		Config: config,
+	}
+
+	genericTEHandler := &TokenExchangeGrantHandler{
+		Config:                   config,
+		ScopeStrategy:            config.ScopeStrategy,
+		AudienceMatchingStrategy: config.AudienceMatchingStrategy,
+	}
+
+	accessTokenHandler := &AccessTokenTypeHandler{
+		Config:               config,
+		AccessTokenLifespan:  5 * time.Minute,
+		RefreshTokenLifespan: 5 * time.Minute,
+		RefreshTokenScopes:   []string{"offline"},
+		CoreStrategy:         coreStrategy,
+		ScopeStrategy:        config.ScopeStrategy,
+		Storage:              store,
+	}
+
+	customJWTHandler := &CustomJWTTypeHandler{
+		Config: config,
+		JWTStrategy: &jwt.DefaultSigner{
+			GetPrivateKey: func(_ context.Context) (any, error) {
+				return key, nil
+			},
+		},
+		Storage: store,
+	}
+
+	for _, c := range []struct {
+		handlers    []oauth2.TokenEndpointHandler
+		areq        *oauth2.AccessRequest
+		description string
+		expectErr   error
+		expect      func(t *testing.T, areq *oauth2.AccessRequest, aresp *oauth2.AccessResponse)
+	}{
+		{
+			handlers: []oauth2.TokenEndpointHandler{genericTEHandler, accessTokenHandler},
+			areq: &oauth2.AccessRequest{
+				Request: oauth2.Request{
+					ID:     uuid.New().String(),
+					Client: store.Clients["my-client"],
+					Form: url.Values{
+						"subject_token_type": []string{consts.TokenTypeRFC8693AccessToken},
+						"subject_token": []string{createAccessToken(context.Background(), coreStrategy, store,
+							store.Clients["custom-lifespan-client"])},
+					},
+					Session: &rfc8693.DefaultSession{
+						DefaultSession: &openid.DefaultSession{},
+						Extra:          map[string]any{},
+					},
+				},
+			},
+			description: "should pass because a valid access token is exchanged for another access token",
+			expect: func(t *testing.T, areq *oauth2.AccessRequest, aresp *oauth2.AccessResponse) {
+				assert.NotEmpty(t, aresp.AccessToken, "Access token is empty; %+v", aresp)
+				req, err := introspectAccessToken(context.Background(), aresp.AccessToken, coreStrategy, store)
+				require.NoError(t, err, "Error occurred during introspection; err=%v", err)
+
+				assert.EqualValues(t, "peter", req.GetSession().GetSubject(), "Subject did not match the expected value")
+			},
+		},
+		{
+			handlers: []oauth2.TokenEndpointHandler{genericTEHandler, accessTokenHandler, customJWTHandler},
+			areq: &oauth2.AccessRequest{
+				Request: oauth2.Request{
+					ID:     uuid.New().String(),
+					Client: store.Clients["my-client"],
+					Form: url.Values{
+						"subject_token_type": []string{jwtName},
+						"subject_token": []string{createJWT(context.Background(), jwtSigner, jwt.MapClaims{
+							"subject": "peter_for_jwt",
+							"jti":     uuid.New(),
+							"iss":     "https://customory.com",
+							"sub":     "peter",
+							"exp":     time.Now().Add(15 * time.Minute).Unix(),
+						})},
+					},
+					Session: &rfc8693.DefaultSession{
+						DefaultSession: &openid.DefaultSession{},
+						Extra:          map[string]any{},
+					},
+				},
+			},
+			description: "should pass because a valid custom JWT is exchanged for access token",
+			expect: func(t *testing.T, areq *oauth2.AccessRequest, aresp *oauth2.AccessResponse) {
+				assert.NotEmpty(t, aresp.AccessToken, "Access token is empty; %+v", aresp)
+				req, err := introspectAccessToken(context.Background(), aresp.AccessToken, coreStrategy, store)
+				require.NoError(t, err, "Error occurred during introspection; err=%v", err)
+
+				assert.EqualValues(t, "peter_for_jwt", req.GetSession().GetSubject(), "Subject did not match the expected value")
+			},
+		},
+	} {
+		t.Run("case="+c.description, func(t *testing.T) {
+			ctx := context.Background()
+			aresp := oauth2.NewAccessResponse()
+			found := false
+			var err error
+			c.areq.Form.Set("grant_type", string(oauth2.GrantTypeTokenExchange))
+			c.areq.GrantTypes = oauth2.Arguments{"urn:ietf:params:oauth:grant-type:token-exchange"}
+			c.areq.Client = store.Clients["my-client"]
+			for _, loader := range c.handlers {
+				// Is the loader responsible for handling the request?
+				if !loader.CanHandleTokenEndpointRequest(ctx, c.areq) {
+					continue
+				}
+
+				// The handler **is** responsible!
+				found = true
+
+				if err = loader.HandleTokenEndpointRequest(ctx, c.areq); err == nil {
+					continue
+				} else if errors.Is(err, oauth2.ErrUnknownRequest) {
+					// This is a duplicate because it should already have been handled by
+					// `loader.CanHandleTokenEndpointRequest(accessRequest)` but let's keep it for sanity.
+					//
+					err = nil
+					continue
+				} else if err != nil {
+					break
+				}
+			}
+
+			if !found {
+				assert.Fail(t, "Unable to find a valid handler")
+			}
+
+			// now execute the response
+			if err == nil {
+				for _, loader := range c.handlers {
+					// Is the loader responsible for handling the request?
+					if !loader.CanHandleTokenEndpointRequest(ctx, c.areq) {
+						continue
+					}
+
+					// The handler **is** responsible!
+
+					if err = loader.PopulateTokenEndpointResponse(ctx, c.areq, aresp); err == nil {
+						found = true
+					} else if errors.Is(err, oauth2.ErrUnknownRequest) {
+						// This is a duplicate because it should already have been handled by
+						// `loader.CanHandleTokenEndpointRequest(accessRequest)` but let's keep it for sanity.
+						//
+						err = nil
+						continue
+					} else if err != nil {
+						break
+					}
+				}
+			}
+
+			var rfcerr *oauth2.RFC6749Error
+			rfcerr, _ = err.(*oauth2.RFC6749Error)
+			if rfcerr == nil {
+				rfcerr = oauth2.ErrServerError
+			}
+			if c.expectErr != nil {
+				require.EqualError(t, err, c.expectErr.Error(), "Error received: %v, rfcerr=%s", err, rfcerr.GetDescription())
+			} else {
+				require.NoError(t, err, "Error received: %v, rfcerr=%s", err, rfcerr.GetDescription())
+			}
+
+			if c.expect != nil {
+				c.expect(t, c.areq, aresp)
+			}
+		})
+	}
+}
+
+func createAccessToken(ctx context.Context, coreStrategy hoauth2.CoreStrategy, storage hoauth2.AccessTokenStorage, client oauth2.Client) string {
+	request := &oauth2.AccessRequest{
+		GrantTypes: oauth2.Arguments{"password"},
+		Request: oauth2.Request{
+			Session: &oauth2.DefaultSession{
+				Username: "peter",
+				Subject:  "peter",
+				ExpiresAt: map[oauth2.TokenType]time.Time{
+					oauth2.AccessToken: time.Now().UTC().Add(10 * time.Minute),
+				},
+			},
+			Client: client,
+		},
+	}
+
+	token, signature, err := coreStrategy.GenerateAccessToken(ctx, request)
+	if err != nil {
+		panic(err.Error())
+	} else if err := storage.CreateAccessTokenSession(ctx, signature, request.Sanitize([]string{})); err != nil {
+		panic(err.Error())
+	}
+
+	return token
+}
+
+func createJWT(ctx context.Context, signer jwt.Signer, claims jwt.MapClaims) string {
+	token, _, err := signer.Generate(ctx, claims, &jwt.Headers{})
+	if err != nil {
+		panic(err.Error())
+	}
+
+	return token
+}
+
+func introspectAccessToken(ctx context.Context, token string, coreStrategy hoauth2.CoreStrategy, storage hoauth2.CoreStorage) (
+	oauth2.Requester, error) {
+	sig := coreStrategy.AccessTokenSignature(ctx, token)
+	or, err := storage.GetAccessTokenSession(ctx, sig, &oauth2.DefaultSession{})
+	return or, err
+}

--- a/handler/rfc8693/token_type.go
+++ b/handler/rfc8693/token_type.go
@@ -1,0 +1,17 @@
+package rfc8693
+
+import (
+	"context"
+)
+
+type DefaultTokenType struct {
+	Name string
+}
+
+func (c *DefaultTokenType) GetName(ctx context.Context) string {
+	return c.Name
+}
+
+func (c *DefaultTokenType) GetType(ctx context.Context) string {
+	return c.Name
+}

--- a/handler/rfc8693/token_type_jwt.go
+++ b/handler/rfc8693/token_type_jwt.go
@@ -1,0 +1,35 @@
+package rfc8693
+
+import (
+	"context"
+	"time"
+
+	"authelia.com/provider/oauth2/internal/consts"
+	"authelia.com/provider/oauth2/token/jwt"
+)
+
+type JWTType struct {
+	Name                string `json:"name"`
+	Issuer              string `json:"iss"`
+	JWTValidationConfig `json:"validate"`
+	JWTIssueConfig      `json:"issue"`
+}
+
+type JWTIssueConfig struct {
+	Audience []string      `json:"aud"`
+	Expiry   time.Duration `json:"exp"`
+}
+
+type JWTValidationConfig struct {
+	ValidateJTI                bool          `json:"validate_jti"`
+	JWTLifetimeToleranceWindow time.Duration `json:"tolerance_window"`
+	ValidateFunc               jwt.Keyfunc   `json:"-"`
+}
+
+func (c *JWTType) GetName(ctx context.Context) string {
+	return c.Name
+}
+
+func (c *JWTType) GetType(ctx context.Context) string {
+	return consts.TokenTypeRFC8693JWT
+}

--- a/internal/consts/claim.go
+++ b/internal/consts/claim.go
@@ -31,4 +31,6 @@ const (
 	ClaimCodeHash                            = "c_hash"
 	ClaimStateHash                           = "s_hash"
 	ClaimNonce                               = valueNonce
+	ClaimAuthorizedActor                     = "may_act"
+	ClaimActor                               = "act"
 )

--- a/internal/consts/form_parameters.go
+++ b/internal/consts/form_parameters.go
@@ -37,6 +37,12 @@ const (
 	FormParameterDisplay                                   = "display"
 	FormParameterAuthenticationContextClassReferenceValues = "acr_values"
 	FormParameterIDTokenHint                               = "id_token_hint"
+	FormParameterRequestedTokenType                        = "requested_token_type"
+	FormParameterIssuedTokenType                           = "issued_token_type"
+	FormParameterSubjectTokenType                          = "subject_token_type"
+	FormParameterSubjectToken                              = "subject_token"
+	FormParameterActorTokenType                            = "actor_token_type"
+	FormParameterActorToken                                = "actor_token"
 	FormParameterDeviceCode                                = valueDeviceCode
 	FormParameterUserCode                                  = valueUserCode
 )

--- a/internal/consts/grant_type.go
+++ b/internal/consts/grant_type.go
@@ -7,6 +7,7 @@ const (
 	GrantTypeAuthorizationCode                = "authorization_code"
 	GrantTypeClientCredentials                = "client_credentials"
 	GrantTypeResourceOwnerPasswordCredentials = valuePassword
-	GrantTypeOAuthJWTBearer                   = "urn:ietf:params:oauth:grant-type:jwt-bearer"  //nolint:gosec
-	GrantTypeOAuthDeviceCode                  = "urn:ietf:params:oauth:grant-type:device_code" //nolint:gosec
+	GrantTypeOAuthJWTBearer                   = "urn:ietf:params:oauth:grant-type:jwt-bearer"     //nolint:gosec
+	GrantTypeOAuthDeviceCode                  = "urn:ietf:params:oauth:grant-type:device_code"    //nolint:gosec
+	GrantTypeOAuthTokenExchange               = "urn:ietf:params:oauth:grant-type:token-exchange" //nolint:gosec
 )

--- a/internal/consts/spec.go
+++ b/internal/consts/spec.go
@@ -22,11 +22,6 @@ const (
 )
 
 const (
-	TokenTypeAccessToken  = "access_token"
-	TokenTypeRefreshToken = "refresh_token"
-)
-
-const (
 	CodeDevice = valueDeviceCode
 	CodeUser   = "user_code"
 )

--- a/internal/consts/token_type.go
+++ b/internal/consts/token_type.go
@@ -1,0 +1,13 @@
+package consts
+
+const (
+	TokenTypeAccessToken  = "access_token"
+	TokenTypeRefreshToken = "refresh_token"
+)
+
+const (
+	TokenTypeRFC8693AccessToken  = "urn:ietf:params:oauth:token-type:access_token"
+	TokenTypeRFC8693RefreshToken = "urn:ietf:params:oauth:token-type:refresh_token"
+	TokenTypeRFC8693IDToken      = "urn:ietf:params:oauth:token-type:id_token"
+	TokenTypeRFC8693JWT          = "urn:ietf:params:oauth:token-type:jwt"
+)

--- a/oauth2.go
+++ b/oauth2.go
@@ -21,14 +21,16 @@ type TokenType string
 type GrantType string
 
 const (
-	AccessToken   TokenType = consts.TokenTypeAccessToken
-	RefreshToken  TokenType = consts.TokenTypeRefreshToken
-	AuthorizeCode TokenType = "authorize_code"
-	IDToken       TokenType = "id_token"
+	AccessToken  TokenType = consts.TokenTypeAccessToken
+	RefreshToken TokenType = consts.TokenTypeRefreshToken
+	DeviceCode   TokenType = consts.CodeDevice
+	UserCode     TokenType = consts.CodeUser
+
 	// PushedAuthorizeRequestContext represents the PAR context object
 	PushedAuthorizeRequestContext TokenType = "par_context"
-	DeviceCode                    TokenType = consts.CodeDevice
-	UserCode                      TokenType = consts.CodeUser
+
+	AuthorizeCode TokenType = "authorize_code"
+	IDToken       TokenType = "id_token"
 
 	GrantTypeImplicit          GrantType = consts.GrantTypeImplicit
 	GrantTypeRefreshToken      GrantType = consts.GrantTypeRefreshToken
@@ -37,7 +39,9 @@ const (
 	GrantTypeClientCredentials GrantType = consts.GrantTypeClientCredentials
 	GrantTypeJWTBearer         GrantType = consts.GrantTypeOAuthJWTBearer
 	GrantTypeDeviceCode        GrantType = consts.GrantTypeOAuthDeviceCode
-	BearerAccessToken          string    = "bearer"
+	GrantTypeTokenExchange     GrantType = consts.GrantTypeOAuthTokenExchange
+
+	BearerAccessToken string = "bearer"
 )
 
 // Provider is an interface that enables you to write OAuth2 handlers with only a few lines of code.
@@ -540,4 +544,10 @@ type RFC8628UserAuthorizeResponder interface {
 type G11NContext interface {
 	// GetLang returns the current language in the context
 	GetLang() language.Tag
+}
+
+type RFC8693TokenType interface {
+	GetName(ctx context.Context) string
+
+	GetType(ctx context.Context) string
 }

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -115,7 +115,7 @@ func NewExampleStore() *MemoryStore {
 				RotatedSecrets: [][]byte{[]byte(`$2y$10$X51gLxUQJ.hGw1epgHTE5u0bt64xM0COU7K9iAp.OFg8p2pUd.1zC `)}, // = "foobaz",
 				RedirectURIs:   []string{"http://localhost:3846/callback"},
 				ResponseTypes:  []string{"id_token", "code", "token", "id_token token", "code id_token", "code token", "code id_token token"},
-				GrantTypes:     []string{"implicit", "refresh_token", "authorization_code", "password", "client_credentials"},
+				GrantTypes:     []string{"implicit", "refresh_token", "authorization_code", "password", "client_credentials", "urn:ietf:params:oauth:grant-type:token-exchange"},
 				Scopes:         []string{"oauth2", consts.ScopeOpenID, "photos", consts.ScopeOffline},
 			},
 			"custom-lifespan-client": &oauth2.DefaultClientWithCustomTokenLifespans{
@@ -153,6 +153,7 @@ func NewExampleStore() *MemoryStore {
 		RefreshTokens:          map[string]StoreRefreshToken{},
 		PKCES:                  map[string]oauth2.Requester{},
 		AccessTokenRequestIDs:  map[string]string{},
+		BlacklistedJTIs:        map[string]time.Time{},
 		RefreshTokenRequestIDs: map[string]string{},
 		IssuerPublicKeys:       map[string]IssuerPublicKeys{},
 		PARSessions:            map[string]oauth2.AuthorizeRequester{},
@@ -512,6 +513,23 @@ func (s *MemoryStore) DeletePARSession(ctx context.Context, requestURI string) (
 	delete(s.PARSessions, requestURI)
 
 	return nil
+}
+
+func (s *MemoryStore) SetTokenExchangeCustomJWT(ctx context.Context, jti string, exp time.Time) error {
+	// the memory store implementation is generic, so just re-use
+	return s.SetClientAssertionJWT(ctx, jti, exp)
+}
+
+// GetSubjectForTokenExchange computes the session subject and is used for token types where there is no way
+// to know the subject value. For some token types, such as access and refresh tokens, the subject is well-defined
+// and this function is not called.
+func (s *MemoryStore) GetSubjectForTokenExchange(ctx context.Context, requester oauth2.Requester, subjectToken map[string]any) (string, error) {
+	sub, _ := subjectToken["subject"].(string)
+	if sub == "" {
+		return "", oauth2.ErrInvalidRequest.WithHint("No subject found.")
+	}
+
+	return sub, nil
 }
 
 func (s *MemoryStore) CreateDeviceCodeSession(ctx context.Context, signature string, request oauth2.DeviceAuthorizeRequester) error {


### PR DESCRIPTION
This is an implementation of the RFC8693 OAuth 2.0 Token Exchange flow. See https://datatracker.ietf.org/doc/html/rfc8693.