### PR TITLE
feat(oauth2): jwt profile per client

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,13 @@ following list of differences:
   - [x] Access Token iat and nbf in JWT Profile always original claims
         <sup>[commit](https://github.com/authelia/oauth2-provider/commit/a87d91df762a8fe26282145ba9dace0461f31b4d)</sup>
 - Features:
-  - [x] Customizable Token Prefix
-        <sup>[commit](https://github.com/authelia/oauth2-provider/commit/4f55dabdf5d87c34053992c3de3fe7b1bf1046f3)</sup>
+  - CoreStrategy:
+    - [x] Customizable Token Prefix
+          <sup>[commit](https://github.com/authelia/oauth2-provider/commit/4f55dabdf5d87c34053992c3de3fe7b1bf1046f3)</sup>
+    - [x] Automatic NewCoreStrategy which provides either:
+      - JWT Profile Core Strategy (if a jwt.Signer is provided)
+      - HMAC-based Core Strategy
+    - [x] JWT Profile Per Client
   - [ ] UserInfo support
   - [x] [RFC8628: OAuth 2.0 Device Authorization Grant](https://datatracker.ietf.org/doc/html/rfc8628)
         support

--- a/client.go
+++ b/client.go
@@ -129,6 +129,19 @@ type ClientCredentialsFlowPolicyClient interface {
 	Client
 }
 
+type JWTProfileClient interface {
+	// GetAccessTokenSignedResponseAlg returns the algorithm used for signing Access Tokens.
+	GetAccessTokenSignedResponseAlg() (alg string)
+
+	// GetAccessTokenSignedResponseKeyID returns the key id used for signing Access Tokens.
+	GetAccessTokenSignedResponseKeyID() (kid string)
+
+	// GetEnableJWTProfileOAuthAccessTokens indicates this client should or should not issue JWT Profile Access Tokens.
+	GetEnableJWTProfileOAuthAccessTokens() (enable bool)
+
+	Client
+}
+
 // DefaultClient is a simple default implementation of the Client interface.
 type DefaultClient struct {
 	ID                   string         `json:"id"`

--- a/config.go
+++ b/config.go
@@ -122,183 +122,190 @@ type JWTSecuredAuthorizeResponseModeLifespanProvider interface {
 	GetJWTSecuredAuthorizeResponseModeLifespan(ctx context.Context) time.Duration
 }
 
+// JWTProfileAccessTokensProvider provides configuration options to the JWT Profile strategies.
+type JWTProfileAccessTokensProvider interface {
+	// GetEnforceJWTProfileAccessTokens when returning true will disregard the registered client capabilities for
+	// Access Token generation and produce only JWT Profile Access Tokens.
+	GetEnforceJWTProfileAccessTokens(ctx context.Context) (enable bool)
+}
+
 // AllowedPromptsProvider returns the provider for configuring the allowed prompts.
 type AllowedPromptsProvider interface {
 	// GetAllowedPrompts returns the allowed prompts.
-	GetAllowedPrompts(ctx context.Context) []string
+	GetAllowedPrompts(ctx context.Context) (prompts []string)
 }
 
 // MinParameterEntropyProvider returns the provider for configuring the minimum parameter entropy.
 type MinParameterEntropyProvider interface {
 	// GetMinParameterEntropy returns the minimum parameter entropy.
-	GetMinParameterEntropy(_ context.Context) int
+	GetMinParameterEntropy(_ context.Context) (min int)
 }
 
 // SanitationAllowedProvider returns the provider for configuring the sanitation white list.
 type SanitationAllowedProvider interface {
 	// GetSanitationWhiteList is a whitelist of form values that are required by the token endpoint. These values
 	// are safe for storage in a database (cleartext).
-	GetSanitationWhiteList(ctx context.Context) []string
+	GetSanitationWhiteList(ctx context.Context) (whitelist []string)
 }
 
 // OmitRedirectScopeParamProvider returns the provider for configuring the omit redirect scope param.
 type OmitRedirectScopeParamProvider interface {
 	// GetOmitRedirectScopeParam must be set to true if the scope query param is to be omitted
 	// in the authorization's redirect URI
-	GetOmitRedirectScopeParam(ctx context.Context) bool
+	GetOmitRedirectScopeParam(ctx context.Context) (omit bool)
 }
 
 // EnforcePKCEProvider returns the provider for configuring the enforcement of PKCE.
 type EnforcePKCEProvider interface {
 	// GetEnforcePKCE returns the enforcement of PKCE.
-	GetEnforcePKCE(ctx context.Context) bool
+	GetEnforcePKCE(ctx context.Context) (enforce bool)
 }
 
 // EnforcePKCEForPublicClientsProvider returns the provider for configuring the enforcement of PKCE for public clients.
 type EnforcePKCEForPublicClientsProvider interface {
 	// GetEnforcePKCEForPublicClients returns the enforcement of PKCE for public clients.
-	GetEnforcePKCEForPublicClients(ctx context.Context) bool
+	GetEnforcePKCEForPublicClients(ctx context.Context) (enforce bool)
 }
 
 // EnablePKCEPlainChallengeMethodProvider returns the provider for configuring the enable PKCE plain challenge method.
 type EnablePKCEPlainChallengeMethodProvider interface {
 	// GetEnablePKCEPlainChallengeMethod returns the enable PKCE plain challenge method.
-	GetEnablePKCEPlainChallengeMethod(ctx context.Context) bool
+	GetEnablePKCEPlainChallengeMethod(ctx context.Context) (enable bool)
 }
 
 // GrantTypeJWTBearerCanSkipClientAuthProvider returns the provider for configuring the grant type JWT bearer can skip client auth.
 type GrantTypeJWTBearerCanSkipClientAuthProvider interface {
 	// GetGrantTypeJWTBearerCanSkipClientAuth returns the grant type JWT bearer can skip client auth.
-	GetGrantTypeJWTBearerCanSkipClientAuth(ctx context.Context) bool
+	GetGrantTypeJWTBearerCanSkipClientAuth(ctx context.Context) (permitted bool)
 }
 
 // GrantTypeJWTBearerIDOptionalProvider returns the provider for configuring the grant type JWT bearer ID optional.
 type GrantTypeJWTBearerIDOptionalProvider interface {
 	// GetGrantTypeJWTBearerIDOptional returns the grant type JWT bearer ID optional.
-	GetGrantTypeJWTBearerIDOptional(ctx context.Context) bool
+	GetGrantTypeJWTBearerIDOptional(ctx context.Context) (optional bool)
 }
 
 // GrantTypeJWTBearerIssuedDateOptionalProvider returns the provider for configuring the grant type JWT bearer issued date optional.
 type GrantTypeJWTBearerIssuedDateOptionalProvider interface {
 	// GetGrantTypeJWTBearerIssuedDateOptional returns the grant type JWT bearer issued date optional.
-	GetGrantTypeJWTBearerIssuedDateOptional(ctx context.Context) bool
+	GetGrantTypeJWTBearerIssuedDateOptional(ctx context.Context) (optional bool)
 }
 
 // GetJWTMaxDurationProvider returns the provider for configuring the JWT max duration.
 type GetJWTMaxDurationProvider interface {
 	// GetJWTMaxDuration returns the JWT max duration.
-	GetJWTMaxDuration(ctx context.Context) time.Duration
+	GetJWTMaxDuration(ctx context.Context) (max time.Duration)
 }
 
 // TokenEntropyProvider returns the provider for configuring the token entropy.
 type TokenEntropyProvider interface {
 	// GetTokenEntropy returns the token entropy.
-	GetTokenEntropy(ctx context.Context) int
+	GetTokenEntropy(ctx context.Context) (entropy int)
 }
 
 // GlobalSecretProvider returns the provider for configuring the global secret.
 type GlobalSecretProvider interface {
 	// GetGlobalSecret returns the global secret.
-	GetGlobalSecret(ctx context.Context) ([]byte, error)
+	GetGlobalSecret(ctx context.Context) (secret []byte, err error)
 }
 
 // RotatedGlobalSecretsProvider returns the provider for configuring the rotated global secrets.
 type RotatedGlobalSecretsProvider interface {
 	// GetRotatedGlobalSecrets returns the rotated global secrets.
-	GetRotatedGlobalSecrets(ctx context.Context) ([][]byte, error)
+	GetRotatedGlobalSecrets(ctx context.Context) (secrets [][]byte, err error)
 }
 
 // HMACHashingProvider returns the provider for configuring the hash function.
 type HMACHashingProvider interface {
 	// GetHMACHasher returns the hash function.
-	GetHMACHasher(ctx context.Context) func() hash.Hash
+	GetHMACHasher(ctx context.Context) func() (hasher hash.Hash)
 }
 
 // SendDebugMessagesToClientsProvider returns the provider for configuring the send debug messages to clients.
 type SendDebugMessagesToClientsProvider interface {
 	// GetSendDebugMessagesToClients returns the send debug messages to clients.
-	GetSendDebugMessagesToClients(ctx context.Context) bool
+	GetSendDebugMessagesToClients(ctx context.Context) (send bool)
 }
 
 // RevokeRefreshTokensExplicitlyProvider returns the provider for configuring the Refresh Token Explicit Revocation policy.
 type RevokeRefreshTokensExplicitlyProvider interface {
 	// GetRevokeRefreshTokensExplicit returns true if a refresh token should only be revoked explicitly.
-	GetRevokeRefreshTokensExplicit(ctx context.Context) bool
+	GetRevokeRefreshTokensExplicit(ctx context.Context) (explicit bool)
 
 	// GetEnforceRevokeFlowRevokeRefreshTokensExplicitClient returns true if a
 	// RevokeFlowRevokeRefreshTokensExplicitClient returning false should be enforced.
-	GetEnforceRevokeFlowRevokeRefreshTokensExplicitClient(ctx context.Context) bool
+	GetEnforceRevokeFlowRevokeRefreshTokensExplicitClient(ctx context.Context) (explicit bool)
 }
 
 // JWKSFetcherStrategyProvider returns the provider for configuring the JWKS fetcher strategy.
 type JWKSFetcherStrategyProvider interface {
 	// GetJWKSFetcherStrategy returns the JWKS fetcher strategy.
-	GetJWKSFetcherStrategy(ctx context.Context) JWKSFetcherStrategy
+	GetJWKSFetcherStrategy(ctx context.Context) (strategy JWKSFetcherStrategy)
 }
 
 // HTTPClientProvider returns the provider for configuring the HTTP client.
 type HTTPClientProvider interface {
 	// GetHTTPClient returns the HTTP client provider.
-	GetHTTPClient(ctx context.Context) *retryablehttp.Client
+	GetHTTPClient(ctx context.Context) (client *retryablehttp.Client)
 }
 
 // ClientAuthenticationStrategyProvider returns the provider for configuring the client authentication strategy.
 type ClientAuthenticationStrategyProvider interface {
 	// GetClientAuthenticationStrategy returns the client authentication strategy.
-	GetClientAuthenticationStrategy(ctx context.Context) ClientAuthenticationStrategy
+	GetClientAuthenticationStrategy(ctx context.Context) (strategy ClientAuthenticationStrategy)
 }
 
 // ResponseModeHandlerProvider returns the provider for configuring the response mode handlers.
 type ResponseModeHandlerProvider interface {
 	// GetResponseModeHandlers returns the response mode handlers in order of execution.
-	GetResponseModeHandlers(ctx context.Context) []ResponseModeHandler
+	GetResponseModeHandlers(ctx context.Context) (handlers []ResponseModeHandler)
 }
 
 // MessageCatalogProvider returns the provider for configuring the message catalog.
 type MessageCatalogProvider interface {
 	// GetMessageCatalog returns the message catalog.
-	GetMessageCatalog(ctx context.Context) i18n.MessageCatalog
+	GetMessageCatalog(ctx context.Context) (catalog i18n.MessageCatalog)
 }
 
 // FormPostHTMLTemplateProvider returns the provider for configuring the form post HTML template.
 type FormPostHTMLTemplateProvider interface {
 	// GetFormPostHTMLTemplate returns the form post HTML template.
-	GetFormPostHTMLTemplate(ctx context.Context) *template.Template
+	GetFormPostHTMLTemplate(ctx context.Context) (tmpl *template.Template)
 }
 
 type TokenURLProvider interface {
 	// GetTokenURL returns the token URL.
-	GetTokenURL(ctx context.Context) string
+	GetTokenURL(ctx context.Context) (url string)
 }
 
 // AuthorizeEndpointHandlersProvider returns the provider for configuring the authorize endpoint handlers.
 type AuthorizeEndpointHandlersProvider interface {
 	// GetAuthorizeEndpointHandlers returns the authorize endpoint handlers.
-	GetAuthorizeEndpointHandlers(ctx context.Context) AuthorizeEndpointHandlers
+	GetAuthorizeEndpointHandlers(ctx context.Context) (handlers AuthorizeEndpointHandlers)
 }
 
 // TokenEndpointHandlersProvider returns the provider for configuring the token endpoint handlers.
 type TokenEndpointHandlersProvider interface {
 	// GetTokenEndpointHandlers returns the token endpoint handlers.
-	GetTokenEndpointHandlers(ctx context.Context) TokenEndpointHandlers
+	GetTokenEndpointHandlers(ctx context.Context) (handlers TokenEndpointHandlers)
 }
 
 // TokenIntrospectionHandlersProvider returns the provider for configuring the token introspection handlers.
 type TokenIntrospectionHandlersProvider interface {
 	// GetTokenIntrospectionHandlers returns the token introspection handlers.
-	GetTokenIntrospectionHandlers(ctx context.Context) TokenIntrospectionHandlers
+	GetTokenIntrospectionHandlers(ctx context.Context) (handlers TokenIntrospectionHandlers)
 }
 
 // RevocationHandlersProvider returns the provider for configuring the revocation handlers.
 type RevocationHandlersProvider interface {
 	// GetRevocationHandlers returns the revocation handlers.
-	GetRevocationHandlers(ctx context.Context) RevocationHandlers
+	GetRevocationHandlers(ctx context.Context) (handlers RevocationHandlers)
 }
 
 // PushedAuthorizeRequestHandlersProvider returns the provider for configuring the PAR handlers.
 type PushedAuthorizeRequestHandlersProvider interface {
 	// GetPushedAuthorizeEndpointHandlers returns the handlers.
-	GetPushedAuthorizeEndpointHandlers(ctx context.Context) PushedAuthorizeEndpointHandlers
+	GetPushedAuthorizeEndpointHandlers(ctx context.Context) (handlers PushedAuthorizeEndpointHandlers)
 }
 
 // RFC9628DeviceAuthorizeConfigProvider returns the provider for configuring the device authorization response.
@@ -316,20 +323,20 @@ type RFC9628DeviceAuthorizeConfigProvider interface {
 // RFC8628DeviceAuthorizeEndpointHandlersProvider returns the provider for setting up the Device authorization handlers.
 type RFC8628DeviceAuthorizeEndpointHandlersProvider interface {
 	// GetRFC8628DeviceAuthorizeEndpointHandlers returns the handlers.
-	GetRFC8628DeviceAuthorizeEndpointHandlers(ctx context.Context) RFC8628DeviceAuthorizeEndpointHandlers
+	GetRFC8628DeviceAuthorizeEndpointHandlers(ctx context.Context) (handlers RFC8628DeviceAuthorizeEndpointHandlers)
 }
 
 // RFC8628UserAuthorizeEndpointHandlersProvider returns the provider for setting up the Device grant user interaction handlers.
 type RFC8628UserAuthorizeEndpointHandlersProvider interface {
 	// GetRFC8628UserAuthorizeEndpointHandlers returns the handlers.
-	GetRFC8628UserAuthorizeEndpointHandlers(ctx context.Context) RFC8628UserAuthorizeEndpointHandlers
+	GetRFC8628UserAuthorizeEndpointHandlers(ctx context.Context) (handlers RFC8628UserAuthorizeEndpointHandlers)
 }
 
 // RFC8693ConfigProvider is the configuration provider for RFC8693 Token Exchange.
 type RFC8693ConfigProvider interface {
-	GetRFC8693TokenTypes(ctx context.Context) map[string]RFC8693TokenType
+	GetRFC8693TokenTypes(ctx context.Context) (types map[string]RFC8693TokenType)
 
-	GetDefaultRFC8693RequestedTokenType(ctx context.Context) string
+	GetDefaultRFC8693RequestedTokenType(ctx context.Context) (tokenType string)
 }
 
 // UseLegacyErrorFormatProvider returns the provider for configuring whether to use the legacy error format.
@@ -339,7 +346,7 @@ type UseLegacyErrorFormatProvider interface {
 	// GetUseLegacyErrorFormat returns whether to use the legacy error format.
 	//
 	// Deprecated: Do not use this flag anymore.
-	GetUseLegacyErrorFormat(ctx context.Context) bool
+	GetUseLegacyErrorFormat(ctx context.Context) (use bool)
 }
 
 // PushedAuthorizeRequestConfigProvider is the configuration provider for pushed
@@ -347,13 +354,13 @@ type UseLegacyErrorFormatProvider interface {
 type PushedAuthorizeRequestConfigProvider interface {
 	// GetPushedAuthorizeRequestURIPrefix is the request URI prefix. This is
 	// usually 'urn:ietf:params:oauth:request_uri:'.
-	GetPushedAuthorizeRequestURIPrefix(ctx context.Context) string
+	GetPushedAuthorizeRequestURIPrefix(ctx context.Context) (prefix string)
 
 	// GetPushedAuthorizeContextLifespan is the lifespan of the short-lived PAR context.
-	GetPushedAuthorizeContextLifespan(ctx context.Context) time.Duration
+	GetPushedAuthorizeContextLifespan(ctx context.Context) (lifespan time.Duration)
 
 	// EnforcePushedAuthorize indicates if PAR is enforced. In this mode, a client
 	// cannot pass authorize parameters at the 'authorize' endpoint. The 'authorize' endpoint
 	// must contain the PAR request_uri.
-	EnforcePushedAuthorize(ctx context.Context) bool
+	EnforcePushedAuthorize(ctx context.Context) (enforce bool)
 }

--- a/config_default.go
+++ b/config_default.go
@@ -163,6 +163,9 @@ type Config struct {
 	// JWTSecuredAuthorizeResponseModeSigner is the signer for JWT Secured Authorization Response Mode. Has no default.
 	JWTSecuredAuthorizeResponseModeSigner jwt.Signer
 
+	// EnforceJWTProfileAccessTokens forces the issuer to return JWT Profile Access Tokens to all clients.
+	EnforceJWTProfileAccessTokens bool
+
 	// HTTPClient is the HTTP client to use for requests.
 	HTTPClient *retryablehttp.Client
 
@@ -353,6 +356,10 @@ func (c *Config) GetJWTSecuredAuthorizeResponseModeIssuer(ctx context.Context) s
 
 func (c *Config) GetJWTSecuredAuthorizeResponseModeSigner(ctx context.Context) jwt.Signer {
 	return c.JWTSecuredAuthorizeResponseModeSigner
+}
+
+func (c *Config) GetEnforceJWTProfileAccessTokens(ctx context.Context) (enable bool) {
+	return c.EnforceJWTProfileAccessTokens
 }
 
 func (c *Config) GetAllowedPrompts(_ context.Context) []string {
@@ -584,6 +591,7 @@ var (
 	_ JWTSecuredAuthorizeResponseModeIssuerProvider   = (*Config)(nil)
 	_ JWTSecuredAuthorizeResponseModeSignerProvider   = (*Config)(nil)
 	_ JWTSecuredAuthorizeResponseModeLifespanProvider = (*Config)(nil)
+	_ JWTProfileAccessTokensProvider                  = (*Config)(nil)
 	_ AllowedPromptsProvider                          = (*Config)(nil)
 	_ OmitRedirectScopeParamProvider                  = (*Config)(nil)
 	_ MinParameterEntropyProvider                     = (*Config)(nil)

--- a/fosite.go
+++ b/fosite.go
@@ -129,6 +129,7 @@ type Configurator interface {
 	JWTSecuredAuthorizeResponseModeIssuerProvider
 	JWTSecuredAuthorizeResponseModeSignerProvider
 	JWTSecuredAuthorizeResponseModeLifespanProvider
+	JWTProfileAccessTokensProvider
 	AccessTokenIssuerProvider
 	DisableRefreshTokenValidationProvider
 	RefreshTokenScopesProvider

--- a/handler/oauth2/introspector_jwt.go
+++ b/handler/oauth2/introspector_jwt.go
@@ -21,7 +21,7 @@ type StatelessJWTValidator struct {
 }
 
 func (v *StatelessJWTValidator) IntrospectToken(ctx context.Context, token string, tokenUse oauth2.TokenUse, accessRequest oauth2.AccessRequester, scopes []string) (oauth2.TokenUse, error) {
-	t, err := validate(ctx, v.Signer, token)
+	t, err := validateJWT(ctx, v.Signer, token)
 	if err != nil {
 		return "", err
 	}

--- a/handler/oauth2/introspector_jwt_test.go
+++ b/handler/oauth2/introspector_jwt_test.go
@@ -20,13 +20,20 @@ import (
 
 func TestIntrospectJWT(t *testing.T) {
 	rsaKey := gen.MustRSAKey()
+
+	config := &oauth2.Config{
+		EnforceJWTProfileAccessTokens: true,
+		GlobalSecret:                  []byte("foofoofoofoofoofoofoofoofoofoofoo"),
+	}
+
 	strategy := &JWTProfileCoreStrategy{
+		HMACCoreStrategy: NewHMACCoreStrategy(config, "authelia_%s_"),
 		Signer: &jwt.DefaultSigner{
 			GetPrivateKey: func(_ context.Context) (any, error) {
 				return rsaKey, nil
 			},
 		},
-		Config: &oauth2.Config{},
+		Config: config,
 	}
 
 	var v = &StatelessJWTValidator{

--- a/handler/oauth2/strategy_hmac.go
+++ b/handler/oauth2/strategy_hmac.go
@@ -46,97 +46,98 @@ type HMACCoreStrategy struct {
 }
 
 // AccessTokenSignature implements oauth2.AccessTokenStrategy.
-func (h *HMACCoreStrategy) AccessTokenSignature(ctx context.Context, tokenString string) (signature string) {
-	return h.Enigma.Signature(tokenString)
+func (s *HMACCoreStrategy) AccessTokenSignature(ctx context.Context, tokenString string) (signature string) {
+	return s.Enigma.Signature(tokenString)
 }
 
 // GenerateAccessToken implements oauth2.AccessTokenStrategy.
-func (h *HMACCoreStrategy) GenerateAccessToken(ctx context.Context, _ oauth2.Requester) (tokenString string, signature string, err error) {
-	if tokenString, signature, err = h.Enigma.Generate(ctx); err != nil {
+func (s *HMACCoreStrategy) GenerateAccessToken(ctx context.Context, _ oauth2.Requester) (tokenString string, signature string, err error) {
+	if tokenString, signature, err = s.Enigma.Generate(ctx); err != nil {
 		return "", "", err
 	}
 
-	return h.prependPrefix(tokenString, tokenPrefixPartAccessToken), signature, nil
+	return s.prependPrefix(tokenString, tokenPrefixPartAccessToken), signature, nil
 }
 
 // ValidateAccessToken implements oauth2.AccessTokenStrategy.
-func (h *HMACCoreStrategy) ValidateAccessToken(ctx context.Context, r oauth2.Requester, tokenString string) (err error) {
+func (s *HMACCoreStrategy) ValidateAccessToken(ctx context.Context, r oauth2.Requester, tokenString string) (err error) {
 	var exp = r.GetSession().GetExpiresAt(oauth2.AccessToken)
-	if exp.IsZero() && r.GetRequestedAt().Add(h.Config.GetAccessTokenLifespan(ctx)).Before(time.Now().UTC()) {
-		return errorsx.WithStack(oauth2.ErrTokenExpired.WithHintf("Access token expired at '%s'.", r.GetRequestedAt().Add(h.Config.GetAccessTokenLifespan(ctx))))
+
+	if exp.IsZero() && r.GetRequestedAt().Add(s.Config.GetAccessTokenLifespan(ctx)).Before(time.Now().UTC()) {
+		return errorsx.WithStack(oauth2.ErrTokenExpired.WithHintf("Access token expired at '%s'.", r.GetRequestedAt().Add(s.Config.GetAccessTokenLifespan(ctx))))
 	}
 
 	if !exp.IsZero() && exp.Before(time.Now().UTC()) {
 		return errorsx.WithStack(oauth2.ErrTokenExpired.WithHintf("Access token expired at '%s'.", exp))
 	}
 
-	return h.Enigma.Validate(ctx, h.trimPrefix(tokenString, tokenPrefixPartAccessToken))
+	return s.Enigma.Validate(ctx, s.trimPrefix(tokenString, tokenPrefixPartAccessToken))
 }
 
 // RefreshTokenSignature implements oauth2.RefreshTokenStrategy.
-func (h *HMACCoreStrategy) RefreshTokenSignature(ctx context.Context, tokenString string) string {
-	return h.Enigma.Signature(tokenString)
+func (s *HMACCoreStrategy) RefreshTokenSignature(ctx context.Context, tokenString string) string {
+	return s.Enigma.Signature(tokenString)
 }
 
 // GenerateRefreshToken implements oauth2.RefreshTokenStrategy.
-func (h *HMACCoreStrategy) GenerateRefreshToken(ctx context.Context, _ oauth2.Requester) (tokenString string, signature string, err error) {
-	if tokenString, signature, err = h.Enigma.Generate(ctx); err != nil {
+func (s *HMACCoreStrategy) GenerateRefreshToken(ctx context.Context, _ oauth2.Requester) (tokenString string, signature string, err error) {
+	if tokenString, signature, err = s.Enigma.Generate(ctx); err != nil {
 		return "", "", err
 	}
 
-	return h.prependPrefix(tokenString, tokenPrefixPartRefreshToken), signature, nil
+	return s.prependPrefix(tokenString, tokenPrefixPartRefreshToken), signature, nil
 }
 
 // ValidateRefreshToken implements oauth2.RefreshTokenStrategy.
-func (h *HMACCoreStrategy) ValidateRefreshToken(ctx context.Context, r oauth2.Requester, tokenString string) (err error) {
+func (s *HMACCoreStrategy) ValidateRefreshToken(ctx context.Context, r oauth2.Requester, tokenString string) (err error) {
 	var exp = r.GetSession().GetExpiresAt(oauth2.RefreshToken)
 
 	if exp.IsZero() {
-		return h.Enigma.Validate(ctx, h.trimPrefix(tokenString, tokenPrefixPartRefreshToken))
+		return s.Enigma.Validate(ctx, s.trimPrefix(tokenString, tokenPrefixPartRefreshToken))
 	}
 
 	if exp.Before(time.Now().UTC()) {
 		return errorsx.WithStack(oauth2.ErrTokenExpired.WithHintf("Refresh token expired at '%s'.", exp))
 	}
 
-	return h.Enigma.Validate(ctx, h.trimPrefix(tokenString, tokenPrefixPartRefreshToken))
+	return s.Enigma.Validate(ctx, s.trimPrefix(tokenString, tokenPrefixPartRefreshToken))
 }
 
 // AuthorizeCodeSignature implements oauth2.AuthorizeCodeStrategy.
-func (h *HMACCoreStrategy) AuthorizeCodeSignature(ctx context.Context, token string) string {
-	return h.Enigma.Signature(token)
+func (s *HMACCoreStrategy) AuthorizeCodeSignature(ctx context.Context, token string) string {
+	return s.Enigma.Signature(token)
 }
 
 // GenerateAuthorizeCode implements oauth2.AuthorizeCodeStrategy.
-func (h *HMACCoreStrategy) GenerateAuthorizeCode(ctx context.Context, _ oauth2.Requester) (tokenString string, signature string, err error) {
-	if tokenString, signature, err = h.Enigma.Generate(ctx); err != nil {
+func (s *HMACCoreStrategy) GenerateAuthorizeCode(ctx context.Context, _ oauth2.Requester) (tokenString string, signature string, err error) {
+	if tokenString, signature, err = s.Enigma.Generate(ctx); err != nil {
 		return "", "", err
 	}
 
-	return h.prependPrefix(tokenString, tokenPrefixPartAuthorizeCode), signature, nil
+	return s.prependPrefix(tokenString, tokenPrefixPartAuthorizeCode), signature, nil
 }
 
 // ValidateAuthorizeCode implements oauth2.AuthorizeCodeStrategy.
-func (h *HMACCoreStrategy) ValidateAuthorizeCode(ctx context.Context, r oauth2.Requester, tokenString string) (err error) {
+func (s *HMACCoreStrategy) ValidateAuthorizeCode(ctx context.Context, r oauth2.Requester, tokenString string) (err error) {
 	var exp = r.GetSession().GetExpiresAt(oauth2.AuthorizeCode)
 
-	if exp.IsZero() && r.GetRequestedAt().Add(h.Config.GetAuthorizeCodeLifespan(ctx)).Before(time.Now().UTC()) {
-		return errorsx.WithStack(oauth2.ErrTokenExpired.WithHintf("Authorize code expired at '%s'.", r.GetRequestedAt().Add(h.Config.GetAuthorizeCodeLifespan(ctx))))
+	if exp.IsZero() && r.GetRequestedAt().Add(s.Config.GetAuthorizeCodeLifespan(ctx)).Before(time.Now().UTC()) {
+		return errorsx.WithStack(oauth2.ErrTokenExpired.WithHintf("Authorize code expired at '%s'.", r.GetRequestedAt().Add(s.Config.GetAuthorizeCodeLifespan(ctx))))
 	}
 
 	if !exp.IsZero() && exp.Before(time.Now().UTC()) {
 		return errorsx.WithStack(oauth2.ErrTokenExpired.WithHintf("Authorize code expired at '%s'.", exp))
 	}
 
-	return h.Enigma.Validate(ctx, h.trimPrefix(tokenString, tokenPrefixPartAuthorizeCode))
+	return s.Enigma.Validate(ctx, s.trimPrefix(tokenString, tokenPrefixPartAuthorizeCode))
 }
 
-func (h *HMACCoreStrategy) RFC8628UserCodeSignature(ctx context.Context, tokenString string) (signature string, err error) {
-	return h.Enigma.GenerateHMACForString(ctx, tokenString)
+func (s *HMACCoreStrategy) RFC8628UserCodeSignature(ctx context.Context, tokenString string) (signature string, err error) {
+	return s.Enigma.GenerateHMACForString(ctx, tokenString)
 }
 
 // GenerateRFC8628UserCode implements rfc8628.UserCodeStrategy.
-func (h *HMACCoreStrategy) GenerateRFC8628UserCode(ctx context.Context) (tokenString string, signature string, err error) {
+func (s *HMACCoreStrategy) GenerateRFC8628UserCode(ctx context.Context) (tokenString string, signature string, err error) {
 	seq, err := randx.RuneSequence(8, []rune("BCDFGHJKLMNPQRSTVWXZ"))
 	if err != nil {
 		return "", "", err
@@ -144,7 +145,7 @@ func (h *HMACCoreStrategy) GenerateRFC8628UserCode(ctx context.Context) (tokenSt
 
 	userCode := string(seq)
 
-	signUserCode, err := h.RFC8628UserCodeSignature(ctx, userCode)
+	signUserCode, err := s.RFC8628UserCodeSignature(ctx, userCode)
 	if err != nil {
 		return "", "", err
 	}
@@ -153,11 +154,11 @@ func (h *HMACCoreStrategy) GenerateRFC8628UserCode(ctx context.Context) (tokenSt
 }
 
 // ValidateRFC8628UserCode implements rfc8628.UserCodeStrategy.
-func (h *HMACCoreStrategy) ValidateRFC8628UserCode(ctx context.Context, r oauth2.Requester, code string) (err error) {
+func (s *HMACCoreStrategy) ValidateRFC8628UserCode(ctx context.Context, r oauth2.Requester, code string) (err error) {
 	var exp = r.GetSession().GetExpiresAt(oauth2.UserCode)
 
-	if exp.IsZero() && r.GetRequestedAt().Add(h.Config.GetRFC8628CodeLifespan(ctx)).Before(time.Now().UTC()) {
-		return errorsx.WithStack(oauth2.ErrDeviceExpiredToken.WithHintf("User code expired at '%s'.", r.GetRequestedAt().Add(h.Config.GetRFC8628CodeLifespan(ctx))))
+	if exp.IsZero() && r.GetRequestedAt().Add(s.Config.GetRFC8628CodeLifespan(ctx)).Before(time.Now().UTC()) {
+		return errorsx.WithStack(oauth2.ErrDeviceExpiredToken.WithHintf("User code expired at '%s'.", r.GetRequestedAt().Add(s.Config.GetRFC8628CodeLifespan(ctx))))
 	}
 
 	if !exp.IsZero() && exp.Before(time.Now().UTC()) {
@@ -168,57 +169,65 @@ func (h *HMACCoreStrategy) ValidateRFC8628UserCode(ctx context.Context, r oauth2
 }
 
 // RFC8628DeviceCodeSignature implements rfc8628.DeviceCodeStrategy.
-func (h *HMACCoreStrategy) RFC8628DeviceCodeSignature(ctx context.Context, tokenString string) (signature string, err error) {
-	return h.Enigma.Signature(tokenString), nil
+func (s *HMACCoreStrategy) RFC8628DeviceCodeSignature(ctx context.Context, tokenString string) (signature string, err error) {
+	return s.Enigma.Signature(tokenString), nil
 }
 
 // GenerateRFC8628DeviceCode implements rfc8628.DeviceCodeStrategy.
-func (h *HMACCoreStrategy) GenerateRFC8628DeviceCode(ctx context.Context) (tokenString string, signature string, err error) {
-	tokenString, sig, err := h.Enigma.Generate(ctx)
+func (s *HMACCoreStrategy) GenerateRFC8628DeviceCode(ctx context.Context) (tokenString string, signature string, err error) {
+	tokenString, sig, err := s.Enigma.Generate(ctx)
 	if err != nil {
 		return "", "", err
 	}
 
-	return h.getPrefix(tokenPrefixPartDeviceCode) + tokenString, sig, nil
+	return s.getPrefix(tokenPrefixPartDeviceCode) + tokenString, sig, nil
 }
 
 // ValidateRFC8628DeviceCode implements rfc8628.DeviceCodeStrategy.
-func (h *HMACCoreStrategy) ValidateRFC8628DeviceCode(ctx context.Context, r oauth2.Requester, code string) (err error) {
+func (s *HMACCoreStrategy) ValidateRFC8628DeviceCode(ctx context.Context, r oauth2.Requester, code string) (err error) {
 	var exp = r.GetSession().GetExpiresAt(oauth2.DeviceCode)
 
-	if exp.IsZero() && r.GetRequestedAt().Add(h.Config.GetRFC8628CodeLifespan(ctx)).Before(time.Now().UTC()) {
-		return errorsx.WithStack(oauth2.ErrDeviceExpiredToken.WithHintf("Device code expired at '%s'.", r.GetRequestedAt().Add(h.Config.GetRFC8628CodeLifespan(ctx))))
+	if exp.IsZero() && r.GetRequestedAt().Add(s.Config.GetRFC8628CodeLifespan(ctx)).Before(time.Now().UTC()) {
+		return errorsx.WithStack(oauth2.ErrDeviceExpiredToken.WithHintf("Device code expired at '%s'.", r.GetRequestedAt().Add(s.Config.GetRFC8628CodeLifespan(ctx))))
 	}
 
 	if !exp.IsZero() && exp.Before(time.Now().UTC()) {
 		return errorsx.WithStack(oauth2.ErrDeviceExpiredToken.WithHintf("Device code expired at '%s'.", exp))
 	}
 
-	return h.Enigma.Validate(ctx, h.trimPrefix(code, tokenPrefixPartDeviceCode))
+	return s.Enigma.Validate(ctx, s.trimPrefix(code, tokenPrefixPartDeviceCode))
 }
 
-func (h *HMACCoreStrategy) trimPrefix(tokenString, part string) string {
-	if !h.usePrefix {
+func (s *HMACCoreStrategy) hasPrefix(tokenString, part string) (has bool) {
+	if !s.usePrefix {
+		return false
+	}
+
+	return strings.HasPrefix(tokenString, s.getPrefix(part))
+}
+
+func (s *HMACCoreStrategy) trimPrefix(tokenString, part string) string {
+	if !s.usePrefix {
 		return tokenString
 	}
 
-	return strings.TrimPrefix(tokenString, h.getPrefix(part))
+	return strings.TrimPrefix(tokenString, s.getPrefix(part))
 }
 
-func (h *HMACCoreStrategy) prependPrefix(tokenString, part string) string {
-	if !h.usePrefix {
+func (s *HMACCoreStrategy) prependPrefix(tokenString, part string) string {
+	if !s.usePrefix {
 		return tokenString
 	}
 
-	return h.getPrefix(part) + tokenString
+	return s.getPrefix(part) + tokenString
 }
 
-func (h *HMACCoreStrategy) getPrefix(part string) string {
-	if !h.usePrefix {
+func (s *HMACCoreStrategy) getPrefix(part string) string {
+	if !s.usePrefix {
 		return ""
 	}
 
-	return fmt.Sprintf(h.prefix, part)
+	return fmt.Sprintf(s.prefix, part)
 }
 
 const (
@@ -233,6 +242,7 @@ type CoreStrategyConfigurator interface {
 
 	oauth2.AccessTokenIssuerProvider
 	oauth2.JWTScopeFieldProvider
+	oauth2.JWTProfileAccessTokensProvider
 }
 
 type HMACCoreStrategyConfigurator interface {

--- a/token/hmac/hmacsha.go
+++ b/token/hmac/hmacsha.go
@@ -150,7 +150,7 @@ func (c *HMACStrategy) validate(ctx context.Context, secret []byte, token string
 	var signingKey [32]byte
 	copy(signingKey[:], secret)
 
-	split := strings.Split(token, ".")
+	split := strings.SplitN(token, ".", 3)
 	if len(split) != 2 {
 		return errorsx.WithStack(oauth2.ErrInvalidTokenFormat)
 	}
@@ -181,7 +181,7 @@ func (c *HMACStrategy) validate(ctx context.Context, secret []byte, token string
 }
 
 func (c *HMACStrategy) Signature(token string) string {
-	split := strings.Split(token, ".")
+	split := strings.SplitN(token, ".", 3)
 
 	if len(split) != 2 {
 		return ""

--- a/token/jwt/header.go
+++ b/token/jwt/header.go
@@ -36,12 +36,37 @@ func (h *Headers) Add(key string, value any) {
 	if h.Extra == nil {
 		h.Extra = make(map[string]any)
 	}
+
 	h.Extra[key] = value
 }
 
 // Get will get a value from the extra field based on a given key
 func (h *Headers) Get(key string) any {
 	return h.Extra[key]
+}
+
+func (h *Headers) SetDefaultString(key, value string) {
+	if h.Extra == nil {
+		h.Extra = make(map[string]any)
+	}
+
+	var (
+		v  any
+		s  string
+		ok bool
+	)
+
+	if v, ok = h.Extra[key]; !ok {
+		h.Extra[key] = value
+
+		return
+	}
+
+	if s, ok = v.(string); ok && len(s) != 0 {
+		return
+	}
+
+	h.Extra[key] = value
 }
 
 // ToMapClaims will return a jwt-go MapClaims representation

--- a/token/jwt/jwt.go
+++ b/token/jwt/jwt.go
@@ -21,12 +21,12 @@ import (
 )
 
 type Signer interface {
-	Generate(ctx context.Context, claims MapClaims, header Mapper) (string, string, error)
-	Validate(ctx context.Context, token string) (string, error)
+	Generate(ctx context.Context, claims MapClaims, header Mapper) (tokenString string, signature string, err error)
+	Validate(ctx context.Context, tokenString string) (signature string, err error)
 	Hash(ctx context.Context, in []byte) ([]byte, error)
-	Decode(ctx context.Context, token string) (*Token, error)
-	GetSignature(ctx context.Context, token string) (string, error)
-	GetSigningMethodLength(ctx context.Context) int
+	Decode(ctx context.Context, tokenString string) (token *Token, err error)
+	GetSignature(ctx context.Context, token string) (signature string, err error)
+	GetSigningMethodLength(ctx context.Context) (length int)
 }
 
 var SHA256HashSize = crypto.SHA256.Size()


### PR DESCRIPTION
This permits and prefers configuring clients for the JWT Profile for Access Tokens individually. An option to enforce the JWT Profile on all Access Tokens issued is also available though not recommended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced customizable token prefix and automatic selection between JWT Profile or HMAC-based options for `CoreStrategy`.
	- Added support for JWT Profile per client, including new interfaces for JWT Profile client information and JWT Profile Access Tokens enforcement.
- **Enhancements**
	- Improved clarity and consistency in code by refactoring method signatures to return named values.
	- Enhanced token introspection logic with new configurations and signers.
- **Bug Fixes**
	- Adjusted token validation logic to limit the number of splits, ensuring more accurate token format validation.
- **Documentation**
	- Updated README.md to highlight new features and configurations related to CoreStrategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->