### PR TITLE
feat: response mode param handlers

### DIFF
--- a/config.go
+++ b/config.go
@@ -268,6 +268,13 @@ type ResponseModeHandlerProvider interface {
 	GetResponseModeHandlers(ctx context.Context) (handlers []ResponseModeHandler)
 }
 
+// ResponseModeParameterHandlerProvider returns the providers for configuring additional parameters in the response
+// mode phase of an Authorization Request which may not be possible to determine until the final response mode is known.
+type ResponseModeParameterHandlerProvider interface {
+	// GetResponseModeParameterHandlers returns the ResponseModeParameterHandler's to process.
+	GetResponseModeParameterHandlers(ctx context.Context) (handlers []ResponseModeParameterHandler)
+}
+
 // MessageCatalogProvider returns the provider for configuring the message catalog.
 type MessageCatalogProvider interface {
 	// GetMessageCatalog returns the message catalog.

--- a/config_default.go
+++ b/config_default.go
@@ -139,6 +139,9 @@ type Config struct {
 	// ResponseModeHandlers provides the handlers for performing response mode formatting.
 	ResponseModeHandlers []ResponseModeHandler
 
+	// ResponseModeParameterHandlers provides handlers for injecting additional parameters into the authorize responses.
+	ResponseModeParameterHandlers []ResponseModeParameterHandler
+
 	// MessageCatalog is the message bundle used for i18n
 	MessageCatalog i18n.MessageCatalog
 
@@ -293,6 +296,10 @@ func (c *Config) GetResponseModeHandlers(ctx context.Context) []ResponseModeHand
 	}
 
 	return c.ResponseModeHandlers
+}
+
+func (c *Config) GetResponseModeParameterHandlers(ctx context.Context) []ResponseModeParameterHandler {
+	return c.ResponseModeParameterHandlers
 }
 
 func (c *Config) GetSendDebugMessagesToClients(ctx context.Context) bool {


### PR DESCRIPTION
This adds response mode parameter handlers to the list of handler types. These are special Authorize Request handlers which can only be executed when the final response mode is known.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced authorization error responses with additional debug information for improved diagnostics.
	- Introduced flexible handling of response modes in authorization requests, allowing for more granular control over the response format.

- **Refactor**
	- Updated configuration handling to support new response mode parameter handlers, enabling customization of authorization responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->