### PR TITLE
fix: handle request objects more precisely

### DIFF
--- a/authorize_request_handler.go
+++ b/authorize_request_handler.go
@@ -91,7 +91,7 @@ func (f *Fosite) authorizeRequestParametersFromOpenIDConnectRequestObject(ctx co
 	if nrequestURI > 0 {
 		// Reject the request if the "request_uri" authorization request parameter is provided.
 		if isPARRequest {
-			return errorsx.WithStack(ErrInvalidRequestObject.WithHint("Pushed Authorization Requests can not contain the 'request_uri' parameter."))
+			return errorsx.WithStack(ErrInvalidRequest.WithHint("Pushed Authorization Requests can not contain the 'request_uri' parameter."))
 		}
 
 		requestURI := request.Form.Get(consts.FormParameterRequestURI)
@@ -165,6 +165,7 @@ func (f *Fosite) authorizeRequestParametersFromOpenIDConnectRequestObject(ctx co
 			return nil, errorsx.WithStack(ErrInvalidRequestObject.WithHintf("This request object uses unsupported signing algorithm '%s'.", t.Header["alg"]))
 		}
 	})
+
 	if err != nil {
 		// Do not re-process already enhanced errors
 		var e *jwt.ValidationError
@@ -175,7 +176,7 @@ func (f *Fosite) authorizeRequestParametersFromOpenIDConnectRequestObject(ctx co
 			return errorsx.WithStack(ErrInvalidRequestObject.WithHint("Unable to verify the request object's signature.").WithWrap(err).WithDebugError(err))
 		}
 		return err
-	} else if err := token.Claims.Valid(); err != nil {
+	} else if err = token.Claims.Valid(); err != nil {
 		return errorsx.WithStack(ErrInvalidRequestObject.WithHint("Unable to verify the request object because its claims could not be validated, check if the expiry time is set correctly.").WithWrap(err).WithDebugError(err))
 	}
 
@@ -230,7 +231,7 @@ func (f *Fosite) authorizeRequestParametersFromOpenIDConnectRequestObject(ctx co
 			return errorsx.WithStack(ErrInvalidRequestObject.WithHint("OpenID Connect 1.0 request object's `iss' claim must contain the `client_id` when using signed or encrypted request objects."))
 		}
 
-		if value != client.GetID() {
+		if value != request.Client.GetID() {
 			return errorsx.WithStack(ErrInvalidRequestObject.WithHint("OpenID Connect 1.0 request object's `iss' claim must contain the `client_id` when using signed or encrypted request objects."))
 		}
 

--- a/authorize_request_handler_oidc_request_test.go
+++ b/authorize_request_handler_oidc_request_test.go
@@ -116,7 +116,7 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 			client:    &DefaultClient{ID: "foo"},
 			expected:  url.Values{consts.FormParameterScope: {consts.ScopeOpenID}},
 			err:       ErrRequestNotSupported,
-			errString: "The OP does not support use of the request parameter. OpenID Connect 1.0 'request' context was given, but the OAuth 2.0 Client does not implement advanced OpenID Connect 1.0 capabilities. The OAuth 2.0 client with id 'foo' doesn't implement the correct methods for this request.",
+			errString: "The OP does not support use of the request parameter. OpenID Connect 1.0 parameter 'request' was used, but the OAuth 2.0 Client does not implement advanced OpenID Connect 1.0 capabilities. The OAuth 2.0 client with id 'foo' doesn't implement the correct functionality for this request.",
 		},
 		{
 			name:      "ShouldFailRequestURINotOpenIDConnectClient",
@@ -124,7 +124,7 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 			client:    &DefaultClient{ID: "foo"},
 			expected:  url.Values{consts.FormParameterScope: {consts.ScopeOpenID}},
 			err:       ErrRequestURINotSupported,
-			errString: "The OP does not support use of the request_uri parameter. OpenID Connect 1.0 'request_uri' context was given, but the OAuth 2.0 Client does not implement advanced OpenID Connect 1.0 capabilities. The OAuth 2.0 client with id 'foo' doesn't implement the correct methods for this request.",
+			errString: "The OP does not support use of the request_uri parameter. OpenID Connect 1.0 parameter 'request_uri' was used, but the OAuth 2.0 Client does not implement advanced OpenID Connect 1.0 capabilities. The OAuth 2.0 client with id 'foo' doesn't implement the correct functionality for this request.",
 		},
 		{
 			name:      "ShouldFailRequestAndRequestURI",
@@ -133,7 +133,7 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 			par:       true,
 			expected:  url.Values{consts.FormParameterRequest: {"foo"}},
 			err:       ErrInvalidRequest,
-			errString: "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. OpenID Connect 1.0 parameters 'request' and 'request_uri' were both given, but you can use at most one.",
+			errString: "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. OpenID Connect 1.0 parameters 'request' and 'request_uri' were both used, but only one may be used in any given request.",
 		},
 		{
 			name:      "ShouldFailRequestMissingResponseType",
@@ -142,7 +142,7 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 			par:       true,
 			expected:  url.Values{consts.FormParameterRequest: {"foo"}},
 			err:       ErrInvalidRequest,
-			errString: "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. OpenID Connect 1.0 parameters 'request' and 'request_uri' must be accompanied by the `client_id' and 'response_type' in the request syntax.",
+			errString: "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. OpenID Connect 1.0 parameter 'request' must be accompanied by the `client_id' and 'response_type' in the request syntax. The OAuth 2.0 client with id 'foo' provided the 'request' with value but either did not include the 'client_id' or 'response_type' parameter.",
 		},
 		{
 			name:      "ShouldFailRequestMissingClientID",
@@ -151,7 +151,7 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 			par:       true,
 			expected:  url.Values{consts.FormParameterRequest: {"foo"}},
 			err:       ErrInvalidRequest,
-			errString: "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. OpenID Connect 1.0 parameters 'request' and 'request_uri' must be accompanied by the `client_id' and 'response_type' in the request syntax.",
+			errString: "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. OpenID Connect 1.0 parameter 'request' must be accompanied by the `client_id' and 'response_type' in the request syntax. The OAuth 2.0 client with id 'foo' provided the 'request' with value but either did not include the 'client_id' or 'response_type' parameter.",
 		},
 		{
 			name:      "ShouldFailRequestURIWithPAR",
@@ -160,7 +160,7 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 			par:       true,
 			expected:  url.Values{consts.FormParameterRequest: {"foo"}},
 			err:       ErrInvalidRequest,
-			errString: "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Pushed Authorization Requests can not contain the 'request_uri' parameter.",
+			errString: "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. OpenID Connect 1.0 parameter 'request_uri' was used, but must not be used with a Pushed Authorization Request. The OAuth 2.0 client with id 'foo' attempted to perform an invalid Authorization Request.",
 		},
 		{
 			name:      "ShouldFailRequestClientNoJWKS",
@@ -168,7 +168,7 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 			client:    &DefaultOpenIDConnectClient{RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
 			expected:  url.Values{consts.FormParameterScope: {consts.ScopeOpenID}},
 			err:       ErrInvalidRequest,
-			errString: "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. OpenID Connect 1.0 'request' context was given, but the OAuth 2.0 Client does not have any JSON Web Keys registered. The OAuth 2.0 client with id 'foo' doesn't have any known JSON Web Keys but requires them when not explicitly registered with a 'request_object_signing_alg' with the value of 'none' but it's registered with 'RS256'.",
+			errString: "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. OpenID Connect 1.0 parameter 'request' was used, but the OAuth 2.0 Client does not have any JSON Web Keys registered. The OAuth 2.0 client with id 'foo' doesn't have any known JSON Web Keys but requires them when not explicitly registered with a 'request_object_signing_alg' with the value of 'none' or an empty value but it's registered with 'RS256'.",
 		},
 		{
 			name:      "ShouldFailRequestURIClientNoJWKS",
@@ -176,7 +176,7 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 			client:    &DefaultOpenIDConnectClient{RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
 			expected:  url.Values{consts.FormParameterScope: {consts.ScopeOpenID}},
 			err:       ErrInvalidRequest,
-			errString: "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. OpenID Connect 1.0 'request_uri' context was given, but the OAuth 2.0 Client does not have any JSON Web Keys registered. The OAuth 2.0 client with id 'foo' doesn't have any known JSON Web Keys but requires them when not explicitly registered with a 'request_object_signing_alg' with the value of 'none' but it's registered with 'RS256'.",
+			errString: "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. OpenID Connect 1.0 parameter 'request_uri' was used, but the OAuth 2.0 Client does not have any JSON Web Keys registered. The OAuth 2.0 client with id 'foo' doesn't have any known JSON Web Keys but requires them when not explicitly registered with a 'request_object_signing_alg' with the value of 'none' or an empty value but it's registered with 'RS256'.",
 		},
 		{
 			name:      "ShouldFailInvalidTokenMalformed",
@@ -200,7 +200,7 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 			client:    &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "test"}},
 			expected:  url.Values{consts.FormParameterScope: {consts.ScopeOpenID}},
 			err:       ErrInvalidRequestObject,
-			errString: "The request parameter contains an invalid Request Object. The request object uses signing algorithm 'HS256', but the requested OAuth 2.0 Client enforces signing algorithm 'RS256'.",
+			errString: "The request parameter contains an invalid Request Object. The request object uses signing algorithm 'HS256', but the requested OAuth 2.0 Client enforces signing algorithm 'RS256'. The OAuth 2.0 client with id 'test' made the Authorization Request.",
 		},
 		{
 			name:      "ShouldFailMismatchedClientID",
@@ -208,7 +208,7 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 			client:    &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
 			expected:  url.Values{consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterResponseMode: {consts.ResponseModeFormPost}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {assertionRequestObjectValid}, "foo": {"bar"}, "baz": {"baz"}},
 			err:       ErrInvalidRequestObject,
-			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object's `client_id' claim must match the values provided in the standard OAuth 2.0 request syntax if provided.",
+			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object's `client_id' claim if provided must match the values provided in the standard OAuth 2.0 request syntax. The OAuth 2.0 client with id 'foo' included a 'client_id' claim with a value of 'foo' in the request object which is required to match the value in the OAuth 2.0 request syntax but the value 'not-foo' was included instead.",
 		},
 		{
 			name:      "ShouldFailRequestClientIDAssert",
@@ -216,7 +216,7 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 			client:    &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
 			expected:  url.Values{consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterResponseMode: {consts.ResponseModeFormPost}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {assertionRequestObjectInvalidClientIDValue}, "foo": {"bar"}, "baz": {"baz"}},
 			err:       ErrInvalidRequestObject,
-			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object's `client_id' claim must match the values provided in the standard OAuth 2.0 request syntax if provided.",
+			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object's `client_id' claim if provided must match the values provided in the standard OAuth 2.0 request syntax. The OAuth 2.0 client with id 'foo' included a 'client_id' claim with a value of '100' which is meant to be a string, not a int64.",
 		},
 		{
 			name:      "ShouldFailRequestWithRequest",
@@ -224,7 +224,7 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 			client:    &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
 			expected:  url.Values{consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterResponseMode: {consts.ResponseModeFormPost}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {assertionRequestObjectInvalidRequestInRequest}, "foo": {"bar"}, "baz": {"baz"}},
 			err:       ErrInvalidRequestObject,
-			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object must not contain the 'request' or 'request_uri' claims.",
+			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object must not contain the 'request' or 'request_uri' claims. The OAuth 2.0 client with id 'foo' made the Authorization Request.",
 		},
 		{
 			name:      "ShouldFailRequestWithRequestURI",
@@ -232,7 +232,7 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 			client:    &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
 			expected:  url.Values{consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterResponseMode: {consts.ResponseModeFormPost}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {assertionRequestObjectInvalidRequestURIInRequest}, "foo": {"bar"}, "baz": {"baz"}},
 			err:       ErrInvalidRequestObject,
-			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object must not contain the 'request' or 'request_uri' claims.",
+			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object must not contain the 'request' or 'request_uri' claims. The OAuth 2.0 client with id 'foo' made the Authorization Request.",
 		},
 		{
 			name:      "ShouldFailMismatchedResponseType",
@@ -240,7 +240,7 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 			client:    &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
 			expected:  url.Values{consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterResponseMode: {consts.ResponseModeFormPost}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {assertionRequestObjectValid}, "foo": {"bar"}, "baz": {"baz"}},
 			err:       ErrInvalidRequestObject,
-			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object's `response_type' claim must match the values provided in the standard OAuth 2.0 request syntax if provided.",
+			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object's `response_type' claim if provided must match the values provided in the standard OAuth 2.0 request syntax. The OAuth 2.0 client with id 'foo' included a 'response_type' claim with a value of 'token' in the request object which when provided is required to match the value in the OAuth 2.0 request syntax but the value 'code' was included instead.",
 		},
 		{
 			name:      "ShouldFailMismatchedResponseTypeAsserted",
@@ -248,7 +248,7 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 			client:    &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
 			expected:  url.Values{consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterResponseMode: {consts.ResponseModeFormPost}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {assertionRequestObjectInvalidResponseTypeValue}, "foo": {"bar"}, "baz": {"baz"}},
 			err:       ErrInvalidRequestObject,
-			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object's `response_type' claim must match the values provided in the standard OAuth 2.0 request syntax if provided.",
+			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object's `response_type' claim if provided must match the values provided in the standard OAuth 2.0 request syntax. The OAuth 2.0 client with id 'foo' included a 'response_type' claim with a value of '100' which is meant to be a string, not a int64.",
 		},
 		{
 			name:     "ShouldPassWithoutKID",
@@ -262,7 +262,7 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 			client:   &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
 			expected: url.Values{consts.FormParameterScope: {"foo openid"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequest: {assertionRequestObjectValidWithoutKID}, "foo": {"bar"}, "baz": {"baz"}},
 			err:      ErrInvalidRequestURI,
-			errRegex: regexp.MustCompile(`^The request_uri in the Authorization Request returns an error or contains invalid data. Request URI 'http://127\.0\.0\.1:\d+/request-object/valid/standard\.jwk' is not whitelisted by the OAuth 2\.0 Client\.`),
+			errRegex: regexp.MustCompile(`^The request_uri in the Authorization Request returns an error or contains invalid data\. OpenID Connect 1\.0 parameter 'request_uri' does not exist in the registered OAuth 2.0 registered 'request_uris' and is therefore not whitelisted. The OAuth 2.0 client with id 'foo' provided the 'request_uri' parameter with value 'http://127\.0\.0\.1:\d+/request-object/valid/standard\.jwk' which is not whitelisted.`),
 		},
 		{
 			name:     "ShouldPassRequestURIFetch",
@@ -273,10 +273,10 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 		{
 			name:      "ShouldFailRequestAlgNone",
 			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequest: {assertionRequestObjectValidNone}},
-			client:    &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "RS256"},
+			client:    &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
 			expected:  url.Values{consts.FormParameterState: {"some-state"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {assertionRequestObjectValidNone}, "foo": {"bar"}, "baz": {"baz"}},
 			err:       ErrInvalidRequestObject,
-			errString: "The request parameter contains an invalid Request Object. The request object uses signing algorithm 'none', but the requested OAuth 2.0 Client enforces signing algorithm 'RS256'.",
+			errString: "The request parameter contains an invalid Request Object. The request object uses signing algorithm 'none', but the requested OAuth 2.0 Client enforces signing algorithm 'RS256'. The OAuth 2.0 client with id 'foo' made the Authorization Request.",
 		},
 		{
 			name:      "ShouldFailRequestURIAlgNone",
@@ -284,15 +284,15 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 			client:    &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "RS256", RequestURIs: []string{root.JoinPath("request-object", "valid", "none.jwk").String()}, DefaultClient: &DefaultClient{ID: "foo"}},
 			expected:  url.Values{consts.FormParameterResponseType: {"token"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterState: {"some-state"}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequestURI: {root.JoinPath("request-object", "valid", "none.jwk").String()}, "foo": {"bar"}, "baz": {"baz"}},
 			err:       ErrInvalidRequestObject,
-			errString: "The request parameter contains an invalid Request Object. The request object uses signing algorithm 'none', but the requested OAuth 2.0 Client enforces signing algorithm 'RS256'.",
+			errString: "The request parameter contains an invalid Request Object. The request object uses signing algorithm 'none', but the requested OAuth 2.0 Client enforces signing algorithm 'RS256'. The OAuth 2.0 client with id 'foo' made the Authorization Request.",
 		},
 		{
 			name:      "ShouldFailRequestRS256",
 			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequest: {assertionRequestObjectValid}},
-			client:    &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "none"},
+			client:    &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "none", DefaultClient: &DefaultClient{ID: "foo"}},
 			expected:  url.Values{consts.FormParameterState: {"some-state"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {assertionRequestObjectValid}, "foo": {"bar"}, "baz": {"baz"}},
 			err:       ErrInvalidRequestObject,
-			errString: "The request parameter contains an invalid Request Object. The request object uses signing algorithm 'RS256', but the requested OAuth 2.0 Client enforces signing algorithm 'none'.",
+			errString: "The request parameter contains an invalid Request Object. The request object uses signing algorithm 'RS256', but the requested OAuth 2.0 Client enforces signing algorithm 'none'. The OAuth 2.0 client with id 'foo' made the Authorization Request.",
 		},
 		{
 			name:      "ShouldFailRequestURIRS256",
@@ -300,7 +300,7 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 			client:    &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "none", RequestURIs: []string{root.JoinPath("request-object", "valid", "standard.jwk").String()}, DefaultClient: &DefaultClient{ID: "foo"}},
 			expected:  url.Values{consts.FormParameterResponseType: {"token"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterState: {"some-state"}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequestURI: {root.JoinPath("request-object", "valid", "standard.jwk").String()}, "foo": {"bar"}, "baz": {"baz"}},
 			err:       ErrInvalidRequestObject,
-			errString: "The request parameter contains an invalid Request Object. The request object uses signing algorithm 'RS256', but the requested OAuth 2.0 Client enforces signing algorithm 'none'.",
+			errString: "The request parameter contains an invalid Request Object. The request object uses signing algorithm 'RS256', but the requested OAuth 2.0 Client enforces signing algorithm 'none'. The OAuth 2.0 client with id 'foo' made the Authorization Request.",
 		},
 		{
 			name:     "ShouldPassRequestAlgNone",
@@ -332,7 +332,7 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 			client:    &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
 			expected:  url.Values{consts.FormParameterState: {"some-state"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {assertionRequestObjectValidNone}, "foo": {"bar"}, "baz": {"baz"}},
 			err:       ErrInvalidRequestObject,
-			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object's `aud' claim must be the Authorization Server's issuer when using signed or encrypted request objects.",
+			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object's `aud' claim must be the Authorization Server's issuer when using signed or encrypted request objects. The OAuth 2.0 client with id 'foo' included a 'aud' claim with the values 'https://auth.not-example.com' in the request object which must match the issuer 'https://auth.example.com'.",
 		},
 		{
 			name:      "ShouldFailRequestURIBadAudience",
@@ -340,7 +340,7 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 			client:    &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "RS256", RequestURIs: []string{root.JoinPath("request-object", "invalid", "audience.jwk").String()}, DefaultClient: &DefaultClient{ID: "foo"}},
 			expected:  url.Values{consts.FormParameterResponseType: {"token"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterState: {"some-state"}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequestURI: {root.JoinPath("request-object", "invalid", "audience.jwk").String()}, "foo": {"bar"}, "baz": {"baz"}},
 			err:       ErrInvalidRequestObject,
-			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object's `response_type' claim must match the values provided in the standard OAuth 2.0 request syntax if provided.",
+			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object's `response_type' claim if provided must match the values provided in the standard OAuth 2.0 request syntax. The OAuth 2.0 client with id 'foo' included a 'response_type' claim with a value of 'code' in the request object which when provided is required to match the value in the OAuth 2.0 request syntax but the value 'token' was included instead.",
 		},
 		{
 			name:      "ShouldFailRequestBadIssuer",
@@ -348,7 +348,7 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 			client:    &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
 			expected:  url.Values{consts.FormParameterState: {"some-state"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {assertionRequestObjectValidNone}, "foo": {"bar"}, "baz": {"baz"}},
 			err:       ErrInvalidRequestObject,
-			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object's `iss' claim must contain the `client_id` when using signed or encrypted request objects.",
+			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object's `iss' claim must contain the `client_id` when using signed or encrypted request objects. The OAuth 2.0 client with id 'foo' made the Authorization Request.",
 		},
 		{
 			name:      "ShouldFailRequestURIBadIssuer",
@@ -356,7 +356,7 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 			client:    &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "RS256", RequestURIs: []string{root.JoinPath("request-object", "invalid", "issuer.jwk").String()}, DefaultClient: &DefaultClient{ID: "foo"}},
 			expected:  url.Values{consts.FormParameterResponseType: {"token"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterState: {"some-state"}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequestURI: {root.JoinPath("request-object", "invalid", "issuer.jwk").String()}, "foo": {"bar"}, "baz": {"baz"}},
 			err:       ErrInvalidRequestObject,
-			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object's `response_type' claim must match the values provided in the standard OAuth 2.0 request syntax if provided.",
+			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object's `response_type' claim if provided must match the values provided in the standard OAuth 2.0 request syntax. The OAuth 2.0 client with id 'foo' included a 'response_type' claim with a value of 'code' in the request object which when provided is required to match the value in the OAuth 2.0 request syntax but the value 'token' was included instead.",
 		},
 	}
 

--- a/authorize_request_handler_oidc_request_test.go
+++ b/authorize_request_handler_oidc_request_test.go
@@ -12,16 +12,386 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
 	"testing"
 
 	"github.com/go-jose/go-jose/v4"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"authelia.com/provider/oauth2/internal/consts"
 	"authelia.com/provider/oauth2/token/jwt"
 )
+
+func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 1024) //nolint:gosec
+	require.NoError(t, err)
+
+	jwks := &jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{
+				KeyID: "kid-foo",
+				Use:   "sig",
+				Key:   &key.PublicKey,
+			},
+		},
+	}
+
+	assertionRequestObjectValid := mustGenerateAssertion(t, jwt.MapClaims{consts.ClaimIssuer: "foo", consts.ClaimClientIdentifier: "foo", consts.ClaimAudience: []string{"https://auth.example.com"}, consts.FormParameterScope: "foo", "foo": "bar", "baz": "baz", consts.FormParameterResponseType: consts.ResponseTypeImplicitFlowToken, consts.FormParameterResponseMode: consts.ResponseModeFormPost}, key, "kid-foo")
+	assertionRequestObjectInvalidRequestInRequest := mustGenerateAssertion(t, jwt.MapClaims{consts.ClaimIssuer: "foo", consts.FormParameterRequest: "abc", consts.ClaimClientIdentifier: "foo", consts.ClaimAudience: []string{"https://auth.example.com"}, consts.FormParameterScope: "foo", "foo": "bar", "baz": "baz", consts.FormParameterResponseType: consts.ResponseTypeImplicitFlowToken, consts.FormParameterResponseMode: consts.ResponseModeFormPost}, key, "kid-foo")
+	assertionRequestObjectInvalidRequestURIInRequest := mustGenerateAssertion(t, jwt.MapClaims{consts.ClaimIssuer: "foo", consts.FormParameterRequestURI: "https://auth.example.com", consts.ClaimClientIdentifier: "foo", consts.ClaimAudience: []string{"https://auth.example.com"}, consts.FormParameterScope: "foo", "foo": "bar", "baz": "baz", consts.FormParameterResponseType: consts.ResponseTypeImplicitFlowToken, consts.FormParameterResponseMode: consts.ResponseModeFormPost}, key, "kid-foo")
+	assertionRequestObjectInvalidClientIDValue := mustGenerateAssertion(t, jwt.MapClaims{consts.ClaimIssuer: "foo", consts.ClaimClientIdentifier: 100, consts.ClaimAudience: []string{"https://auth.example.com"}, consts.FormParameterScope: "foo", "foo": "bar", "baz": "baz", consts.FormParameterResponseType: consts.ResponseTypeImplicitFlowToken, consts.FormParameterResponseMode: consts.ResponseModeFormPost}, key, "kid-foo")
+	assertionRequestObjectInvalidResponseTypeValue := mustGenerateAssertion(t, jwt.MapClaims{consts.ClaimIssuer: "foo", consts.ClaimAudience: []string{"https://auth.example.com"}, consts.FormParameterScope: "foo", "foo": "bar", "baz": "baz", consts.FormParameterResponseType: 100, consts.FormParameterResponseMode: consts.ResponseModeFormPost}, key, "kid-foo")
+	assertionRequestObjectInvalidAudience := mustGenerateAssertion(t, jwt.MapClaims{consts.ClaimIssuer: "foo", consts.ClaimAudience: []string{"https://auth.not-example.com"}, consts.FormParameterScope: "foo", "foo": "bar", "baz": "baz", consts.FormParameterResponseType: consts.ResponseTypeAuthorizationCodeFlow, consts.FormParameterResponseMode: consts.ResponseModeFormPost}, key, "kid-foo")
+	assertionRequestObjectInvalidIssuer := mustGenerateAssertion(t, jwt.MapClaims{consts.ClaimIssuer: "not-foo", consts.ClaimAudience: []string{"https://auth.example.com"}, consts.FormParameterScope: "foo", "foo": "bar", "baz": "baz", consts.FormParameterResponseType: consts.ResponseTypeAuthorizationCodeFlow, consts.FormParameterResponseMode: consts.ResponseModeFormPost}, key, "kid-foo")
+	assertionRequestObjectValidWithoutKID := mustGenerateAssertion(t, jwt.MapClaims{consts.ClaimIssuer: "foo", consts.ClaimAudience: []string{"https://auth.example.com"}, consts.FormParameterScope: "foo", "foo": "bar", "baz": "baz"}, key, "")
+	assertionRequestObjectValidNone := mustGenerateNoneAssertion(t, jwt.MapClaims{consts.FormParameterScope: "foo", "foo": "bar", "baz": "baz", consts.FormParameterState: "some-state"})
+
+	mux := http.NewServeMux()
+
+	var handlerJWKS http.HandlerFunc = func(rw http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewEncoder(rw).Encode(jwks))
+	}
+
+	handleString := func(in string) http.HandlerFunc {
+		var h http.HandlerFunc = func(rw http.ResponseWriter, r *http.Request) {
+			_, _ = rw.Write([]byte(in))
+		}
+
+		return h
+	}
+
+	mux.Handle("/jwks.json", handlerJWKS)
+	mux.Handle("/request-object/valid/standard.jwk", handleString(assertionRequestObjectValid))
+	mux.Handle("/request-object/invalid/issuer.jwk", handleString(assertionRequestObjectInvalidIssuer))
+	mux.Handle("/request-object/invalid/audience.jwk", handleString(assertionRequestObjectInvalidAudience))
+	mux.Handle("/request-object/invalid/response-type-value.jwk", handleString(assertionRequestObjectInvalidResponseTypeValue))
+	mux.Handle("/request-object/invalid/client-id-value.jwk", handleString(assertionRequestObjectInvalidClientIDValue))
+	mux.Handle("/request-object/invalid/has-request.jwk", handleString(assertionRequestObjectInvalidRequestInRequest))
+	mux.Handle("/request-object/invalid/has-request-uri.jwk", handleString(assertionRequestObjectInvalidRequestURIInRequest))
+	mux.Handle("/request-object/valid/without-kid.jwk", handleString(assertionRequestObjectValidWithoutKID))
+	mux.Handle("/request-object/valid/none.jwk", handleString(assertionRequestObjectValidNone))
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	root, err := url.ParseRequestURI(server.URL)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name      string
+		have      url.Values
+		par       bool
+		client    Client
+		expected  url.Values
+		err       error
+		errString string
+		errRegex  *regexp.Regexp
+	}{
+		{
+			name:     "ShouldPassWithoutRequestObject",
+			have:     url.Values{consts.FormParameterScope: {consts.ScopeOpenID}},
+			expected: url.Values{consts.FormParameterScope: {consts.ScopeOpenID}},
+		},
+		{
+			name:     "ShouldPassWithoutRequestObjectAndNotOpenID",
+			have:     url.Values{},
+			expected: url.Values{},
+		},
+		{
+			name:     "ShouldPassRequestWithRequestObjectNotOpenID",
+			have:     url.Values{consts.FormParameterRequest: {"foo"}},
+			client:   &DefaultClient{ID: "foo"},
+			expected: url.Values{consts.FormParameterRequest: {"foo"}},
+		},
+		{
+			name:     "ShouldPassRequest",
+			have:     url.Values{consts.FormParameterScope: {"foo openid"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterRequest: {assertionRequestObjectValid}},
+			client:   &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
+			expected: url.Values{consts.FormParameterScope: {"foo openid"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterResponseMode: {consts.ResponseModeFormPost}, consts.FormParameterRequest: {assertionRequestObjectValid}, "foo": {"bar"}, "baz": {"baz"}},
+		},
+		{
+			name:      "ShouldFailRequestNotOpenIDConnectClient",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterRequest: {"foo"}},
+			client:    &DefaultClient{ID: "foo"},
+			expected:  url.Values{consts.FormParameterScope: {consts.ScopeOpenID}},
+			err:       ErrRequestNotSupported,
+			errString: "The OP does not support use of the request parameter. OpenID Connect 1.0 'request' context was given, but the OAuth 2.0 Client does not implement advanced OpenID Connect 1.0 capabilities. The OAuth 2.0 client with id 'foo' doesn't implement the correct methods for this request.",
+		},
+		{
+			name:      "ShouldFailRequestURINotOpenIDConnectClient",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterRequestURI: {"foo"}},
+			client:    &DefaultClient{ID: "foo"},
+			expected:  url.Values{consts.FormParameterScope: {consts.ScopeOpenID}},
+			err:       ErrRequestURINotSupported,
+			errString: "The OP does not support use of the request_uri parameter. OpenID Connect 1.0 'request_uri' context was given, but the OAuth 2.0 Client does not implement advanced OpenID Connect 1.0 capabilities. The OAuth 2.0 client with id 'foo' doesn't implement the correct methods for this request.",
+		},
+		{
+			name:      "ShouldFailRequestAndRequestURI",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterRequest: {"foo"}, consts.FormParameterRequestURI: {"foo"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}},
+			client:    &DefaultOpenIDConnectClient{RequestObjectSigningAlg: "", DefaultClient: &DefaultClient{ID: "foo"}},
+			par:       true,
+			expected:  url.Values{consts.FormParameterRequest: {"foo"}},
+			err:       ErrInvalidRequest,
+			errString: "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. OpenID Connect 1.0 parameters 'request' and 'request_uri' were both given, but you can use at most one.",
+		},
+		{
+			name:      "ShouldFailRequestMissingResponseType",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterRequest: {"foo"}, consts.FormParameterClientID: {"foo"}},
+			client:    &DefaultOpenIDConnectClient{RequestObjectSigningAlg: "", DefaultClient: &DefaultClient{ID: "foo"}},
+			par:       true,
+			expected:  url.Values{consts.FormParameterRequest: {"foo"}},
+			err:       ErrInvalidRequest,
+			errString: "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. OpenID Connect 1.0 parameters 'request' and 'request_uri' must be accompanied by the `client_id' and 'response_type' in the request syntax.",
+		},
+		{
+			name:      "ShouldFailRequestMissingClientID",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterRequest: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}},
+			client:    &DefaultOpenIDConnectClient{RequestObjectSigningAlg: "", DefaultClient: &DefaultClient{ID: "foo"}},
+			par:       true,
+			expected:  url.Values{consts.FormParameterRequest: {"foo"}},
+			err:       ErrInvalidRequest,
+			errString: "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. OpenID Connect 1.0 parameters 'request' and 'request_uri' must be accompanied by the `client_id' and 'response_type' in the request syntax.",
+		},
+		{
+			name:      "ShouldFailRequestURIWithPAR",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterRequestURI: {"foo"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}},
+			client:    &DefaultOpenIDConnectClient{RequestObjectSigningAlg: "", DefaultClient: &DefaultClient{ID: "foo"}},
+			par:       true,
+			expected:  url.Values{consts.FormParameterRequest: {"foo"}},
+			err:       ErrInvalidRequest,
+			errString: "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Pushed Authorization Requests can not contain the 'request_uri' parameter.",
+		},
+		{
+			name:      "ShouldFailRequestClientNoJWKS",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterRequest: {"foo"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}},
+			client:    &DefaultOpenIDConnectClient{RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
+			expected:  url.Values{consts.FormParameterScope: {consts.ScopeOpenID}},
+			err:       ErrInvalidRequest,
+			errString: "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. OpenID Connect 1.0 'request' context was given, but the OAuth 2.0 Client does not have any JSON Web Keys registered. The OAuth 2.0 client with id 'foo' doesn't have any known JSON Web Keys but requires them when not explicitly registered with a 'request_object_signing_alg' with the value of 'none' but it's registered with 'RS256'.",
+		},
+		{
+			name:      "ShouldFailRequestURIClientNoJWKS",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterRequestURI: {"foo"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}},
+			client:    &DefaultOpenIDConnectClient{RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
+			expected:  url.Values{consts.FormParameterScope: {consts.ScopeOpenID}},
+			err:       ErrInvalidRequest,
+			errString: "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. OpenID Connect 1.0 'request_uri' context was given, but the OAuth 2.0 Client does not have any JSON Web Keys registered. The OAuth 2.0 client with id 'foo' doesn't have any known JSON Web Keys but requires them when not explicitly registered with a 'request_object_signing_alg' with the value of 'none' but it's registered with 'RS256'.",
+		},
+		{
+			name:      "ShouldFailInvalidTokenMalformed",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequest: {"bad-token"}},
+			client:    &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
+			expected:  url.Values{consts.FormParameterScope: {consts.ScopeOpenID}},
+			err:       ErrInvalidRequestObject,
+			errString: "The request parameter contains an invalid Request Object. Unable to verify the request object's signature. go-jose/go-jose: compact JWS format must have three parts",
+		},
+		{
+			name:      "ShouldFailUnknownKID",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequest: {mustGenerateAssertion(t, jwt.MapClaims{}, key, "does-not-exists")}},
+			client:    &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "test"}},
+			expected:  url.Values{consts.FormParameterScope: {consts.ScopeOpenID}},
+			err:       ErrInvalidRequestObject,
+			errString: "The request parameter contains an invalid Request Object. Unable to retrieve RSA signing key from OAuth 2.0 Client. The JSON Web Token uses signing key with kid 'does-not-exists', which could not be found. The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The JSON Web Token uses signing key with kid 'does-not-exists', which could not be found.",
+		},
+		{
+			name:      "ShouldFailBadAlgRS256",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequest: {mustGenerateHSAssertion(t, jwt.MapClaims{})}},
+			client:    &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "test"}},
+			expected:  url.Values{consts.FormParameterScope: {consts.ScopeOpenID}},
+			err:       ErrInvalidRequestObject,
+			errString: "The request parameter contains an invalid Request Object. The request object uses signing algorithm 'HS256', but the requested OAuth 2.0 Client enforces signing algorithm 'RS256'.",
+		},
+		{
+			name:      "ShouldFailMismatchedClientID",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"not-foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterResponseMode: {consts.ResponseModeNone}, consts.FormParameterRequest: {assertionRequestObjectValid}},
+			client:    &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
+			expected:  url.Values{consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterResponseMode: {consts.ResponseModeFormPost}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {assertionRequestObjectValid}, "foo": {"bar"}, "baz": {"baz"}},
+			err:       ErrInvalidRequestObject,
+			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object's `client_id' claim must match the values provided in the standard OAuth 2.0 request syntax if provided.",
+		},
+		{
+			name:      "ShouldFailRequestClientIDAssert",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"not-foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterResponseMode: {consts.ResponseModeNone}, consts.FormParameterRequest: {assertionRequestObjectInvalidClientIDValue}},
+			client:    &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
+			expected:  url.Values{consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterResponseMode: {consts.ResponseModeFormPost}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {assertionRequestObjectInvalidClientIDValue}, "foo": {"bar"}, "baz": {"baz"}},
+			err:       ErrInvalidRequestObject,
+			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object's `client_id' claim must match the values provided in the standard OAuth 2.0 request syntax if provided.",
+		},
+		{
+			name:      "ShouldFailRequestWithRequest",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterResponseMode: {consts.ResponseModeNone}, consts.FormParameterRequest: {assertionRequestObjectInvalidRequestInRequest}},
+			client:    &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
+			expected:  url.Values{consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterResponseMode: {consts.ResponseModeFormPost}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {assertionRequestObjectInvalidRequestInRequest}, "foo": {"bar"}, "baz": {"baz"}},
+			err:       ErrInvalidRequestObject,
+			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object must not contain the 'request' or 'request_uri' claims.",
+		},
+		{
+			name:      "ShouldFailRequestWithRequestURI",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterResponseMode: {consts.ResponseModeNone}, consts.FormParameterRequest: {assertionRequestObjectInvalidRequestURIInRequest}},
+			client:    &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
+			expected:  url.Values{consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterResponseMode: {consts.ResponseModeFormPost}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {assertionRequestObjectInvalidRequestURIInRequest}, "foo": {"bar"}, "baz": {"baz"}},
+			err:       ErrInvalidRequestObject,
+			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object must not contain the 'request' or 'request_uri' claims.",
+		},
+		{
+			name:      "ShouldFailMismatchedResponseType",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterResponseMode: {consts.ResponseModeNone}, consts.FormParameterRequest: {assertionRequestObjectValid}},
+			client:    &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
+			expected:  url.Values{consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterResponseMode: {consts.ResponseModeFormPost}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {assertionRequestObjectValid}, "foo": {"bar"}, "baz": {"baz"}},
+			err:       ErrInvalidRequestObject,
+			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object's `response_type' claim must match the values provided in the standard OAuth 2.0 request syntax if provided.",
+		},
+		{
+			name:      "ShouldFailMismatchedResponseTypeAsserted",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterResponseMode: {consts.ResponseModeNone}, consts.FormParameterRequest: {assertionRequestObjectInvalidResponseTypeValue}},
+			client:    &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
+			expected:  url.Values{consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterResponseMode: {consts.ResponseModeFormPost}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {assertionRequestObjectInvalidResponseTypeValue}, "foo": {"bar"}, "baz": {"baz"}},
+			err:       ErrInvalidRequestObject,
+			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object's `response_type' claim must match the values provided in the standard OAuth 2.0 request syntax if provided.",
+		},
+		{
+			name:     "ShouldPassWithoutKID",
+			have:     url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequest: {assertionRequestObjectValidWithoutKID}},
+			client:   &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
+			expected: url.Values{consts.FormParameterScope: {"foo openid"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequest: {assertionRequestObjectValidWithoutKID}, "foo": {"bar"}, "baz": {"baz"}},
+		},
+		{
+			name:     "ShouldFailRequestURINotWhiteListed",
+			have:     url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequestURI: {root.JoinPath("request-object", "valid", "standard.jwk").String()}},
+			client:   &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
+			expected: url.Values{consts.FormParameterScope: {"foo openid"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequest: {assertionRequestObjectValidWithoutKID}, "foo": {"bar"}, "baz": {"baz"}},
+			err:      ErrInvalidRequestURI,
+			errRegex: regexp.MustCompile(`^The request_uri in the Authorization Request returns an error or contains invalid data. Request URI 'http://127\.0\.0\.1:\d+/request-object/valid/standard\.jwk' is not whitelisted by the OAuth 2\.0 Client\.`),
+		},
+		{
+			name:     "ShouldPassRequestURIFetch",
+			have:     url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterRequestURI: {root.JoinPath("request-object", "valid", "standard.jwk").String()}},
+			client:   &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "RS256", RequestURIs: []string{root.JoinPath("request-object", "valid", "standard.jwk").String()}, DefaultClient: &DefaultClient{ID: "foo"}},
+			expected: url.Values{consts.FormParameterResponseType: {"token"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseMode: {consts.ResponseModeFormPost}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequestURI: {root.JoinPath("request-object", "valid", "standard.jwk").String()}, "foo": {"bar"}, "baz": {"baz"}},
+		},
+		{
+			name:      "ShouldFailRequestAlgNone",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequest: {assertionRequestObjectValidNone}},
+			client:    &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "RS256"},
+			expected:  url.Values{consts.FormParameterState: {"some-state"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {assertionRequestObjectValidNone}, "foo": {"bar"}, "baz": {"baz"}},
+			err:       ErrInvalidRequestObject,
+			errString: "The request parameter contains an invalid Request Object. The request object uses signing algorithm 'none', but the requested OAuth 2.0 Client enforces signing algorithm 'RS256'.",
+		},
+		{
+			name:      "ShouldFailRequestURIAlgNone",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterRequestURI: {root.JoinPath("request-object", "valid", "none.jwk").String()}},
+			client:    &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "RS256", RequestURIs: []string{root.JoinPath("request-object", "valid", "none.jwk").String()}, DefaultClient: &DefaultClient{ID: "foo"}},
+			expected:  url.Values{consts.FormParameterResponseType: {"token"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterState: {"some-state"}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequestURI: {root.JoinPath("request-object", "valid", "none.jwk").String()}, "foo": {"bar"}, "baz": {"baz"}},
+			err:       ErrInvalidRequestObject,
+			errString: "The request parameter contains an invalid Request Object. The request object uses signing algorithm 'none', but the requested OAuth 2.0 Client enforces signing algorithm 'RS256'.",
+		},
+		{
+			name:      "ShouldFailRequestRS256",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequest: {assertionRequestObjectValid}},
+			client:    &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "none"},
+			expected:  url.Values{consts.FormParameterState: {"some-state"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {assertionRequestObjectValid}, "foo": {"bar"}, "baz": {"baz"}},
+			err:       ErrInvalidRequestObject,
+			errString: "The request parameter contains an invalid Request Object. The request object uses signing algorithm 'RS256', but the requested OAuth 2.0 Client enforces signing algorithm 'none'.",
+		},
+		{
+			name:      "ShouldFailRequestURIRS256",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterRequestURI: {root.JoinPath("request-object", "valid", "standard.jwk").String()}},
+			client:    &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "none", RequestURIs: []string{root.JoinPath("request-object", "valid", "standard.jwk").String()}, DefaultClient: &DefaultClient{ID: "foo"}},
+			expected:  url.Values{consts.FormParameterResponseType: {"token"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterState: {"some-state"}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequestURI: {root.JoinPath("request-object", "valid", "standard.jwk").String()}, "foo": {"bar"}, "baz": {"baz"}},
+			err:       ErrInvalidRequestObject,
+			errString: "The request parameter contains an invalid Request Object. The request object uses signing algorithm 'RS256', but the requested OAuth 2.0 Client enforces signing algorithm 'none'.",
+		},
+		{
+			name:     "ShouldPassRequestAlgNone",
+			have:     url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequest: {assertionRequestObjectValidNone}},
+			client:   &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "none"},
+			expected: url.Values{consts.FormParameterState: {"some-state"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {assertionRequestObjectValidNone}, "foo": {"bar"}, "baz": {"baz"}},
+		},
+		{
+			name:     "ShouldPassRequestURIAlgNone",
+			have:     url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterRequestURI: {root.JoinPath("request-object", "valid", "none.jwk").String()}},
+			client:   &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "none", RequestURIs: []string{root.JoinPath("request-object", "valid", "none.jwk").String()}, DefaultClient: &DefaultClient{ID: "foo"}},
+			expected: url.Values{consts.FormParameterResponseType: {"token"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterState: {"some-state"}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequestURI: {root.JoinPath("request-object", "valid", "none.jwk").String()}, "foo": {"bar"}, "baz": {"baz"}},
+		},
+		{
+			name:     "ShouldPassRequestAlgNoneAllowAny",
+			have:     url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequest: {assertionRequestObjectValidNone}},
+			client:   &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String()},
+			expected: url.Values{consts.FormParameterState: {"some-state"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {assertionRequestObjectValidNone}, "foo": {"bar"}, "baz": {"baz"}},
+		},
+		{
+			name:     "ShouldPassRequestURIAlgNoneAllowAny",
+			have:     url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterRequestURI: {root.JoinPath("request-object", "valid", "none.jwk").String()}},
+			client:   &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "", RequestURIs: []string{root.JoinPath("request-object", "valid", "none.jwk").String()}, DefaultClient: &DefaultClient{ID: "foo"}},
+			expected: url.Values{consts.FormParameterResponseType: {"token"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterState: {"some-state"}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequestURI: {root.JoinPath("request-object", "valid", "none.jwk").String()}, "foo": {"bar"}, "baz": {"baz"}},
+		},
+		{
+			name:      "ShouldFailRequestBadAudience",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequest: {assertionRequestObjectInvalidAudience}},
+			client:    &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
+			expected:  url.Values{consts.FormParameterState: {"some-state"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {assertionRequestObjectValidNone}, "foo": {"bar"}, "baz": {"baz"}},
+			err:       ErrInvalidRequestObject,
+			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object's `aud' claim must be the Authorization Server's issuer when using signed or encrypted request objects.",
+		},
+		{
+			name:      "ShouldFailRequestURIBadAudience",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterRequestURI: {root.JoinPath("request-object", "invalid", "audience.jwk").String()}},
+			client:    &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "RS256", RequestURIs: []string{root.JoinPath("request-object", "invalid", "audience.jwk").String()}, DefaultClient: &DefaultClient{ID: "foo"}},
+			expected:  url.Values{consts.FormParameterResponseType: {"token"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterState: {"some-state"}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequestURI: {root.JoinPath("request-object", "invalid", "audience.jwk").String()}, "foo": {"bar"}, "baz": {"baz"}},
+			err:       ErrInvalidRequestObject,
+			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object's `response_type' claim must match the values provided in the standard OAuth 2.0 request syntax if provided.",
+		},
+		{
+			name:      "ShouldFailRequestBadIssuer",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequest: {assertionRequestObjectInvalidIssuer}},
+			client:    &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
+			expected:  url.Values{consts.FormParameterState: {"some-state"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {assertionRequestObjectValidNone}, "foo": {"bar"}, "baz": {"baz"}},
+			err:       ErrInvalidRequestObject,
+			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object's `iss' claim must contain the `client_id` when using signed or encrypted request objects.",
+		},
+		{
+			name:      "ShouldFailRequestURIBadIssuer",
+			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterRequestURI: {root.JoinPath("request-object", "invalid", "issuer.jwk").String()}},
+			client:    &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "RS256", RequestURIs: []string{root.JoinPath("request-object", "invalid", "issuer.jwk").String()}, DefaultClient: &DefaultClient{ID: "foo"}},
+			expected:  url.Values{consts.FormParameterResponseType: {"token"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterState: {"some-state"}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequestURI: {root.JoinPath("request-object", "invalid", "issuer.jwk").String()}, "foo": {"bar"}, "baz": {"baz"}},
+			err:       ErrInvalidRequestObject,
+			errString: "The request parameter contains an invalid Request Object. OpenID Connect 1.0 request object's `response_type' claim must match the values provided in the standard OAuth 2.0 request syntax if provided.",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &AuthorizeRequest{
+				Request: Request{
+					Client: tc.client,
+					Form:   tc.have,
+				},
+			}
+
+			provider := &Fosite{Config: &Config{JWKSFetcherStrategy: NewDefaultJWKSFetcherStrategy(), IDTokenIssuer: "https://auth.example.com"}}
+
+			err = provider.authorizeRequestParametersFromOpenIDConnectRequestObject(context.Background(), r, tc.par)
+			if tc.err != nil {
+				assert.EqualError(t, err, tc.err.Error())
+				if tc.errString != "" {
+					assert.EqualError(t, ErrorToDebugRFC6749Error(err), tc.errString)
+				}
+
+				if tc.errRegex != nil {
+					assert.Regexp(t, tc.errRegex, ErrorToDebugRFC6749Error(err).Error())
+				}
+			} else {
+				assert.NoError(t, ErrorToDebugRFC6749Error(err))
+
+				assert.Equal(t, len(tc.expected), len(r.Form))
+				for k, v := range tc.expected {
+					assert.EqualValues(t, v, r.Form[k], fmt.Sprintf("Parameter %s did not match", k))
+				}
+			}
+		})
+	}
+}
 
 func mustGenerateAssertion(t *testing.T, claims jwt.MapClaims, key *rsa.PrivateKey, kid string) string {
 	token := jwt.NewWithClaims(jose.RS256, claims)
@@ -45,180 +415,4 @@ func mustGenerateNoneAssertion(t *testing.T, claims jwt.MapClaims) string {
 	tokenString, err := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
 	require.NoError(t, err)
 	return tokenString
-}
-
-func TestAuthorizeRequestParametersFromOpenIDConnectRequest(t *testing.T) {
-	key, err := rsa.GenerateKey(rand.Reader, 1024) //nolint:gosec
-	if err != nil {
-		panic(err)
-	}
-	jwks := &jose.JSONWebKeySet{
-		Keys: []jose.JSONWebKey{
-			{
-				KeyID: "kid-foo",
-				Use:   "sig",
-				Key:   &key.PublicKey,
-			},
-		},
-	}
-
-	validRequestObject := mustGenerateAssertion(t, jwt.MapClaims{consts.ClaimIssuer: "foo", consts.ClaimAudience: []string{"https://auth.example.com"}, consts.FormParameterScope: "foo", "foo": "bar", "baz": "baz", consts.FormParameterResponseType: consts.ResponseTypeImplicitFlowToken, consts.FormParameterResponseMode: consts.ResponseModeFormPost}, key, "kid-foo")
-	validRequestObjectWithoutKid := mustGenerateAssertion(t, jwt.MapClaims{consts.ClaimIssuer: "foo", consts.ClaimAudience: []string{"https://auth.example.com"}, consts.FormParameterScope: "foo", "foo": "bar", "baz": "baz"}, key, "")
-	validNoneRequestObject := mustGenerateNoneAssertion(t, jwt.MapClaims{consts.FormParameterScope: "foo", "foo": "bar", "baz": "baz", consts.FormParameterState: "some-state"})
-
-	var reqH http.HandlerFunc = func(rw http.ResponseWriter, r *http.Request) {
-		_, _ = rw.Write([]byte(validRequestObject))
-	}
-	reqTS := httptest.NewServer(reqH)
-	defer reqTS.Close()
-
-	var hJWK http.HandlerFunc = func(rw http.ResponseWriter, r *http.Request) {
-		require.NoError(t, json.NewEncoder(rw).Encode(jwks))
-	}
-	reqJWK := httptest.NewServer(hJWK)
-	defer reqJWK.Close()
-
-	provider := &Fosite{Config: &Config{JWKSFetcherStrategy: NewDefaultJWKSFetcherStrategy(), IDTokenIssuer: "https://auth.example.com"}}
-	for k, tc := range []struct {
-		client Client
-		form   url.Values
-		d      string
-
-		expectErr       error
-		expectErrReason string
-		expectForm      url.Values
-	}{
-		{
-			d:          "should pass because no request context given and not openid",
-			form:       url.Values{},
-			expectErr:  nil,
-			expectForm: url.Values{},
-		},
-		{
-			d:          "should pass because no request context given",
-			form:       url.Values{consts.FormParameterScope: {consts.ScopeOpenID}},
-			expectErr:  nil,
-			expectForm: url.Values{consts.FormParameterScope: {consts.ScopeOpenID}},
-		},
-		{
-			d:          "should pass because request context given but not openid",
-			form:       url.Values{consts.FormParameterRequest: {"foo"}},
-			expectErr:  nil,
-			expectForm: url.Values{consts.FormParameterRequest: {"foo"}},
-		},
-		{
-			d:          "should fail because not an OpenIDConnect compliant client",
-			client:     &DefaultClient{ID: "test"},
-			form:       url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterRequest: {"foo"}},
-			expectErr:  ErrRequestNotSupported,
-			expectForm: url.Values{consts.FormParameterScope: {consts.ScopeOpenID}},
-		},
-		{
-			d:          "should fail because not an OpenIDConnect compliant client",
-			client:     &DefaultClient{ID: "test"},
-			form:       url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterRequestURI: {"foo"}},
-			expectErr:  ErrRequestURINotSupported,
-			expectForm: url.Values{consts.FormParameterScope: {consts.ScopeOpenID}},
-		},
-		{
-			d:          "should fail because token invalid an no key set",
-			form:       url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterRequestURI: {"foo"}},
-			client:     &DefaultOpenIDConnectClient{RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "test"}},
-			expectErr:  ErrInvalidRequest,
-			expectForm: url.Values{consts.FormParameterScope: {consts.ScopeOpenID}},
-		},
-		{
-			d:          "should fail because token invalid",
-			form:       url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequest: {"foo"}},
-			client:     &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "test"}},
-			expectErr:  ErrInvalidRequestObject,
-			expectForm: url.Values{consts.FormParameterScope: {consts.ScopeOpenID}},
-		},
-		{
-			d:               "should fail because kid does not exist",
-			form:            url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequest: {mustGenerateAssertion(t, jwt.MapClaims{}, key, "does-not-exists")}},
-			client:          &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "test"}},
-			expectErr:       ErrInvalidRequestObject,
-			expectErrReason: "Unable to retrieve RSA signing key from OAuth 2.0 Client. The JSON Web Token uses signing key with kid 'does-not-exists', which could not be found.",
-			expectForm:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}},
-		},
-		{
-			d:               "should fail because not RS256 token",
-			form:            url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequest: {mustGenerateHSAssertion(t, jwt.MapClaims{})}},
-			client:          &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "test"}},
-			expectErr:       ErrInvalidRequestObject,
-			expectErrReason: "The request object uses signing algorithm 'HS256', but the requested OAuth 2.0 Client enforces signing algorithm 'RS256'.",
-			expectForm:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}},
-		},
-		{
-			d:      "should fail mismatched response type",
-			form:   url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterResponseMode: {consts.ResponseModeNone}, consts.FormParameterRequest: {validRequestObject}},
-			client: &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "test"}},
-			// The values from form are overwritten by the request object.
-			expectErr:       ErrInvalidRequestObject,
-			expectErrReason: "OpenID Connect 1.0 request object's `response_type' claim must match the values provided in the standard OAuth 2.0 request syntax if provided.",
-			expectForm:      url.Values{consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterResponseMode: {consts.ResponseModeFormPost}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {validRequestObject}, "foo": {"bar"}, "baz": {"baz"}},
-		},
-		{
-			d:          "should pass even if kid is unset",
-			form:       url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequest: {validRequestObjectWithoutKid}},
-			client:     &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
-			expectForm: url.Values{consts.FormParameterScope: {"foo openid"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequest: {validRequestObjectWithoutKid}, "foo": {"bar"}, "baz": {"baz"}},
-		},
-		{
-			d:          "should fail because request uri is not whitelisted",
-			form:       url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequestURI: {reqTS.URL}},
-			client:     &DefaultOpenIDConnectClient{JSONWebKeysURI: reqJWK.URL, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
-			expectForm: url.Values{consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequestURI: {reqTS.URL}, "foo": {"bar"}, "baz": {"baz"}},
-			expectErr:  ErrInvalidRequestURI,
-		},
-		{
-			d:          "should pass and set request_uri parameters properly and also fetch jwk from remote",
-			form:       url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterRequestURI: {reqTS.URL}},
-			client:     &DefaultOpenIDConnectClient{JSONWebKeysURI: reqJWK.URL, RequestObjectSigningAlg: "RS256", RequestURIs: []string{reqTS.URL}, DefaultClient: &DefaultClient{ID: "foo"}},
-			expectForm: url.Values{consts.FormParameterResponseType: {"token"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseMode: {consts.ResponseModeFormPost}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequestURI: {reqTS.URL}, "foo": {"bar"}, "baz": {"baz"}},
-		},
-		{
-			d:          "should pass when request object uses algorithm none",
-			form:       url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequest: {validNoneRequestObject}},
-			client:     &DefaultOpenIDConnectClient{JSONWebKeysURI: reqJWK.URL, RequestObjectSigningAlg: "none"},
-			expectForm: url.Values{consts.FormParameterState: {"some-state"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {validNoneRequestObject}, "foo": {"bar"}, "baz": {"baz"}},
-		},
-		{
-			d:          "should pass when request object uses algorithm none and the client did not explicitly allow any algorithm",
-			form:       url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequest: {validNoneRequestObject}},
-			client:     &DefaultOpenIDConnectClient{JSONWebKeysURI: reqJWK.URL},
-			expectForm: url.Values{consts.FormParameterState: {"some-state"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {validNoneRequestObject}, "foo": {"bar"}, "baz": {"baz"}},
-		},
-	} {
-		t.Run(fmt.Sprintf("case=%d/description=%s", k, tc.d), func(t *testing.T) {
-			req := &AuthorizeRequest{
-				Request: Request{
-					Client: tc.client,
-					Form:   tc.form,
-				},
-			}
-
-			err := provider.authorizeRequestParametersFromOpenIDConnectRequestObject(context.Background(), req, false)
-			if tc.expectErr != nil {
-				assert.EqualError(t, err, tc.expectErr.Error(), "%+v", err)
-				if tc.expectErrReason != "" {
-					actual := new(RFC6749Error)
-					require.True(t, errors.As(err, &actual))
-					assert.EqualValues(t, tc.expectErrReason, actual.Reason())
-				}
-			} else {
-				if err != nil {
-					actual := new(RFC6749Error)
-					errors.As(err, &actual)
-					require.NoErrorf(t, err, "Hint: %v\nDebug:%v", actual.HintField, actual.DebugField)
-				}
-				assert.NoErrorf(t, err, "%+v", err)
-				require.Equal(t, len(tc.expectForm), len(req.Form))
-				for k, v := range tc.expectForm {
-					assert.EqualValues(t, v, req.Form[k])
-				}
-			}
-		})
-	}
 }


### PR DESCRIPTION
This adds additional error handling to the request and request_uri parameters to ensure request objects meet the specifications. In addition it greatly enhances the errors returned and the testing suite applied to this section of code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed and improved the handling of OpenID Connect request parameters, including better error messages and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->