### PR TITLE
feat: introspection jwt responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ following list of differences:
       - JWT Profile Core Strategy (if a jwt.Signer is provided)
       - HMAC-based Core Strategy
     - [x] JWT Profile Per Client
+  - [x] Introspection JWT Responses
   - [x] Custom Form Post Response Writer
   - [ ] UserInfo support
   - [x] [RFC8628: OAuth 2.0 Device Authorization Grant](https://datatracker.ietf.org/doc/html/rfc8628)

--- a/authorize_request_handler.go
+++ b/authorize_request_handler.go
@@ -76,7 +76,7 @@ func (f *Fosite) authorizeRequestParametersFromOpenIDConnectRequestObject(ctx co
 	)
 
 	switch alg := client.GetRequestObjectSigningAlg(); alg {
-	case "none":
+	case consts.JSONWebTokenAlgNone:
 		algNone = true
 	case "":
 		algAny = true

--- a/authorize_request_handler_oidc_request_test.go
+++ b/authorize_request_handler_oidc_request_test.go
@@ -289,7 +289,7 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 		{
 			name:      "ShouldFailRequestRS256",
 			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequest: {assertionRequestObjectValid}},
-			client:    &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "none", DefaultClient: &DefaultClient{ID: "foo"}},
+			client:    &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: consts.JSONWebTokenAlgNone, DefaultClient: &DefaultClient{ID: "foo"}},
 			expected:  url.Values{consts.FormParameterState: {"some-state"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {assertionRequestObjectValid}, "foo": {"bar"}, "baz": {"baz"}},
 			err:       ErrInvalidRequestObject,
 			errString: "The request parameter contains an invalid Request Object. The request object uses signing algorithm 'RS256', but the requested OAuth 2.0 Client enforces signing algorithm 'none'. The OAuth 2.0 client with id 'foo' made the Authorization Request.",
@@ -297,7 +297,7 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 		{
 			name:      "ShouldFailRequestURIRS256",
 			have:      url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterRequestURI: {root.JoinPath("request-object", "valid", "standard.jwk").String()}},
-			client:    &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "none", RequestURIs: []string{root.JoinPath("request-object", "valid", "standard.jwk").String()}, DefaultClient: &DefaultClient{ID: "foo"}},
+			client:    &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: consts.JSONWebTokenAlgNone, RequestURIs: []string{root.JoinPath("request-object", "valid", "standard.jwk").String()}, DefaultClient: &DefaultClient{ID: "foo"}},
 			expected:  url.Values{consts.FormParameterResponseType: {"token"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterState: {"some-state"}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequestURI: {root.JoinPath("request-object", "valid", "standard.jwk").String()}, "foo": {"bar"}, "baz": {"baz"}},
 			err:       ErrInvalidRequestObject,
 			errString: "The request parameter contains an invalid Request Object. The request object uses signing algorithm 'RS256', but the requested OAuth 2.0 Client enforces signing algorithm 'none'. The OAuth 2.0 client with id 'foo' made the Authorization Request.",
@@ -305,13 +305,13 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 		{
 			name:     "ShouldPassRequestAlgNone",
 			have:     url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterRequest: {assertionRequestObjectValidNone}},
-			client:   &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "none"},
+			client:   &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: consts.JSONWebTokenAlgNone},
 			expected: url.Values{consts.FormParameterState: {"some-state"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequest: {assertionRequestObjectValidNone}, "foo": {"bar"}, "baz": {"baz"}},
 		},
 		{
 			name:     "ShouldPassRequestURIAlgNone",
 			have:     url.Values{consts.FormParameterScope: {consts.ScopeOpenID}, consts.FormParameterClientID: {"foo"}, consts.FormParameterResponseType: {consts.ResponseTypeImplicitFlowToken}, consts.FormParameterRequestURI: {root.JoinPath("request-object", "valid", "none.jwk").String()}},
-			client:   &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: "none", RequestURIs: []string{root.JoinPath("request-object", "valid", "none.jwk").String()}, DefaultClient: &DefaultClient{ID: "foo"}},
+			client:   &DefaultOpenIDConnectClient{JSONWebKeysURI: root.JoinPath("jwks.json").String(), RequestObjectSigningAlg: consts.JSONWebTokenAlgNone, RequestURIs: []string{root.JoinPath("request-object", "valid", "none.jwk").String()}, DefaultClient: &DefaultClient{ID: "foo"}},
 			expected: url.Values{consts.FormParameterResponseType: {"token"}, consts.FormParameterClientID: {"foo"}, consts.FormParameterState: {"some-state"}, consts.FormParameterScope: {"foo openid"}, consts.FormParameterRequestURI: {root.JoinPath("request-object", "valid", "none.jwk").String()}, "foo": {"bar"}, "baz": {"baz"}},
 		},
 		{

--- a/client.go
+++ b/client.go
@@ -176,6 +176,21 @@ type RequestedAudienceImplicitClient interface {
 	Client
 }
 
+// IntrospectionJWTResponseClient is a client which can potentially sign Introspection responses.
+//
+// See: https://www.ietf.org/id/draft-ietf-oauth-jwt-introspection-response-12.html
+type IntrospectionJWTResponseClient interface {
+	// GetIntrospectionSignedResponseAlg returns the alg header used to sign the introspection responses for the client.
+	// If empty or 'none' and the kid is empty the responses are not signed i.e. standard responses.
+	GetIntrospectionSignedResponseAlg() (alg string)
+
+	// GetIntrospectionSignedResponseKeyID returns the kid header used to sign the introspection responses for the
+	// client. If empty and the alg is empty or 'none' the responses are not signed i.e. standard responses.
+	GetIntrospectionSignedResponseKeyID() (kid string)
+
+	Client
+}
+
 // DefaultClient is a simple default implementation of the Client interface.
 type DefaultClient struct {
 	ID                   string         `json:"id"`

--- a/config.go
+++ b/config.go
@@ -83,22 +83,28 @@ type DisableRefreshTokenValidationProvider interface {
 	GetDisableRefreshTokenValidation(ctx context.Context) bool
 }
 
-// AllowedPromptValuesProvider returns the provider for configuring the allowed prompt values.
-type AllowedPromptValuesProvider interface {
-	// GetAllowedPromptValues returns the allowed prompt values.
-	GetAllowedPromptValues(ctx context.Context) int
-}
-
 // AccessTokenIssuerProvider returns the provider for configuring the JWT issuer.
 type AccessTokenIssuerProvider interface {
 	// GetAccessTokenIssuer returns the access token issuer.
-	GetAccessTokenIssuer(ctx context.Context) string
+	GetAccessTokenIssuer(ctx context.Context) (issuer string)
 }
 
 // IDTokenIssuerProvider returns the provider for configuring the ID token issuer.
 type IDTokenIssuerProvider interface {
 	// GetIDTokenIssuer returns the ID token issuer.
-	GetIDTokenIssuer(ctx context.Context) string
+	GetIDTokenIssuer(ctx context.Context) (issuer string)
+}
+
+// IntrospectionIssuerProvider returns the provider for configuring the Introspection issuer.
+type IntrospectionIssuerProvider interface {
+	// GetIntrospectionIssuer returns the Introspection token issuer.
+	GetIntrospectionIssuer(ctx context.Context) (issuer string)
+}
+
+// IntrospectionJWTResponseSignerProvider returns the provider for configuring the Introspection signer.
+type IntrospectionJWTResponseSignerProvider interface {
+	// GetIntrospectionJWTResponseSigner returns the Introspection JWT signer.
+	GetIntrospectionJWTResponseSigner(ctx context.Context) jwt.Signer
 }
 
 // AuthorizationServerIssuerIdentificationProvider provides OAuth 2.0 Authorization Server Issuer Identification related methods.

--- a/config_default.go
+++ b/config_default.go
@@ -51,6 +51,12 @@ type Config struct {
 	// 	AuthorizationServerIdentificationIssuer string sets the issuer identifier for authorization responses (RFC9207).
 	AuthorizationServerIdentificationIssuer string
 
+	// IntrospectionIssuer is the issuer to be used when generating signed introspection responses.
+	IntrospectionIssuer string
+
+	// IntrospectionJWTResponseSigner is the signer for Introspection Responses. Has no default.
+	IntrospectionJWTResponseSigner jwt.Signer
+
 	// HashCost sets the cost of the password hashing cost. Defaults to 12.
 	HashCost int
 
@@ -148,7 +154,8 @@ type Config struct {
 	// FormPostHTMLTemplate sets html template for rendering the authorization response when the request has response_mode=form_post.
 	FormPostHTMLTemplate *template.Template
 
-	//
+	// FormPostResponseWriter is the FormPostResponseWriter used for writing the form post response. Useful for
+	// overwriting the behaviour of this element.
 	FormPostResponseWriter FormPostResponseWriter
 
 	// OmitRedirectScopeParam indicates whether the "scope" parameter should be omitted from the redirect URL.
@@ -320,6 +327,14 @@ func (c *Config) GetIDTokenIssuer(ctx context.Context) string {
 
 func (c *Config) GetAuthorizationServerIdentificationIssuer(ctx context.Context) (issuer string) {
 	return c.AuthorizationServerIdentificationIssuer
+}
+
+func (c *Config) GetIntrospectionIssuer(ctx context.Context) string {
+	return c.IntrospectionIssuer
+}
+
+func (c *Config) GetIntrospectionJWTResponseSigner(ctx context.Context) jwt.Signer {
+	return c.IntrospectionJWTResponseSigner
 }
 
 // GetGrantTypeJWTBearerIssuedDateOptional returns the GrantTypeJWTBearerIssuedDateOptional field.
@@ -650,4 +665,6 @@ var (
 	_ RFC9628DeviceAuthorizeConfigProvider            = (*Config)(nil)
 	_ RFC8628DeviceAuthorizeEndpointHandlersProvider  = (*Config)(nil)
 	_ RFC8628UserAuthorizeEndpointHandlersProvider    = (*Config)(nil)
+	_ IntrospectionIssuerProvider                     = (*Config)(nil)
+	_ IntrospectionJWTResponseSignerProvider          = (*Config)(nil)
 )

--- a/fosite.go
+++ b/fosite.go
@@ -195,6 +195,8 @@ type Configurator interface {
 	RFC8628DeviceAuthorizeEndpointHandlersProvider
 	RFC8628UserAuthorizeEndpointHandlersProvider
 	RFC9628DeviceAuthorizeConfigProvider
+	IntrospectionIssuerProvider
+	IntrospectionJWTResponseSignerProvider
 	UseLegacyErrorFormatProvider
 }
 

--- a/internal/consts/http.go
+++ b/internal/consts/http.go
@@ -10,9 +10,10 @@ const (
 )
 
 const (
-	ContentTypeApplicationURLEncodedForm = "application/x-www-form-urlencoded"
-	ContentTypeApplicationJSON           = "application/json; charset=utf-8"
-	ContentTypeTextHTML                  = "text/html; charset=utf-8"
+	ContentTypeApplicationURLEncodedForm        = "application/x-www-form-urlencoded"
+	ContentTypeApplicationJSON                  = "application/json; charset=utf-8"
+	ContentTypeApplicationTokenIntrospectionJWT = "application/token-introspection+jwt; charset=utf-8"
+	ContentTypeTextHTML                         = "text/html; charset=utf-8"
 )
 
 const (

--- a/internal/consts/jwt.go
+++ b/internal/consts/jwt.go
@@ -13,6 +13,11 @@ const (
 )
 
 const (
-	JSONWebTokenTypeJWT         = "JWT"
-	JSONWebTokenTypeAccessToken = "at+jwt"
+	JSONWebTokenTypeJWT                = "JWT"
+	JSONWebTokenTypeAccessToken        = "at+jwt"
+	JSONWebTokenTypeTokenIntrospection = "token-introspection+jwt"
+)
+
+const (
+	JSONWebTokenAlgNone = valueNone
 )

--- a/introspection_response_writer_test.go
+++ b/introspection_response_writer_test.go
@@ -53,6 +53,8 @@ func TestWriteIntrospectionResponse(t *testing.T) {
 
 	rw := mock.NewMockResponseWriter(c)
 	rw.EXPECT().Write(gomock.Any()).AnyTimes()
+	rw.EXPECT().Header().AnyTimes().Return(http.Header{})
+	rw.EXPECT().WriteHeader(200)
 	provider.WriteIntrospectionResponse(context.Background(), rw, &IntrospectionResponse{
 		AccessRequester: NewAccessRequest(nil),
 	})

--- a/token/jwt/token.go
+++ b/token/jwt/token.go
@@ -31,7 +31,7 @@ type Token struct {
 }
 
 const (
-	SigningMethodNone = jose.SignatureAlgorithm("none")
+	SigningMethodNone = jose.SignatureAlgorithm(consts.JSONWebTokenAlgNone)
 	// This key should be use to correctly sign and verify alg:none JWT tokens
 	UnsafeAllowNoneSignatureType unsafeNoneMagicConstant = "none signing method allowed"
 
@@ -39,12 +39,12 @@ const (
 )
 
 const (
-	JWTHeaderKeyValueType = "typ"
+	JWTHeaderKeyValueType = consts.JSONWebTokenHeaderType
 )
 
 const (
-	JWTHeaderTypeValueJWT            = "JWT"
-	JWTHeaderTypeValueAccessTokenJWT = "at+jwt"
+	JWTHeaderTypeValueJWT            = consts.JSONWebTokenTypeJWT
+	JWTHeaderTypeValueAccessTokenJWT = consts.JSONWebTokenTypeAccessToken
 )
 
 type unsafeNoneMagicConstant string
@@ -119,7 +119,7 @@ func (t *Token) SignedString(k any) (rawToken string, err error) {
 }
 
 func unsignedToken(t *Token) (string, error) {
-	t.Header[consts.JSONWebTokenHeaderAlgorithm] = "none"
+	t.Header[consts.JSONWebTokenHeaderAlgorithm] = consts.JSONWebTokenAlgNone
 	if _, ok := t.Header[string(JWTHeaderType)]; !ok {
 		t.Header[string(JWTHeaderType)] = JWTHeaderTypeValueJWT
 	}
@@ -166,7 +166,7 @@ type Keyfunc func(*Token) (any, error)
 
 // Parse is an overload for ParseCustom which accepts all normal algs including 'none'.
 func Parse(tokenString string, keyFunc Keyfunc) (*Token, error) {
-	return ParseCustom(tokenString, keyFunc, "none", jose.HS256, jose.HS384, jose.HS512, jose.RS256, jose.RS384, jose.RS512, jose.PS256, jose.PS384, jose.PS512, jose.ES256, jose.ES384, jose.ES512)
+	return ParseCustom(tokenString, keyFunc, consts.JSONWebTokenAlgNone, jose.HS256, jose.HS384, jose.HS512, jose.RS256, jose.RS384, jose.RS512, jose.PS256, jose.PS384, jose.PS512, jose.ES256, jose.ES384, jose.ES512)
 }
 
 // ParseCustom parses, validates, and returns a token. The keyFunc will receive the parsed token and should
@@ -177,7 +177,7 @@ func ParseCustom(tokenString string, keyFunc Keyfunc, algs ...jose.SignatureAlgo
 
 // ParseWithClaims is an overload for ParseCustomWithClaims which accepts all normal algs including 'none'.
 func ParseWithClaims(rawToken string, claims MapClaims, keyFunc Keyfunc) (*Token, error) {
-	return ParseCustomWithClaims(rawToken, claims, keyFunc, "none", jose.HS256, jose.HS384, jose.HS512, jose.RS256, jose.RS384, jose.RS512, jose.PS256, jose.PS384, jose.PS512, jose.ES256, jose.ES384, jose.ES512)
+	return ParseCustomWithClaims(rawToken, claims, keyFunc, consts.JSONWebTokenAlgNone, jose.HS256, jose.HS384, jose.HS512, jose.RS256, jose.RS384, jose.RS512, jose.PS256, jose.PS384, jose.PS512, jose.ES256, jose.ES384, jose.ES512)
 }
 
 // ParseCustomWithClaims parses, validates, and returns a token with its respective claims. The keyFunc will receive the parsed token and should

--- a/token/jwt/token_test.go
+++ b/token/jwt/token_test.go
@@ -55,10 +55,10 @@ func TestUnsignedToken(t *testing.T) {
 			parts := strings.Split(rawToken, ".")
 			require.Len(t, parts, 3)
 			require.Empty(t, parts[2])
-			tk, err := jwt.ParseSigned(rawToken, []jose.SignatureAlgorithm{"none", jose.HS256, jose.HS384, jose.HS512, jose.RS256, jose.RS384, jose.RS512, jose.PS256, jose.PS384, jose.PS512, jose.ES256, jose.ES384, jose.ES512})
+			tk, err := jwt.ParseSigned(rawToken, []jose.SignatureAlgorithm{consts.JSONWebTokenAlgNone, jose.HS256, jose.HS384, jose.HS512, jose.RS256, jose.RS384, jose.RS512, jose.PS256, jose.PS384, jose.PS512, jose.ES256, jose.ES384, jose.ES512})
 			require.NoError(t, err)
 			require.Len(t, tk.Headers, 1)
-			require.Equal(t, tc.expectedType, tk.Headers[0].ExtraHeaders[("typ")])
+			require.Equal(t, tc.expectedType, tk.Headers[0].ExtraHeaders[(consts.JSONWebTokenHeaderType)])
 		})
 	}
 }


### PR DESCRIPTION
This implements the Introspection JWT Responses as per https://www.ietf.org/id/draft-ietf-oauth-jwt-introspection-response-12.html and related specifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added support for Introspection JWT Responses, enhancing security and flexibility in handling introspection responses.
- **Refactor**
	- Improved code clarity and consistency by replacing string literals with constants across various components.
- **Documentation**
	- Updated the list of features to include support for Introspection JWT Responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->