### PR TITLE
fix: redirect_uri error has no debug information

### DIFF
--- a/authorize_helper.go
+++ b/authorize_helper.go
@@ -77,7 +77,7 @@ func MatchRedirectURIWithClientRedirectURIs(rawurl string, client Client) (*url.
 		}
 	}
 
-	return nil, errorsx.WithStack(ErrInvalidRequest.WithHint("The 'redirect_uri' parameter does not match any of the OAuth 2.0 Client's pre-registered redirect urls."))
+	return nil, errorsx.WithStack(ErrInvalidRequest.WithHint("The 'redirect_uri' parameter does not match any of the OAuth 2.0 Client's pre-registered 'redirect_uris'.").WithDebugf("The 'redirect_uris' registered with OAuth 2.0 Client with id '%s' match 'redirect_uri' value '%s'.", client.GetID(), rawurl))
 }
 
 // Match a requested  redirect URI against a pool of registered client URIs


### PR DESCRIPTION
This fixes an issue where the debug information for a bad redirect_uri is not populated with helpful information to an administrator or developer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error messages in authorization to include detailed information about mismatches in redirect URIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->