### PR TITLE
refactor: adjust client signature

### DIFF
--- a/client.go
+++ b/client.go
@@ -62,7 +62,7 @@ type ClientAuthenticationPolicyClient interface {
 	// methods due to the client implementation breaching RFC6749 Section 2.3.
 	//
 	// See: https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.
-	GetAllowMultipleAuthenticationMethods(ctx context.Context) (allow bool)
+	GetAllowMultipleAuthenticationMethods() (allow bool)
 
 	Client
 }

--- a/client_authentication.go
+++ b/client_authentication.go
@@ -121,7 +121,7 @@ func (s *DefaultClientAuthenticationStrategy) handleResolvedClientAuthentication
 		// within a request per https://datatracker.ietf.org/doc/html/rfc6749#section-2.3 clients MUST NOT use more than
 		// one, however some bad clients use a shotgun approach to authentication. This allows developing a personal
 		// policy around these bad clients on a per-client basis.
-		if capc, ok := c.(ClientAuthenticationPolicyClient); ok && capc.GetAllowMultipleAuthenticationMethods(ctx) {
+		if capc, ok := c.(ClientAuthenticationPolicyClient); ok && capc.GetAllowMultipleAuthenticationMethods() {
 			break
 		}
 

--- a/client_authentication_test.go
+++ b/client_authentication_test.go
@@ -819,7 +819,7 @@ type TestClientAuthenticationPolicyClient struct {
 	AllowMultipleAuthenticationMethods bool
 }
 
-func (c *TestClientAuthenticationPolicyClient) GetAllowMultipleAuthenticationMethods(ctx context.Context) bool {
+func (c *TestClientAuthenticationPolicyClient) GetAllowMultipleAuthenticationMethods() bool {
 	return c.AllowMultipleAuthenticationMethods
 }
 


### PR DESCRIPTION
This adjusts the interface signature for the ClientAuthenticationPolicyClient which has been noted as having a differing signature to other such client methods (inclusion of context).