### PR TITLE
fix(openid): redirect uri not unchecked implicit/hybrid flows

### DIFF
--- a/access_request_handler.go
+++ b/access_request_handler.go
@@ -53,7 +53,7 @@ func (f *Fosite) NewAccessRequest(ctx context.Context, r *http.Request, session 
 
 	if r.Method != http.MethodPost {
 		return accessRequest, errorsx.WithStack(ErrInvalidRequest.WithHintf("HTTP method is '%s', expected 'POST'.", r.Method))
-	} else if err := r.ParseMultipartForm(1 << 20); err != nil && err != http.ErrNotMultipart {
+	} else if err := r.ParseMultipartForm(1 << 20); err != nil && !errors.Is(err, http.ErrNotMultipart) {
 		return accessRequest, errorsx.WithStack(ErrInvalidRequest.WithHint("Unable to parse HTTP body, make sure to send a properly formatted form request body.").WithWrap(err).WithDebugError(err))
 	} else if len(r.PostForm) == 0 {
 		return accessRequest, errorsx.WithStack(ErrInvalidRequest.WithHint("The POST body can not be empty."))

--- a/handler/openid/flow_explicit_auth.go
+++ b/handler/openid/flow_explicit_auth.go
@@ -46,6 +46,17 @@ func (c *OpenIDConnectExplicitHandler) HandleAuthorizeEndpointRequest(ctx contex
 		return errorsx.WithStack(oauth2.ErrMisconfiguration.WithDebug("The authorization code has not been issued yet, indicating a broken code configuration."))
 	}
 
+	// This ensures that the 'redirect_uri' parameter is present for OpenID Connect 1.0 authorization requests as per:
+	//
+	// Authorization Code Flow - https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
+	// Implicit Flow - https://openid.net/specs/openid-connect-core-1_0.html#ImplicitAuthRequest
+	// Hybrid Flow - https://openid.net/specs/openid-connect-core-1_0.html#HybridAuthRequest
+	//
+	// Note: as per the Hybrid Flow documentation the Hybrid Flow has the same requirements as the Authorization Code Flow.
+	if len(requester.GetRequestForm().Get(consts.FormParameterRedirectURI)) == 0 {
+		return errorsx.WithStack(oauth2.ErrInvalidRequest.WithHint("The 'redirect_uri' parameter is required when using OpenID Connect 1.0."))
+	}
+
 	if err := c.OpenIDConnectRequestValidator.ValidatePrompt(ctx, requester); err != nil {
 		return err
 	}

--- a/handler/openid/flow_hybrid.go
+++ b/handler/openid/flow_hybrid.go
@@ -65,6 +65,17 @@ func (c *OpenIDConnectHybridHandler) HandleAuthorizeEndpointRequest(ctx context.
 		return errorsx.WithStack(oauth2.ErrInsufficientEntropy.WithHintf("Parameter 'nonce' is set but does not satisfy the minimum entropy of %d characters.", c.Config.GetMinParameterEntropy(ctx)))
 	}
 
+	// This ensures that the 'redirect_uri' parameter is present for OpenID Connect 1.0 authorization requests as per:
+	//
+	// Authorization Code Flow - https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
+	// Implicit Flow - https://openid.net/specs/openid-connect-core-1_0.html#ImplicitAuthRequest
+	// Hybrid Flow - https://openid.net/specs/openid-connect-core-1_0.html#HybridAuthRequest
+	//
+	// Note: as per the Hybrid Flow documentation the Hybrid Flow has the same requirements as the Authorization Code Flow.
+	if len(requester.GetRequestForm().Get(consts.FormParameterRedirectURI)) == 0 {
+		return errorsx.WithStack(oauth2.ErrInvalidRequest.WithHint("The 'redirect_uri' parameter is required when using OpenID Connect 1.0."))
+	}
+
 	sess, ok := requester.GetSession().(Session)
 	if !ok {
 		return errorsx.WithStack(ErrInvalidSession)

--- a/handler/openid/flow_implicit_test.go
+++ b/handler/openid/flow_implicit_test.go
@@ -135,7 +135,7 @@ func TestImplicit_HandleAuthorizeEndpointRequest(t *testing.T) {
 		{
 			description: "should not do anything because request requirements are not met",
 			setup: func() OpenIDConnectImplicitHandler {
-				areq.Form = url.Values{consts.FormParameterNonce: {"short"}}
+				areq.Form = url.Values{consts.FormParameterNonce: {"short"}, consts.FormParameterRedirectURI: {"https://example.com"}}
 				areq.ResponseTypes = oauth2.Arguments{consts.ResponseTypeImplicitFlowIDToken}
 				areq.RequestedScope = oauth2.Arguments{consts.ScopeOpenID}
 				areq.Client = &oauth2.DefaultClient{
@@ -150,7 +150,7 @@ func TestImplicit_HandleAuthorizeEndpointRequest(t *testing.T) {
 		{
 			description: "should fail because session not set",
 			setup: func() OpenIDConnectImplicitHandler {
-				areq.Form = url.Values{consts.FormParameterNonce: {"long-enough"}}
+				areq.Form = url.Values{consts.FormParameterNonce: {"long-enough"}, consts.FormParameterRedirectURI: {"https://example.com"}}
 				areq.ResponseTypes = oauth2.Arguments{consts.ResponseTypeImplicitFlowIDToken}
 				areq.RequestedScope = oauth2.Arguments{consts.ScopeOpenID}
 				areq.Client = &oauth2.DefaultClient{
@@ -173,6 +173,7 @@ func TestImplicit_HandleAuthorizeEndpointRequest(t *testing.T) {
 					Subject: "peter",
 				}
 				areq.Form.Add(consts.FormParameterNonce, "some-random-foo-nonce-wow")
+				areq.Form.Add(consts.FormParameterRedirectURI, "https://example.com")
 				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
 			},
 		},
@@ -266,6 +267,14 @@ func TestImplicit_HandleAuthorizeEndpointRequest(t *testing.T) {
 				assert.NotEmpty(t, aresp.GetParameters().Get(consts.FormParameterState))
 				assert.NotEmpty(t, aresp.GetParameters().Get(consts.AccessResponseAccessToken))
 			},
+		},
+		{
+			description: "should fail without redirect_uri",
+			setup: func() OpenIDConnectImplicitHandler {
+				areq.Form.Del("redirect_uri")
+				return makeOpenIDConnectImplicitHandler(4)
+			},
+			expectErr: oauth2.ErrInvalidRequest,
 		},
 	} {
 		t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {

--- a/integration/oidc_explicit_test.go
+++ b/integration/oidc_explicit_test.go
@@ -60,6 +60,30 @@ func TestOpenIDConnectExplicitFlow(t *testing.T) {
 			session:     newIDSession(&jwt.IDTokenClaims{Subject: "peter"}),
 			description: "should fail registered single redirect uri but no redirect uri in request",
 			setup: func(oauthClient *xoauth2.Config) string {
+				oauthClient.Scopes = []string{"openid"}
+				oauthClient.RedirectURL = ""
+
+				return oauthClient.AuthCodeURL("12345678901234567890") + "&nonce=11234123"
+			},
+			authStatusCode: http.StatusBadRequest,
+			expectAuthErr:  `{"error":"invalid_request","error_description":"The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The 'redirect_uri' parameter is required when using OpenID Connect 1.0."}`,
+		},
+		{
+			session:     newIDSession(&jwt.IDTokenClaims{Subject: "peter"}),
+			description: "should fail registered single redirect uri but no redirect uri in request",
+			setup: func(oauthClient *xoauth2.Config) string {
+				oauthClient.Scopes = []string{"openid"}
+				oauthClient.RedirectURL = ""
+
+				return oauthClient.AuthCodeURL("12345678901234567890") + "&nonce=11234123"
+			},
+			authStatusCode: http.StatusBadRequest,
+			expectAuthErr:  `{"error":"invalid_request","error_description":"The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The 'redirect_uri' parameter is required when using OpenID Connect 1.0."}`,
+		},
+		{
+			session:     newIDSession(&jwt.IDTokenClaims{Subject: "peter"}),
+			description: "should fail registered single redirect uri but no redirect uri in request",
+			setup: func(oauthClient *xoauth2.Config) string {
 				oauthClient.Scopes = []string{consts.ScopeOpenID}
 				oauthClient.RedirectURL = ""
 
@@ -77,6 +101,21 @@ func TestOpenIDConnectExplicitFlow(t *testing.T) {
 			},
 			authStatusCode: http.StatusOK,
 			expectTokenErr: "insufficient_entropy",
+		},
+		{
+			session: newIDSession(&jwt.IDTokenClaims{
+				Subject:     "peter",
+				RequestedAt: time.Now().UTC(),
+				AuthTime:    time.Now().Add(time.Second).UTC(),
+			}),
+			description: "should not pass missing redirect uri",
+			setup: func(oauthClient *xoauth2.Config) string {
+				oauthClient.RedirectURL = ""
+				oauthClient.Scopes = []string{"openid"}
+				return oauthClient.AuthCodeURL("12345678901234567890") + "&nonce=1234567890&prompt=login"
+			},
+			expectAuthErr:  `{"error":"invalid_request","error_description":"The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The 'redirect_uri' parameter is required when using OpenID Connect 1.0."}`,
+			authStatusCode: http.StatusBadRequest,
 		},
 		{
 			session:     newIDSession(&jwt.IDTokenClaims{Subject: "peter"}),
@@ -111,6 +150,21 @@ func TestOpenIDConnectExplicitFlow(t *testing.T) {
 			setup: func(oauthClient *xoauth2.Config) string {
 				oauthClient.RedirectURL = ""
 				oauthClient.Scopes = []string{consts.ScopeOpenID}
+				return oauthClient.AuthCodeURL("12345678901234567890") + "&nonce=1234567890&prompt=login"
+			},
+			expectAuthErr:  `{"error":"invalid_request","error_description":"The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The 'redirect_uri' parameter is required when using OpenID Connect 1.0."}`,
+			authStatusCode: http.StatusBadRequest,
+		},
+		{
+			session: newIDSession(&jwt.IDTokenClaims{
+				Subject:     "peter",
+				RequestedAt: time.Now().UTC(),
+				AuthTime:    time.Now().Add(time.Second).UTC(),
+			}),
+			description: "should not pass missing redirect uri",
+			setup: func(oauthClient *xoauth2.Config) string {
+				oauthClient.RedirectURL = ""
+				oauthClient.Scopes = []string{"openid"}
 				return oauthClient.AuthCodeURL("12345678901234567890") + "&nonce=1234567890&prompt=login"
 			},
 			expectAuthErr:  `{"error":"invalid_request","error_description":"The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The 'redirect_uri' parameter is required when using OpenID Connect 1.0."}`,


### PR DESCRIPTION
… flows

This fixes an issue where the Implicit and Hybrid flows may not properly check the existence of a redirect URI.