### PR TITLE
fix: implicit scopes not granted

### DIFF
--- a/audience_strategy.go
+++ b/audience_strategy.go
@@ -99,7 +99,7 @@ func GetAudiences(form url.Values) []string {
 func (f *Fosite) validateAuthorizeAudience(ctx context.Context, r *http.Request, request *AuthorizeRequest) error {
 	audience := GetAudiences(request.Form)
 
-	if len(audience) == 0 {
+	if len(audience) == 0 && !request.GetRequestForm().Has(consts.FormParameterAudience) {
 		if client, ok := request.Client.(RequestedAudienceImplicitClient); ok && client.GetRequestedAudienceImplicit() {
 			audience = client.GetAudience()
 		}


### PR DESCRIPTION
This fixes an issue where the intended implicit scopes were not granted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Refined the handling of scopes in token endpoint requests, ensuring proper behavior when no scopes are provided.
- **Tests**
	- Enhanced test coverage for the client credentials grant flow, including tests for scope and audience validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->