### PR TITLE
feat: implicit client credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ following list of differences:
   - [x] Access Token iat and nbf in JWT Profile always original claims
         <sup>[commit](https://github.com/authelia/oauth2-provider/commit/a87d91df762a8fe26282145ba9dace0461f31b4d)</sup>
 - Features:
-  - [ ] Requested Audience Policy (many clients do not support the parameter)
+  - [x] Requested Audience Policy (many clients do not support the parameter)
   - PAR Flow:
     - [ ] Per-Client Enforcement Policy
   - PKCE Flow:

--- a/audience_strategy.go
+++ b/audience_strategy.go
@@ -99,7 +99,11 @@ func GetAudiences(form url.Values) []string {
 func (f *Fosite) validateAuthorizeAudience(ctx context.Context, r *http.Request, request *AuthorizeRequest) error {
 	audience := GetAudiences(request.Form)
 
-	if err := f.Config.GetAudienceStrategy(ctx)(request.Client.GetAudience(), audience); err != nil {
+	if len(audience) == 0 {
+		if client, ok := request.Client.(RequestedAudienceImplicitClient); ok && client.GetRequestedAudienceImplicit() {
+			audience = client.GetAudience()
+		}
+	} else if err := f.Config.GetAudienceStrategy(ctx)(request.Client.GetAudience(), audience); err != nil {
 		return err
 	}
 

--- a/client.go
+++ b/client.go
@@ -131,13 +131,6 @@ type ResponseModeClient interface {
 	Client
 }
 
-// ClientCredentialsFlowPolicyClient is a client which can allow implicit scopes in the client credentials flow.
-type ClientCredentialsFlowPolicyClient interface {
-	GetClientCredentialsFlowAllowImplicitScope() (allow bool)
-
-	Client
-}
-
 type JWTProfileClient interface {
 	// GetAccessTokenSignedResponseAlg returns the algorithm used for signing Access Tokens.
 	GetAccessTokenSignedResponseAlg() (alg string)
@@ -147,6 +140,25 @@ type JWTProfileClient interface {
 
 	// GetEnableJWTProfileOAuthAccessTokens indicates this client should or should not issue JWT Profile Access Tokens.
 	GetEnableJWTProfileOAuthAccessTokens() (enforce bool)
+
+	Client
+}
+
+// ClientCredentialsFlowRequestedScopeImplicitClient is a client which can allow implicit scopes in the client credentials flow.
+type ClientCredentialsFlowRequestedScopeImplicitClient interface {
+	// GetClientCredentialsFlowRequestedScopeImplicit is indicative of if a client will implicitly request all scopes it
+	// is allowed to request in the absence of requested scopes during the Client Credentials Flow.
+	GetClientCredentialsFlowRequestedScopeImplicit() (implicit bool)
+
+	Client
+}
+
+// RequestedAudienceImplicitClient is a client which can potentially implicitly grant permitted audiences given the
+// absence of a request parameter.
+type RequestedAudienceImplicitClient interface {
+	// GetRequestedAudienceImplicit is indicative of if a client will implicitly request all audiences it is allowed to
+	// request in the absence of requested audience during an Authorization Endpoint Flow or Client Credentials Flow.
+	GetRequestedAudienceImplicit() (implicit bool)
 
 	Client
 }

--- a/config.go
+++ b/config.go
@@ -58,6 +58,13 @@ type AudienceStrategyProvider interface {
 	GetAudienceStrategy(ctx context.Context) AudienceMatchingStrategy
 }
 
+// ClientCredentialsImplicitProvider describes the provider of the Client Credentials Flow Implicit actions.
+type ClientCredentialsImplicitProvider interface {
+	// GetClientCredentialsFlowImplicitGrantRequested returns true if the PopulateTokenEndpointResponse portion of the
+	// oauth2.ClientCredentialsGrantHandler should implicitly grant all requested and validated scopes and audiences.
+	GetClientCredentialsFlowImplicitGrantRequested(ctx context.Context) (implicit bool)
+}
+
 // RedirectSecureCheckerProvider returns the provider for configuring the redirect URL security validator.
 type RedirectSecureCheckerProvider interface {
 	// GetRedirectSecureChecker returns the redirect URL security validator.

--- a/config_default.go
+++ b/config_default.go
@@ -75,6 +75,8 @@ type Config struct {
 	// AudienceMatchingStrategy sets the audience matching strategy that should be supported, defaults to oauth2.DefaultsAudienceMatchingStrategy.
 	AudienceMatchingStrategy AudienceMatchingStrategy
 
+	ClientCredentialsFlowImplicitGrantRequested bool
+
 	// EnforcePKCE, if set to true, requires clients to perform authorize code flows with PKCE. Defaults to false.
 	EnforcePKCE bool
 
@@ -382,6 +384,10 @@ func (c *Config) GetAudienceStrategy(_ context.Context) AudienceMatchingStrategy
 	}
 
 	return c.AudienceMatchingStrategy
+}
+
+func (c *Config) GetClientCredentialsFlowImplicitGrantRequested(_ context.Context) bool {
+	return c.ClientCredentialsFlowImplicitGrantRequested
 }
 
 // GetAuthorizeCodeLifespan returns how long an authorize code should be valid. Defaults to one fifteen minutes.

--- a/fosite.go
+++ b/fosite.go
@@ -120,8 +120,9 @@ type Configurator interface {
 	GrantTypeJWTBearerIDOptionalProvider
 	GrantTypeJWTBearerIssuedDateOptionalProvider
 	GetJWTMaxDurationProvider
-	AudienceStrategyProvider
 	ScopeStrategyProvider
+	AudienceStrategyProvider
+	ClientCredentialsImplicitProvider
 	RedirectSecureCheckerProvider
 	OmitRedirectScopeParamProvider
 	SanitationAllowedProvider

--- a/handler/oauth2/flow_client_credentials_test.go
+++ b/handler/oauth2/flow_client_credentials_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
@@ -57,7 +58,7 @@ func TestClientCredentials_HandleTokenEndpointRequest(t *testing.T) {
 			mock: func() {
 				areq.EXPECT().GetGrantTypes().Return(oauth2.Arguments{consts.GrantTypeClientCredentials})
 				areq.EXPECT().GetRequestedScopes().Return([]string{})
-				areq.EXPECT().GetRequestedAudience().Return([]string{"https://www.authelia.com/not-api"})
+				areq.EXPECT().GetRequestedAudience().Return([]string{"https://www.authelia.com/not-api"}).Times(2)
 				areq.EXPECT().GetClient().Return(&oauth2.DefaultClient{
 					GrantTypes: oauth2.Arguments{consts.GrantTypeClientCredentials},
 					Audience:   []string{"https://www.authelia.com/api"},
@@ -82,7 +83,7 @@ func TestClientCredentials_HandleTokenEndpointRequest(t *testing.T) {
 				areq.EXPECT().GetSession().Return(new(oauth2.DefaultSession))
 				areq.EXPECT().GetGrantTypes().Return(oauth2.Arguments{consts.GrantTypeClientCredentials})
 				areq.EXPECT().GetRequestedScopes().Return([]string{"foo", "bar", "baz.bar"})
-				areq.EXPECT().GetRequestedAudience().Return([]string{})
+				areq.EXPECT().GetRequestedAudience().Return([]string{}).Times(2)
 				areq.EXPECT().GetClient().Return(&oauth2.DefaultClient{
 					GrantTypes: oauth2.Arguments{consts.GrantTypeClientCredentials},
 					Scopes:     []string{"foo", "bar", "baz"},
@@ -164,4 +165,140 @@ func TestClientCredentials_PopulateTokenEndpointResponse(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClientCredentialsGrantHandler_HandleTokenEndpointRequest(t *testing.T) {
+	testCases := []struct {
+		name     string
+		have     oauth2.AccessRequester
+		expected oauth2.AccessRequester
+		err      string
+	}{
+		{
+			"ShouldSuccessfullyNotGrantAnyAudience",
+			&oauth2.AccessRequest{
+				GrantTypes: oauth2.Arguments{consts.GrantTypeClientCredentials},
+				Request: oauth2.Request{
+					Session: &oauth2.DefaultSession{},
+					Client: &TestRequestedAudienceClient{
+						DefaultClient: &oauth2.DefaultClient{
+							ID:         "test",
+							GrantTypes: []string{consts.GrantTypeClientCredentials},
+							Audience:   []string{"https://exmaple.com"},
+						},
+					},
+				},
+			},
+			&oauth2.AccessRequest{
+				GrantTypes: oauth2.Arguments{consts.GrantTypeClientCredentials},
+				Request:    oauth2.Request{},
+			},
+			"",
+		},
+		{
+			"ShouldSuccessfullyRequestNoAudienceUnsupportedClient",
+			&oauth2.AccessRequest{
+				GrantTypes: oauth2.Arguments{consts.GrantTypeClientCredentials},
+				Request: oauth2.Request{
+					Session: &oauth2.DefaultSession{},
+					Client: &oauth2.DefaultClient{
+						ID:         "test",
+						GrantTypes: []string{consts.GrantTypeClientCredentials},
+						Audience:   []string{"https://exmaple.com"},
+					},
+				},
+			},
+			&oauth2.AccessRequest{
+				GrantTypes: oauth2.Arguments{consts.GrantTypeClientCredentials},
+				Request:    oauth2.Request{},
+			},
+			"",
+		},
+		{
+			"ShouldSuccessfullyGrantAllAudience",
+			&oauth2.AccessRequest{
+				GrantTypes: oauth2.Arguments{consts.GrantTypeClientCredentials},
+				Request: oauth2.Request{
+					Session: &oauth2.DefaultSession{},
+					Client: &TestRequestedAudienceClient{
+						DefaultClient: &oauth2.DefaultClient{
+							ID:         "test",
+							GrantTypes: []string{consts.GrantTypeClientCredentials},
+							Audience:   []string{"https://exmaple.com"},
+						},
+						implicit: true,
+					},
+				},
+			},
+			&oauth2.AccessRequest{
+				GrantTypes: oauth2.Arguments{consts.GrantTypeClientCredentials},
+				Request: oauth2.Request{
+					RequestedAudience: []string{"https://exmaple.com"},
+					GrantedAudience:   []string{"https://exmaple.com"},
+				},
+			},
+			"",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			defer ctrl.Finish()
+
+			store := mock.NewMockClientCredentialsGrantStorage(ctrl)
+			strategy := mock.NewMockAccessTokenStrategy(ctrl)
+
+			strategy.EXPECT().GenerateAccessToken(context.Background(), gomock.Any()).Return("abc123.abc", "abc", nil)
+			store.EXPECT().CreateAccessTokenSession(context.Background(), gomock.Any(), gomock.Any()).Return(nil)
+
+			config := &oauth2.Config{
+				AccessTokenLifespan:                         time.Hour,
+				ClientCredentialsFlowImplicitGrantRequested: true,
+				ScopeStrategy:                               oauth2.HierarchicScopeStrategy,
+			}
+
+			handler := ClientCredentialsGrantHandler{
+				HandleHelper: &HandleHelper{
+					AccessTokenStorage:  store,
+					AccessTokenStrategy: strategy,
+					Config:              config,
+				},
+				Config: config,
+			}
+
+			err := handler.HandleTokenEndpointRequest(context.TODO(), tc.have)
+
+			assert.Equal(t, tc.expected.GetRequestedScopes(), tc.have.GetRequestedScopes())
+			assert.Equal(t, tc.expected.GetRequestedAudience(), tc.have.GetRequestedAudience())
+			assert.Equal(t, oauth2.Arguments(nil), tc.have.GetGrantedScopes())
+			assert.Equal(t, oauth2.Arguments(nil), tc.have.GetGrantedAudience())
+
+			if len(tc.err) == 0 {
+				assert.NoError(t, oauth2.ErrorToDebugRFC6749Error(err))
+			} else {
+				assert.EqualError(t, oauth2.ErrorToDebugRFC6749Error(err), tc.err)
+			}
+
+			response := oauth2.NewAccessResponse()
+
+			err = handler.PopulateTokenEndpointResponse(context.Background(), tc.have, response)
+
+			assert.NoError(t, err)
+
+			assert.Equal(t, tc.expected.GetGrantedScopes(), tc.have.GetGrantedScopes())
+			assert.Equal(t, tc.expected.GetGrantedAudience(), tc.have.GetGrantedAudience())
+		})
+	}
+}
+
+type TestRequestedAudienceClient struct {
+	*oauth2.DefaultClient
+
+	implicit bool
+}
+
+func (c *TestRequestedAudienceClient) GetRequestedAudienceImplicit() bool {
+	return c.implicit
 }


### PR DESCRIPTION
This adds a per-client opt in implicit element to requesting and granting scopes and audiences for specifically the Client Credentials Flow.