### PR TITLE
fix(jwt): alg none encryption

### DIFF
--- a/handler/rfc7523/handler.go
+++ b/handler/rfc7523/handler.go
@@ -274,7 +274,7 @@ verify:
 
 	if claims.Expiry.Time().Before(time.Now()) {
 		return errorsx.WithStack(oauth2.ErrInvalidGrant.
-			WithHint("The JWT in 'assertion' request parameter expired."),
+			WithHint("The JWT provided in the 'assertion' request parameter is expired."),
 		)
 	}
 

--- a/handler/rfc7523/handler_test.go
+++ b/handler/rfc7523/handler_test.go
@@ -381,7 +381,7 @@ func (s *AuthorizeJWTGrantRequestHandlerTestSuite) TestExpiredAssertion() {
 	s.True(errors.Is(err, oauth2.ErrInvalidGrant))
 	s.EqualError(err, oauth2.ErrInvalidGrant.Error(), "expected error, because assertion expired")
 	s.Equal(
-		"The JWT in 'assertion' request parameter expired.",
+		"The JWT provided in the 'assertion' request parameter is expired.",
 		oauth2.ErrorToRFC6749Error(err).HintField,
 	)
 }

--- a/token/jwt/jwt_strategy.go
+++ b/token/jwt/jwt_strategy.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 
+	"authelia.com/provider/oauth2/internal/consts"
 	"authelia.com/provider/oauth2/x/errorsx"
 )
 
@@ -75,7 +76,7 @@ func (j *DefaultStrategy) Encode(ctx context.Context, claims Claims, opts ...Str
 
 	kid, alg, enc := o.client.GetEncryptionKeyID(), o.client.GetEncryptionAlg(), o.client.GetEncryptionEnc()
 
-	if len(kid)+len(alg) == 0 {
+	if len(kid) == 0 && (alg == "" || alg == consts.JSONWebTokenAlgNone) {
 		return EncodeCompactSigned(ctx, claims, o.headers, keySig)
 	}
 


### PR DESCRIPTION
Fix an issue where if the encryption alg was none and the kid was empty the encoder tried to mint a compact signed token nested in a compact encrypted JWT.