### PR TITLE
fix(authentication): jwt assertions audience too strict

### DIFF
--- a/client_authentication_test.go
+++ b/client_authentication_test.go
@@ -571,7 +571,7 @@ func TestAuthenticateClient(t *testing.T) {
 			}, keyRSA, "kid-foo")}, "client_assertion_type": []string{consts.ClientAssertionTypeJWTBearer}},
 			r:         new(http.Request),
 			expectErr: ErrInvalidClient,
-			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). Unable to decode 'client_assertion' value for an unknown reason. token has invalid claims: token has invalid audience",
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). Unable to verify the integrity of the 'client_assertion' value. It may have been used before it was issued, may have been used before it's allowed to be used, may have been used after it's expired, or otherwise doesn't meet a particular validation constraint. Unable to validate the 'aud' claim of the 'client_assertion' value 'token-url-1', 'token-url-2' as it doesn't match any of the expected values 'token-url'.",
 		},
 		{
 			name: "ShouldPassWithProperAssertionWhenJWKsAreSetWithinTheClient",
@@ -697,9 +697,9 @@ func TestAuthenticateClient(t *testing.T) {
 			provider := &Fosite{
 				Store: storage.NewMemoryStore(),
 				Config: &Config{
-					JWKSFetcherStrategy: NewDefaultJWKSFetcherStrategy(),
-					TokenURL:            "token-url",
-					HTTPClient:          retryablehttp.NewClient(),
+					JWKSFetcherStrategy:          NewDefaultJWKSFetcherStrategy(),
+					AllowedJWTAssertionAudiences: []string{"token-url"},
+					HTTPClient:                   retryablehttp.NewClient(),
 				},
 			}
 
@@ -764,8 +764,8 @@ func TestAuthenticateClientTwice(t *testing.T) {
 	provider := &Fosite{
 		Store: store,
 		Config: &Config{
-			JWKSFetcherStrategy: NewDefaultJWKSFetcherStrategy(),
-			TokenURL:            "token-url",
+			JWKSFetcherStrategy:          NewDefaultJWKSFetcherStrategy(),
+			AllowedJWTAssertionAudiences: []string{"token-url"},
 		},
 	}
 

--- a/config.go
+++ b/config.go
@@ -300,9 +300,11 @@ type FormPostResponseProvider interface {
 	GetFormPostResponseWriter(ctx context.Context) FormPostResponseWriter
 }
 
-type TokenURLProvider interface {
-	// GetTokenURL returns the token URL.
-	GetTokenURL(ctx context.Context) (url string)
+// AllowedJWTAssertionAudiencesProvider is a provider used in contexts where the permitted audiences for a JWT assertion
+// is required to validate a request.
+type AllowedJWTAssertionAudiencesProvider interface {
+	// GetAllowedJWTAssertionAudiences returns the permitted audience list for JWT Assertions.
+	GetAllowedJWTAssertionAudiences(ctx context.Context) (audiences []string)
 }
 
 // AuthorizeEndpointHandlersProvider returns the provider for configuring the authorize endpoint handlers.

--- a/config_default.go
+++ b/config_default.go
@@ -95,10 +95,10 @@ type Config struct {
 	// AllowedPromptValues sets which OpenID Connect prompt values the server supports. Defaults to []string{"login", "none", "consent", "select_account"}.
 	AllowedPromptValues []string
 
-	// TokenURL is the the URL of the Authorization Server's Token Endpoint. If the authorization server is intended
-	// to be compatible with the private_key_jwt client authentication method (see http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth),
-	// this value MUST be set.
-	TokenURL string
+	// AllowedJWTAssertionAudiences is a list of permitted client assertion audiences. If the authorization server is
+	// intended to be compatible with the client_secret_jwt or private_key_jwt client authentication methods
+	// (see http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth), this value MUST be set.
+	AllowedJWTAssertionAudiences []string
 
 	// JWKSFetcherStrategy is responsible for fetching JSON Web Keys from remote URLs. This is required when the private_key_jwt
 	// client authentication method is used. Defaults to oauth2.DefaultJWKSFetcherStrategy.
@@ -277,8 +277,8 @@ func (c *Config) GetHTTPClient(ctx context.Context) *retryablehttp.Client {
 	return c.HTTPClient
 }
 
-func (c *Config) GetTokenURL(ctx context.Context) string {
-	return c.TokenURL
+func (c *Config) GetAllowedJWTAssertionAudiences(ctx context.Context) []string {
+	return c.AllowedJWTAssertionAudiences
 }
 
 func (c *Config) GetFormPostHTMLTemplate(ctx context.Context) *template.Template {
@@ -652,7 +652,7 @@ var (
 	_ MessageCatalogProvider                          = (*Config)(nil)
 	_ FormPostHTMLTemplateProvider                    = (*Config)(nil)
 	_ FormPostResponseProvider                        = (*Config)(nil)
-	_ TokenURLProvider                                = (*Config)(nil)
+	_ AllowedJWTAssertionAudiencesProvider            = (*Config)(nil)
 	_ HTTPClientProvider                              = (*Config)(nil)
 	_ HMACHashingProvider                             = (*Config)(nil)
 	_ AuthorizeEndpointHandlersProvider               = (*Config)(nil)

--- a/fosite.go
+++ b/fosite.go
@@ -184,7 +184,7 @@ type Configurator interface {
 	MessageCatalogProvider
 	FormPostHTMLTemplateProvider
 	FormPostResponseProvider
-	TokenURLProvider
+	AllowedJWTAssertionAudiencesProvider
 	AuthorizeEndpointHandlersProvider
 	TokenEndpointHandlersProvider
 	TokenIntrospectionHandlersProvider

--- a/handler/rfc7523/handler_test.go
+++ b/handler/rfc7523/handler_test.go
@@ -12,6 +12,7 @@ import (
 	mrand "math/rand"
 	"net/url"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -74,7 +75,7 @@ func (s *AuthorizeJWTGrantRequestHandlerTestSuite) SetupTest() {
 		Config: &oauth2.Config{
 			ScopeStrategy:                        oauth2.HierarchicScopeStrategy,
 			AudienceMatchingStrategy:             oauth2.DefaultAudienceMatchingStrategy,
-			TokenURL:                             "https://www.example.com/token",
+			AllowedJWTAssertionAudiences:         []string{"https://www.example.com/token"},
 			GrantTypeJWTBearerCanSkipClientAuth:  false,
 			GrantTypeJWTBearerIDOptional:         false,
 			GrantTypeJWTBearerIssuedDateOptional: false,
@@ -333,7 +334,7 @@ func (s *AuthorizeJWTGrantRequestHandlerTestSuite) TestNotValidAudienceInAsserti
 	s.Equal(
 		fmt.Sprintf(
 			"The JWT in 'assertion' request parameter MUST contain an 'aud' (audience) claim containing a value '%s' that identifies the authorization server as an intended audience.",
-			s.handler.Config.GetTokenURL(ctx),
+			strings.Join(s.handler.Config.GetAllowedJWTAssertionAudiences(ctx), "', '"),
 		),
 		oauth2.ErrorToRFC6749Error(err).HintField,
 	)
@@ -851,7 +852,7 @@ func (s *AuthorizeJWTGrantPopulateTokenEndpointTestSuite) SetupTest() {
 		Config: &oauth2.Config{
 			ScopeStrategy:                        oauth2.HierarchicScopeStrategy,
 			AudienceMatchingStrategy:             oauth2.DefaultAudienceMatchingStrategy,
-			TokenURL:                             "https://www.example.com/token",
+			AllowedJWTAssertionAudiences:         []string{"https://www.example.com/token"},
 			GrantTypeJWTBearerCanSkipClientAuth:  false,
 			GrantTypeJWTBearerIDOptional:         false,
 			GrantTypeJWTBearerIssuedDateOptional: false,

--- a/integration/authorize_jwt_bearer_required_iat_test.go
+++ b/integration/authorize_jwt_bearer_required_iat_test.go
@@ -90,7 +90,7 @@ func TestAuthorizeJWTBearerRequiredIATSuite(t *testing.T) {
 			GrantTypeJWTBearerCanSkipClientAuth:  true,
 			GrantTypeJWTBearerIDOptional:         true,
 			GrantTypeJWTBearerIssuedDateOptional: false,
-			TokenURL:                             tokenURL,
+			AllowedJWTAssertionAudiences:         []string{tokenURL},
 		},
 		store,
 		jwtStrategy,

--- a/integration/authorize_jwt_bearer_required_jti_test.go
+++ b/integration/authorize_jwt_bearer_required_jti_test.go
@@ -89,7 +89,7 @@ func TestAuthorizeJWTBearerRequiredJtiSuite(t *testing.T) {
 			GrantTypeJWTBearerCanSkipClientAuth:  true,
 			GrantTypeJWTBearerIDOptional:         false,
 			GrantTypeJWTBearerIssuedDateOptional: true,
-			TokenURL:                             tokenURL,
+			AllowedJWTAssertionAudiences:         []string{tokenURL},
 		},
 		store,
 		jwtStrategy,

--- a/integration/authorize_jwt_bearer_test.go
+++ b/integration/authorize_jwt_bearer_test.go
@@ -412,7 +412,7 @@ func TestAuthorizeJWTBearerSuite(t *testing.T) {
 			GrantTypeJWTBearerIDOptional:         true,
 			GrantTypeJWTBearerIssuedDateOptional: true,
 			GrantTypeJWTBearerMaxDuration:        24 * time.Hour,
-			TokenURL:                             tokenURL,
+			AllowedJWTAssertionAudiences:         []string{tokenURL},
 		},
 		store,
 		jwtStrategy,

--- a/integration/introspect_jwt_bearer_token_test.go
+++ b/integration/introspect_jwt_bearer_token_test.go
@@ -233,7 +233,7 @@ func TestIntrospectJWTBearerTokenSuite(t *testing.T) {
 			GrantTypeJWTBearerIDOptional:         true,
 			GrantTypeJWTBearerIssuedDateOptional: true,
 			AccessTokenLifespan:                  time.Hour,
-			TokenURL:                             tokenURL,
+			AllowedJWTAssertionAudiences:         []string{tokenURL},
 		},
 		store,
 		jwtStrategy,


### PR DESCRIPTION
This fixes an issue where all JWT assertions are strictly checked against the Token URL. RFC7523 Section 3 states that the JWT must contain an 'aud' claim that identifies the authorization server and that the token endpoint URL may be used, not that it must be used. RFC9126 clarifies this that it should be the issuer value, and that both the token endpoint URL and pushed authorization request endpoint URL must also be accepted. This fix facilitate this.