### PR TITLE
feat: include grant type error

### DIFF
--- a/access_request_handler.go
+++ b/access_request_handler.go
@@ -105,7 +105,8 @@ func (f *Fosite) NewAccessRequest(ctx context.Context, r *http.Request, session 
 	}
 
 	if !found {
-		return nil, errorsx.WithStack(ErrInvalidRequest)
+		return nil, errorsx.WithStack(ErrInvalidRequest.WithDebugf("The client with id '%s' requested grant type '%s' which is invalid, unknown, not supported, or not configured to be handled.", accessRequest.GetRequestForm().Get(consts.FormParameterClientID), strings.Join(accessRequest.GetGrantTypes(), " ")))
 	}
+
 	return accessRequest, nil
 }

--- a/access_request_handler_test.go
+++ b/access_request_handler_test.go
@@ -46,10 +46,14 @@ func TestNewAccessRequest(t *testing.T) {
 			header: http.Header{},
 			method: "POST",
 			form: url.Values{
+				consts.FormParameterClientID:  {"bar"},
 				consts.FormParameterGrantType: {"foo"},
 			},
+			mock: func(ctx gomock.Matcher, handler *mock.MockTokenEndpointHandler, store *mock.MockStorage, hasher *mock.MockHasher, client *DefaultClient) {
+				store.EXPECT().GetClient(ctx, gomock.Eq("bar")).Return(&DefaultClient{ID: "bar"}, nil)
+			},
 			expectErr:    ErrInvalidRequest,
-			expectStrErr: "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Make sure that the various parameters are correct, be aware of case sensitivity and trim your parameters. Make sure that the client you are using has exactly whitelisted the redirect_uri you specified.",
+			expectStrErr: "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Make sure that the various parameters are correct, be aware of case sensitivity and trim your parameters. Make sure that the client you are using has exactly whitelisted the redirect_uri you specified. The client with id 'bar' requested grant type 'foo' which is invalid, unknown, not supported, or not configured to be handled.",
 		},
 		{
 			name:   "ShouldReturnInvalidRequestWhenEmptyClientID",
@@ -60,7 +64,7 @@ func TestNewAccessRequest(t *testing.T) {
 				consts.FormParameterClientID:  {""},
 			},
 			expectErr:    ErrInvalidRequest,
-			expectStrErr: "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Make sure that the various parameters are correct, be aware of case sensitivity and trim your parameters. Make sure that the client you are using has exactly whitelisted the redirect_uri you specified.",
+			expectStrErr: "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Make sure that the various parameters are correct, be aware of case sensitivity and trim your parameters. Make sure that the client you are using has exactly whitelisted the redirect_uri you specified. The client with id '' requested grant type 'foo' which is invalid, unknown, not supported, or not configured to be handled.",
 		},
 		{
 			name: "ShouldReturnInvalidClientWhenGetClientError",


### PR DESCRIPTION
This includes grant type error information that may be necessary to debug an invalid grant type.