### PR TITLE
feat(pkce): per client policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ following list of differences:
           <sup>[commit](https://github.com/authelia/oauth2-provider/commit/6584d3495422a97ef9aba92e762ffaebce010dd0)</sup>
     - [x] Original request id not set early enough
           <sup>[commit](https://github.com/authelia/oauth2-provider/commit/6584d3495422a97ef9aba92e762ffaebce010dd0)</sup>
-  - PKCE Flow
+  - PKCE Flow:
     - [x] Session generated needlessly
           <sup>[commit](https://github.com/authelia/oauth2-provider/commit/dbdadf5dee92d13683eeacaa198c28d6704ddb1c)</sup>
     - [x] Failure to fetch session causes an error even when not enforced
@@ -57,6 +57,8 @@ following list of differences:
   - [x] Access Token iat and nbf in JWT Profile always original claims
         <sup>[commit](https://github.com/authelia/oauth2-provider/commit/a87d91df762a8fe26282145ba9dace0461f31b4d)</sup>
 - Features:
+  - PKCE Flow:
+    - [x] Per-Client Enforcement Policy
   - CoreStrategy:
     - [x] Customizable Token Prefix
           <sup>[commit](https://github.com/authelia/oauth2-provider/commit/4f55dabdf5d87c34053992c3de3fe7b1bf1046f3)</sup>

--- a/authorize_response.go
+++ b/authorize_response.go
@@ -44,5 +44,6 @@ func (a *AuthorizeResponse) AddParameter(key, value string) {
 	if key == consts.FormParameterAuthorizationCode {
 		a.code = value
 	}
+
 	a.Parameters.Add(key, value)
 }

--- a/client.go
+++ b/client.go
@@ -46,6 +46,15 @@ type RotatedClientSecretsClient interface {
 	Client
 }
 
+// ProofKeyCodeExchangeClient is a Client implementation which provides PKCE client policy values.
+type ProofKeyCodeExchangeClient interface {
+	GetEnforcePKCE() (enforce bool)
+	GetEnforcePKCEChallengeMethod() (enforce bool)
+	GetPKCEChallengeMethod() (method string)
+
+	Client
+}
+
 // ClientAuthenticationPolicyClient is a Client implementation which also provides client authentication policy values.
 type ClientAuthenticationPolicyClient interface {
 	// GetAllowMultipleAuthenticationMethods should return true if the client policy allows multiple authentication

--- a/compose/compose_pkce.go
+++ b/compose/compose_pkce.go
@@ -13,7 +13,7 @@ import (
 func OAuth2PKCEFactory(config oauth2.Configurator, storage any, strategy any) any {
 	return &pkce.Handler{
 		AuthorizeCodeStrategy: strategy.(hoauth2.AuthorizeCodeStrategy),
-		Storage:               storage.(pkce.PKCERequestStorage),
+		Storage:               storage.(pkce.Storage),
 		Config:                config,
 	}
 }

--- a/handler/pkce/const.go
+++ b/handler/pkce/const.go
@@ -1,0 +1,7 @@
+package pkce
+
+import "regexp"
+
+var (
+	verifierWrongFormat = regexp.MustCompile(`[^\w.~-]`)
+)

--- a/handler/pkce/storage.go
+++ b/handler/pkce/storage.go
@@ -9,7 +9,7 @@ import (
 	"authelia.com/provider/oauth2"
 )
 
-type PKCERequestStorage interface {
+type Storage interface {
 	GetPKCERequestSession(ctx context.Context, signature string, session oauth2.Session) (oauth2.Requester, error)
 	CreatePKCERequestSession(ctx context.Context, signature string, requester oauth2.Requester) error
 	DeletePKCERequestSession(ctx context.Context, signature string) error


### PR DESCRIPTION
This adds a PKCE policy control on a per-client basis and overhauls the testing of this particular handler and the particular error messages it returns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced PKCE Flow with per-client enforcement policy.
	- Introduced a customizable token prefix in CoreStrategy.
- **Bug Fixes**
	- Fixed issues related to session generation and fetching in PKCE Flow.
- **Refactor**
	- Updated type assertion in `OAuth2PKCEFactory` function for improved storage handling.
	- Replaced usage of `regexp` with `fmt` in PKCE handler for more efficient error handling.
	- Renamed `PKCERequestStorage` interface to `Storage` for clarity.
- **Documentation**
	- Added regular expression validation for verifier formats in PKCE.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->