### PR TITLE
feat(oauth2): bypass stateless introspection

### DIFF
--- a/compose/compose_oauth2.go
+++ b/compose/compose_oauth2.go
@@ -6,7 +6,6 @@ package compose
 import (
 	"authelia.com/provider/oauth2"
 	hoauth2 "authelia.com/provider/oauth2/handler/oauth2"
-	"authelia.com/provider/oauth2/token/jwt"
 )
 
 // OAuth2AuthorizeExplicitFactory creates an OAuth2 authorize code grant ("authorize explicit flow") handler and registers
@@ -111,7 +110,7 @@ func OAuth2TokenIntrospectionFactory(config oauth2.Configurator, storage any, st
 // If you need revocation, you can validate JWTs statefully, using the other factories.
 func OAuth2StatelessJWTIntrospectionFactory(config oauth2.Configurator, storage any, strategy any) any {
 	return &hoauth2.StatelessJWTValidator{
-		Strategy: strategy.(jwt.Strategy),
-		Config:   config,
+		StatelessJWTStrategy: strategy.(hoauth2.StatelessJWTStrategy),
+		Config:               config,
 	}
 }

--- a/handler/oauth2/context.go
+++ b/handler/oauth2/context.go
@@ -1,0 +1,9 @@
+package oauth2
+
+type contextKey int
+
+var (
+	// ContextKeySkipStatelessIntrospection is utilzed to communicate skipping StatelessJWTValidator which is useful for
+	// the UserInfo endpoint.
+	ContextKeySkipStatelessIntrospection = contextKey(0)
+)

--- a/handler/oauth2/introspector_jwt_test.go
+++ b/handler/oauth2/introspector_jwt_test.go
@@ -34,7 +34,7 @@ func TestIntrospectJWT(t *testing.T) {
 	}
 
 	validator := &StatelessJWTValidator{
-		Strategy: strategy,
+		StatelessJWTStrategy: strategy,
 		Config: &oauth2.Config{
 			ScopeStrategy: oauth2.HierarchicScopeStrategy,
 		},
@@ -162,7 +162,7 @@ func BenchmarkIntrospectJWT(b *testing.B) {
 	}
 
 	v := &StatelessJWTValidator{
-		Strategy: strategy,
+		StatelessJWTStrategy: strategy,
 	}
 
 	jwt := jwtValidCase(oauth2.AccessToken)

--- a/handler/oauth2/strategy.go
+++ b/handler/oauth2/strategy.go
@@ -34,31 +34,76 @@ type CoreStrategy interface {
 }
 
 type AccessTokenStrategy interface {
-	AccessTokenSignature(ctx context.Context, token string) string
+	// IsOpaqueAccessToken returns true if the provided token is possibly an opaque Access Token.
+	//
+	// This function is only effective if the token provided has a deterministic characteristic such as a prefix.
+	IsOpaqueAccessToken(ctx context.Context, token string) (is bool)
+
+	// AccessTokenSignature returns the signature of the provided Access Token.
+	AccessTokenSignature(ctx context.Context, token string) (signature string)
+
+	// GenerateAccessToken generates a new Access Token.
 	GenerateAccessToken(ctx context.Context, requester oauth2.Requester) (token string, signature string, err error)
+
+	// ValidateAccessToken validates the provided Access Token.
 	ValidateAccessToken(ctx context.Context, requester oauth2.Requester, token string) (err error)
 }
 
 type RefreshTokenStrategy interface {
-	RefreshTokenSignature(ctx context.Context, token string) string
+	// IsOpaqueRefreshToken returns true if the provided token is possibly an opaque Refresh Token.
+	//
+	// This function is only effective if the token provided has a deterministic characteristic such as a prefix.
+	IsOpaqueRefreshToken(ctx context.Context, token string) (is bool)
+
+	// RefreshTokenSignature returns the signature of the provided Refresh Token.
+	RefreshTokenSignature(ctx context.Context, token string) (signature string)
+
+	// GenerateRefreshToken generates a new Refresh Token.
 	GenerateRefreshToken(ctx context.Context, requester oauth2.Requester) (token string, signature string, err error)
+
+	// ValidateRefreshToken validates the provided Refresh Token.
 	ValidateRefreshToken(ctx context.Context, requester oauth2.Requester, token string) (err error)
 }
 
 type AuthorizeCodeStrategy interface {
-	AuthorizeCodeSignature(ctx context.Context, token string) string
+	// IsOpaqueAuthorizeCode returns true if the provided token is possibly an opaque Authorize Code.
+	//
+	// This function is only effective if the token provided has a deterministic characteristic such as a prefix.
+	IsOpaqueAuthorizeCode(ctx context.Context, token string) bool
+
+	// AuthorizeCodeSignature returns the signature of the provided Authorize Code.
+	AuthorizeCodeSignature(ctx context.Context, token string) (signature string)
+
+	// GenerateAuthorizeCode generates a new Authorize Code.
 	GenerateAuthorizeCode(ctx context.Context, requester oauth2.Requester) (token string, signature string, err error)
+
+	// ValidateAuthorizeCode validates the provided Authorize Code.
 	ValidateAuthorizeCode(ctx context.Context, requester oauth2.Requester, token string) (err error)
 }
 
 type DeviceCodeStrategy interface {
+	// IsOpaqueRFC8628DeviceCode returns true if the provided token is possibly an opaque RFC8628 Device Code.
+	//
+	// This function is only effective if the token provided has a deterministic characteristic such as a prefix.
+	IsOpaqueRFC8628DeviceCode(ctx context.Context, token string) (is bool)
+
+	// RFC8628DeviceCodeSignature returns the signature of the provided RFC8628 Device Code.
 	RFC8628DeviceCodeSignature(ctx context.Context, code string) (signature string, err error)
+
+	// GenerateRFC8628DeviceCode generates a new RFC8628 Device Code.
 	GenerateRFC8628DeviceCode(ctx context.Context) (code string, signature string, err error)
+
+	// ValidateRFC8628DeviceCode validates the provided RFC8628 Device Code.
 	ValidateRFC8628DeviceCode(ctx context.Context, r oauth2.Requester, code string) (err error)
 }
 
 type UserCodeStrategy interface {
+	// RFC8628UserCodeSignature returns the signature of the provided RFC8628 User Code.
 	RFC8628UserCodeSignature(ctx context.Context, code string) (signature string, err error)
+
+	// GenerateRFC8628UserCode generates a new RFC8628 User Code.
 	GenerateRFC8628UserCode(ctx context.Context) (code string, signature string, err error)
+
+	// ValidateRFC8628UserCode validates the provided RFC8628 User Code.
 	ValidateRFC8628UserCode(ctx context.Context, r oauth2.Requester, code string) (err error)
 }

--- a/handler/oauth2/strategy_hmac.go
+++ b/handler/oauth2/strategy_hmac.go
@@ -45,6 +45,11 @@ type HMACCoreStrategy struct {
 	prefix    string
 }
 
+// IsOpaqueAccessToken implements oauth2.AccessTokenStrategy.
+func (s *HMACCoreStrategy) IsOpaqueAccessToken(ctx context.Context, tokenString string) bool {
+	return s.usePrefix && s.hasPrefix(tokenString, tokenPrefixPartAccessToken)
+}
+
 // AccessTokenSignature implements oauth2.AccessTokenStrategy.
 func (s *HMACCoreStrategy) AccessTokenSignature(ctx context.Context, tokenString string) (signature string) {
 	return s.Enigma.Signature(tokenString)
@@ -72,6 +77,11 @@ func (s *HMACCoreStrategy) ValidateAccessToken(ctx context.Context, r oauth2.Req
 	}
 
 	return s.Enigma.Validate(ctx, s.trimPrefix(tokenString, tokenPrefixPartAccessToken))
+}
+
+// IsOpaqueRefreshToken implements oauth2.RefreshTokenStrategy.
+func (s *HMACCoreStrategy) IsOpaqueRefreshToken(ctx context.Context, tokenString string) bool {
+	return s.usePrefix && s.hasPrefix(tokenString, tokenPrefixPartRefreshToken)
 }
 
 // RefreshTokenSignature implements oauth2.RefreshTokenStrategy.
@@ -103,9 +113,14 @@ func (s *HMACCoreStrategy) ValidateRefreshToken(ctx context.Context, r oauth2.Re
 	return s.Enigma.Validate(ctx, s.trimPrefix(tokenString, tokenPrefixPartRefreshToken))
 }
 
+// IsOpaqueAuthorizeCode implements oauth2.AuthorizeCodeStrategy.
+func (s *HMACCoreStrategy) IsOpaqueAuthorizeCode(ctx context.Context, tokenString string) bool {
+	return s.usePrefix && s.hasPrefix(tokenString, tokenPrefixPartAuthorizeCode)
+}
+
 // AuthorizeCodeSignature implements oauth2.AuthorizeCodeStrategy.
-func (s *HMACCoreStrategy) AuthorizeCodeSignature(ctx context.Context, token string) string {
-	return s.Enigma.Signature(token)
+func (s *HMACCoreStrategy) AuthorizeCodeSignature(ctx context.Context, tokenString string) string {
+	return s.Enigma.Signature(tokenString)
 }
 
 // GenerateAuthorizeCode implements oauth2.AuthorizeCodeStrategy.
@@ -166,6 +181,11 @@ func (s *HMACCoreStrategy) ValidateRFC8628UserCode(ctx context.Context, r oauth2
 	}
 
 	return nil
+}
+
+// IsOpaqueRFC8628DeviceCode implements rfc8628.DeviceCodeStrategy.
+func (s *HMACCoreStrategy) IsOpaqueRFC8628DeviceCode(ctx context.Context, tokenString string) bool {
+	return s.usePrefix && s.hasPrefix(tokenString, tokenPrefixPartDeviceCode)
 }
 
 // RFC8628DeviceCodeSignature implements rfc8628.DeviceCodeStrategy.

--- a/handler/oauth2/strategy_jwt_profile.go
+++ b/handler/oauth2/strategy_jwt_profile.go
@@ -28,6 +28,10 @@ type JWTProfileCoreStrategy struct {
 	}
 }
 
+func (s *JWTProfileCoreStrategy) IsOpaqueAccessToken(ctx context.Context, tokenString string) bool {
+	return s.HMACCoreStrategy.IsOpaqueAccessToken(ctx, tokenString)
+}
+
 func (s *JWTProfileCoreStrategy) AccessTokenSignature(ctx context.Context, tokenString string) (signature string) {
 	var possible bool
 
@@ -65,12 +69,12 @@ func (s *JWTProfileCoreStrategy) ValidateAccessToken(ctx context.Context, reques
 	return s.HMACCoreStrategy.ValidateAccessToken(ctx, requester, tokenString)
 }
 
-func (s *JWTProfileCoreStrategy) RefreshTokenSignature(ctx context.Context, tokenString string) string {
-	return s.HMACCoreStrategy.RefreshTokenSignature(ctx, tokenString)
+func (s *JWTProfileCoreStrategy) IsOpaqueRefreshToken(ctx context.Context, tokenString string) bool {
+	return s.HMACCoreStrategy.IsOpaqueRefreshToken(ctx, tokenString)
 }
 
-func (s *JWTProfileCoreStrategy) AuthorizeCodeSignature(ctx context.Context, tokenString string) string {
-	return s.HMACCoreStrategy.AuthorizeCodeSignature(ctx, tokenString)
+func (s *JWTProfileCoreStrategy) RefreshTokenSignature(ctx context.Context, tokenString string) string {
+	return s.HMACCoreStrategy.RefreshTokenSignature(ctx, tokenString)
 }
 
 func (s *JWTProfileCoreStrategy) GenerateRefreshToken(ctx context.Context, req oauth2.Requester) (tokenString string, signature string, err error) {
@@ -79,6 +83,14 @@ func (s *JWTProfileCoreStrategy) GenerateRefreshToken(ctx context.Context, req o
 
 func (s *JWTProfileCoreStrategy) ValidateRefreshToken(ctx context.Context, req oauth2.Requester, tokenString string) (err error) {
 	return s.HMACCoreStrategy.ValidateRefreshToken(ctx, req, tokenString)
+}
+
+func (s *JWTProfileCoreStrategy) AuthorizeCodeSignature(ctx context.Context, tokenString string) string {
+	return s.HMACCoreStrategy.AuthorizeCodeSignature(ctx, tokenString)
+}
+
+func (s *JWTProfileCoreStrategy) IsOpaqueAuthorizeCode(ctx context.Context, tokenString string) bool {
+	return s.HMACCoreStrategy.IsOpaqueAuthorizeCode(ctx, tokenString)
 }
 
 func (s *JWTProfileCoreStrategy) GenerateAuthorizeCode(ctx context.Context, req oauth2.Requester) (tokenString string, signature string, err error) {
@@ -99,6 +111,10 @@ func (s *JWTProfileCoreStrategy) GenerateRFC8628UserCode(ctx context.Context) (t
 
 func (s *JWTProfileCoreStrategy) ValidateRFC8628UserCode(ctx context.Context, r oauth2.Requester, tokenString string) (err error) {
 	return s.HMACCoreStrategy.ValidateRFC8628UserCode(ctx, r, tokenString)
+}
+
+func (s *JWTProfileCoreStrategy) IsOpaqueRFC8628DeviceCode(ctx context.Context, tokenString string) bool {
+	return s.HMACCoreStrategy.IsOpaqueRFC8628DeviceCode(ctx, tokenString)
 }
 
 func (s *JWTProfileCoreStrategy) RFC8628DeviceCodeSignature(ctx context.Context, tokenString string) (signature string, err error) {

--- a/testing/mock/access_token_strategy.go
+++ b/testing/mock/access_token_strategy.go
@@ -71,6 +71,20 @@ func (mr *MockAccessTokenStrategyMockRecorder) GenerateAccessToken(ctx, requeste
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateAccessToken", reflect.TypeOf((*MockAccessTokenStrategy)(nil).GenerateAccessToken), ctx, requester)
 }
 
+// IsOpaqueAccessToken mocks base method.
+func (m *MockAccessTokenStrategy) IsOpaqueAccessToken(ctx context.Context, token string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsOpaqueAccessToken", ctx, token)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsOpaqueAccessToken indicates an expected call of IsOpaqueAccessToken.
+func (mr *MockAccessTokenStrategyMockRecorder) IsOpaqueAccessToken(ctx, token any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOpaqueAccessToken", reflect.TypeOf((*MockAccessTokenStrategy)(nil).IsOpaqueAccessToken), ctx, token)
+}
+
 // ValidateAccessToken mocks base method.
 func (m *MockAccessTokenStrategy) ValidateAccessToken(ctx context.Context, requester oauth2.Requester, token string) error {
 	m.ctrl.T.Helper()

--- a/testing/mock/authorize_code_strategy.go
+++ b/testing/mock/authorize_code_strategy.go
@@ -71,6 +71,20 @@ func (mr *MockAuthorizeCodeStrategyMockRecorder) GenerateAuthorizeCode(ctx, requ
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateAuthorizeCode", reflect.TypeOf((*MockAuthorizeCodeStrategy)(nil).GenerateAuthorizeCode), ctx, requester)
 }
 
+// IsOpaqueAuthorizeCode mocks base method.
+func (m *MockAuthorizeCodeStrategy) IsOpaqueAuthorizeCode(ctx context.Context, token string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsOpaqueAuthorizeCode", ctx, token)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsOpaqueAuthorizeCode indicates an expected call of IsOpaqueAuthorizeCode.
+func (mr *MockAuthorizeCodeStrategyMockRecorder) IsOpaqueAuthorizeCode(ctx, token any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOpaqueAuthorizeCode", reflect.TypeOf((*MockAuthorizeCodeStrategy)(nil).IsOpaqueAuthorizeCode), ctx, token)
+}
+
 // ValidateAuthorizeCode mocks base method.
 func (m *MockAuthorizeCodeStrategy) ValidateAuthorizeCode(ctx context.Context, requester oauth2.Requester, token string) error {
 	m.ctrl.T.Helper()

--- a/testing/mock/oauth2_strategy.go
+++ b/testing/mock/oauth2_strategy.go
@@ -149,6 +149,62 @@ func (mr *MockCoreStrategyMockRecorder) GenerateRefreshToken(ctx, requester any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateRefreshToken", reflect.TypeOf((*MockCoreStrategy)(nil).GenerateRefreshToken), ctx, requester)
 }
 
+// IsOpaqueAccessToken mocks base method.
+func (m *MockCoreStrategy) IsOpaqueAccessToken(ctx context.Context, token string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsOpaqueAccessToken", ctx, token)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsOpaqueAccessToken indicates an expected call of IsOpaqueAccessToken.
+func (mr *MockCoreStrategyMockRecorder) IsOpaqueAccessToken(ctx, token any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOpaqueAccessToken", reflect.TypeOf((*MockCoreStrategy)(nil).IsOpaqueAccessToken), ctx, token)
+}
+
+// IsOpaqueAuthorizeCode mocks base method.
+func (m *MockCoreStrategy) IsOpaqueAuthorizeCode(ctx context.Context, token string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsOpaqueAuthorizeCode", ctx, token)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsOpaqueAuthorizeCode indicates an expected call of IsOpaqueAuthorizeCode.
+func (mr *MockCoreStrategyMockRecorder) IsOpaqueAuthorizeCode(ctx, token any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOpaqueAuthorizeCode", reflect.TypeOf((*MockCoreStrategy)(nil).IsOpaqueAuthorizeCode), ctx, token)
+}
+
+// IsOpaqueRFC8628DeviceCode mocks base method.
+func (m *MockCoreStrategy) IsOpaqueRFC8628DeviceCode(ctx context.Context, token string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsOpaqueRFC8628DeviceCode", ctx, token)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsOpaqueRFC8628DeviceCode indicates an expected call of IsOpaqueRFC8628DeviceCode.
+func (mr *MockCoreStrategyMockRecorder) IsOpaqueRFC8628DeviceCode(ctx, token any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOpaqueRFC8628DeviceCode", reflect.TypeOf((*MockCoreStrategy)(nil).IsOpaqueRFC8628DeviceCode), ctx, token)
+}
+
+// IsOpaqueRefreshToken mocks base method.
+func (m *MockCoreStrategy) IsOpaqueRefreshToken(ctx context.Context, token string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsOpaqueRefreshToken", ctx, token)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsOpaqueRefreshToken indicates an expected call of IsOpaqueRefreshToken.
+func (mr *MockCoreStrategyMockRecorder) IsOpaqueRefreshToken(ctx, token any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOpaqueRefreshToken", reflect.TypeOf((*MockCoreStrategy)(nil).IsOpaqueRefreshToken), ctx, token)
+}
+
 // RFC8628DeviceCodeSignature mocks base method.
 func (m *MockCoreStrategy) RFC8628DeviceCodeSignature(ctx context.Context, code string) (string, error) {
 	m.ctrl.T.Helper()

--- a/testing/mock/refresh_token_strategy.go
+++ b/testing/mock/refresh_token_strategy.go
@@ -57,6 +57,20 @@ func (mr *MockRefreshTokenStrategyMockRecorder) GenerateRefreshToken(ctx, reques
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateRefreshToken", reflect.TypeOf((*MockRefreshTokenStrategy)(nil).GenerateRefreshToken), ctx, requester)
 }
 
+// IsOpaqueRefreshToken mocks base method.
+func (m *MockRefreshTokenStrategy) IsOpaqueRefreshToken(ctx context.Context, token string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsOpaqueRefreshToken", ctx, token)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsOpaqueRefreshToken indicates an expected call of IsOpaqueRefreshToken.
+func (mr *MockRefreshTokenStrategyMockRecorder) IsOpaqueRefreshToken(ctx, token any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOpaqueRefreshToken", reflect.TypeOf((*MockRefreshTokenStrategy)(nil).IsOpaqueRefreshToken), ctx, token)
+}
+
 // RefreshTokenSignature mocks base method.
 func (m *MockRefreshTokenStrategy) RefreshTokenSignature(ctx context.Context, token string) string {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This allows using the context values to bypass stateless introspection and ensures tokens which are likely opaque are also skipped.