### PR TITLE
fix(flow): device code grant type lifespan

### DIFF
--- a/client_with_custom_token_lifespans.go
+++ b/client_with_custom_token_lifespans.go
@@ -12,6 +12,7 @@ func GetEffectiveLifespan(c Client, gt GrantType, tt TokenType, fallback time.Du
 	if clc, ok := c.(CustomTokenLifespansClient); ok {
 		return clc.GetEffectiveLifespan(gt, tt, fallback)
 	}
+
 	return fallback
 }
 
@@ -33,6 +34,9 @@ type ClientLifespanConfig struct {
 	AuthorizationCodeGrantAccessTokenLifespan  *time.Duration `json:"authorization_code_grant_access_token_lifespan"`
 	AuthorizationCodeGrantIDTokenLifespan      *time.Duration `json:"authorization_code_grant_id_token_lifespan"`
 	AuthorizationCodeGrantRefreshTokenLifespan *time.Duration `json:"authorization_code_grant_refresh_token_lifespan"`
+	DeviceCodeGrantAccessTokenLifespan         *time.Duration `json:"device_code_grant_access_token_lifespan"`
+	DeviceCodeGrantIDTokenLifespan             *time.Duration `json:"device_code_grant_id_token_lifespan"`
+	DeviceCodeGrantRefreshTokenLifespan        *time.Duration `json:"device_code_grant_refresh_token_lifespan"`
 	ClientCredentialsGrantAccessTokenLifespan  *time.Duration `json:"client_credentials_grant_access_token_lifespan"`
 	ImplicitGrantAccessTokenLifespan           *time.Duration `json:"implicit_grant_access_token_lifespan"`
 	ImplicitGrantIDTokenLifespan               *time.Duration `json:"implicit_grant_id_token_lifespan"`
@@ -74,10 +78,19 @@ func (c *DefaultClientWithCustomTokenLifespans) GetEffectiveLifespan(gt GrantTyp
 		switch tt {
 		case AccessToken:
 			cl = c.TokenLifespans.AuthorizationCodeGrantAccessTokenLifespan
-		case IDToken:
-			cl = c.TokenLifespans.AuthorizationCodeGrantIDTokenLifespan
 		case RefreshToken:
 			cl = c.TokenLifespans.AuthorizationCodeGrantRefreshTokenLifespan
+		case IDToken:
+			cl = c.TokenLifespans.AuthorizationCodeGrantIDTokenLifespan
+		}
+	case GrantTypeDeviceCode:
+		switch tt {
+		case AccessToken:
+			cl = c.TokenLifespans.DeviceCodeGrantAccessTokenLifespan
+		case RefreshToken:
+			cl = c.TokenLifespans.DeviceCodeGrantRefreshTokenLifespan
+		case IDToken:
+			cl = c.TokenLifespans.DeviceCodeGrantIDTokenLifespan
 		}
 	case GrantTypeClientCredentials:
 		if tt == AccessToken {
@@ -105,10 +118,10 @@ func (c *DefaultClientWithCustomTokenLifespans) GetEffectiveLifespan(gt GrantTyp
 		switch tt {
 		case AccessToken:
 			cl = c.TokenLifespans.RefreshTokenGrantAccessTokenLifespan
-		case IDToken:
-			cl = c.TokenLifespans.RefreshTokenGrantIDTokenLifespan
 		case RefreshToken:
 			cl = c.TokenLifespans.RefreshTokenGrantRefreshTokenLifespan
+		case IDToken:
+			cl = c.TokenLifespans.RefreshTokenGrantIDTokenLifespan
 		}
 	}
 

--- a/handler/openid/flow_device_authorization.go
+++ b/handler/openid/flow_device_authorization.go
@@ -85,13 +85,14 @@ func (c *OpenIDConnectDeviceAuthorizeHandler) PopulateTokenEndpointResponse(ctx 
 	}
 
 	claims := session.IDTokenClaims()
+
 	if claims.Subject == "" {
 		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate id token because subject is an empty string."))
 	}
 
 	claims.AccessTokenHash = c.GetAccessTokenHash(ctx, requester, responder)
 
-	lifespan := oauth2.GetEffectiveLifespan(requester.GetClient(), oauth2.GrantTypeAuthorizationCode, oauth2.IDToken, c.Config.GetIDTokenLifespan(ctx))
+	lifespan := oauth2.GetEffectiveLifespan(requester.GetClient(), oauth2.GrantTypeDeviceCode, oauth2.IDToken, c.Config.GetIDTokenLifespan(ctx))
 
 	return c.IssueExplicitIDToken(ctx, lifespan, ar, responder)
 }

--- a/handler/openid/flow_explicit_auth_test.go
+++ b/handler/openid/flow_explicit_auth_test.go
@@ -91,7 +91,7 @@ func TestExplicit_HandleAuthorizeEndpointRequest(t *testing.T) {
 		{
 			description: "should fail because redirect url is missing",
 			setup: func() OpenIDConnectExplicitHandler {
-				areq.Form.Del("redirect_uri")
+				areq.Form.Del(consts.FormParameterRedirectURI)
 				h, store := makeOpenIDConnectExplicitHandler(ctrl, oauth2.MinParameterEntropy)
 				store.EXPECT().CreateOpenIDConnectSession(gomock.Any(), "codeexample", gomock.Eq(areq.Sanitize(oidcParameters))).AnyTimes().Return(nil)
 				return h

--- a/handler/openid/flow_explicit_token.go
+++ b/handler/openid/flow_explicit_token.go
@@ -62,8 +62,9 @@ func (c *OpenIDConnectExplicitHandler) PopulateTokenEndpointResponse(ctx context
 	// 	return errorsx.WithStack(oauth2.ErrInvalidGrant.WithDebug("The client is not allowed to use response type id_token"))
 	// }
 
-	idTokenLifespan := oauth2.GetEffectiveLifespan(requester.GetClient(), oauth2.GrantTypeAuthorizationCode, oauth2.IDToken, c.Config.GetIDTokenLifespan(ctx))
-	return c.IssueExplicitIDToken(ctx, idTokenLifespan, authorize, responder)
+	lifespan := oauth2.GetEffectiveLifespan(requester.GetClient(), oauth2.GrantTypeAuthorizationCode, oauth2.IDToken, c.Config.GetIDTokenLifespan(ctx))
+
+	return c.IssueExplicitIDToken(ctx, lifespan, authorize, responder)
 }
 
 func (c *OpenIDConnectExplicitHandler) CanSkipClientAuth(ctx context.Context, requester oauth2.AccessRequester) bool {

--- a/handler/openid/flow_hybrid.go
+++ b/handler/openid/flow_hybrid.go
@@ -184,15 +184,16 @@ func (c *OpenIDConnectHybridHandler) HandleAuthorizeEndpointRequest(ctx context.
 		return nil
 	}
 
-	// Hybrid flow uses implicit flow config for the id token's lifespan
-	idTokenLifespan := oauth2.GetEffectiveLifespan(requester.GetClient(), oauth2.GrantTypeImplicit, oauth2.IDToken, c.Config.GetIDTokenLifespan(ctx))
-	if err = c.IDTokenHandleHelper.IssueImplicitIDToken(ctx, idTokenLifespan, requester, responder); err != nil {
+	// Hybrid flow uses implicit flow config for the ID Token's lifespan.
+	lifespan := oauth2.GetEffectiveLifespan(requester.GetClient(), oauth2.GrantTypeImplicit, oauth2.IDToken, c.Config.GetIDTokenLifespan(ctx))
+
+	if err = c.IDTokenHandleHelper.IssueImplicitIDToken(ctx, lifespan, requester, responder); err != nil {
 		return errorsx.WithStack(err)
 	}
 
 	requester.SetResponseTypeHandled(consts.ResponseTypeImplicitFlowIDToken)
 
-	// there is no need to check for https, because implicit flow does not require https
-	// https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.2
+	// There is no need to check for https, because implicit flow does not require https,
+	// See: https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.2
 	return nil
 }

--- a/handler/openid/flow_implicit.go
+++ b/handler/openid/flow_implicit.go
@@ -102,15 +102,15 @@ func (c *OpenIDConnectImplicitHandler) HandleAuthorizeEndpointRequest(ctx contex
 		responder.AddParameter(consts.FormParameterState, requester.GetState())
 	}
 
-	idTokenLifespan := oauth2.GetEffectiveLifespan(requester.GetClient(), oauth2.GrantTypeImplicit, oauth2.IDToken, c.Config.GetIDTokenLifespan(ctx))
-	if err := c.IssueImplicitIDToken(ctx, idTokenLifespan, requester, responder); err != nil {
+	lifespan := oauth2.GetEffectiveLifespan(requester.GetClient(), oauth2.GrantTypeImplicit, oauth2.IDToken, c.Config.GetIDTokenLifespan(ctx))
+
+	if err := c.IssueImplicitIDToken(ctx, lifespan, requester, responder); err != nil {
 		return errorsx.WithStack(err)
 	}
 
-	// there is no need to check for https, because implicit flow does not require https
-	// https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.2
-
 	requester.SetResponseTypeHandled(consts.ResponseTypeImplicitFlowIDToken)
 
+	// There is no need to check for https, because implicit flow does not require https,
+	// See: https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.2
 	return nil
 }

--- a/handler/openid/flow_implicit_test.go
+++ b/handler/openid/flow_implicit_test.go
@@ -268,7 +268,7 @@ func TestImplicit_HandleAuthorizeEndpointRequest(t *testing.T) {
 		{
 			description: "should fail without redirect_uri",
 			setup: func() OpenIDConnectImplicitHandler {
-				areq.Form.Del("redirect_uri")
+				areq.Form.Del(consts.FormParameterRedirectURI)
 				return makeOpenIDConnectImplicitHandler(4)
 			},
 			expectErr: oauth2.ErrInvalidRequest,

--- a/handler/openid/flow_refresh_token.go
+++ b/handler/openid/flow_refresh_token.go
@@ -95,8 +95,9 @@ func (c *OpenIDConnectRefreshHandler) PopulateTokenEndpointResponse(ctx context.
 	claims.CodeHash = ""
 	claims.IssuedAt = jwt.Now()
 
-	idTokenLifespan := oauth2.GetEffectiveLifespan(requester.GetClient(), oauth2.GrantTypeRefreshToken, oauth2.IDToken, c.Config.GetIDTokenLifespan(ctx))
-	return c.IssueExplicitIDToken(ctx, idTokenLifespan, requester, responder)
+	lifespan := oauth2.GetEffectiveLifespan(requester.GetClient(), oauth2.GrantTypeRefreshToken, oauth2.IDToken, c.Config.GetIDTokenLifespan(ctx))
+
+	return c.IssueExplicitIDToken(ctx, lifespan, requester, responder)
 }
 
 func (c *OpenIDConnectRefreshHandler) CanSkipClientAuth(ctx context.Context, requester oauth2.AccessRequester) bool {
@@ -104,7 +105,5 @@ func (c *OpenIDConnectRefreshHandler) CanSkipClientAuth(ctx context.Context, req
 }
 
 func (c *OpenIDConnectRefreshHandler) CanHandleTokenEndpointRequest(ctx context.Context, requester oauth2.AccessRequester) bool {
-	// grant_type REQUIRED.
-	// Value MUST be set to "refresh_token"
 	return requester.GetGrantTypes().ExactOne(consts.GrantTypeRefreshToken)
 }

--- a/handler/rfc8693/access_token_type_handler.go
+++ b/handler/rfc8693/access_token_type_handler.go
@@ -204,5 +204,6 @@ func (c *AccessTokenTypeHandler) getExpiresIn(r oauth2.Requester, key oauth2.Tok
 	if r.GetSession().GetExpiresAt(key).IsZero() {
 		return defaultLifespan
 	}
+
 	return time.Duration(r.GetSession().GetExpiresAt(key).UnixNano() - now.UnixNano())
 }

--- a/pushed_authorize_request_handler_test.go
+++ b/pushed_authorize_request_handler_test.go
@@ -65,7 +65,7 @@ func TestNewPushedAuthorizeRequest(t *testing.T) {
 		{
 			desc:          "invalid redirect uri fails",
 			provider:      provider,
-			query:         url.Values{"redirect_uri": []string{"invalid"}},
+			query:         url.Values{consts.FormParameterRedirectURI: []string{"invalid"}},
 			expectedError: ErrInvalidClient,
 			mock:          func() {},
 		},


### PR DESCRIPTION
This ensures the tokens issued properly match the grant type used for the Device Authorization Flow. Previously the lifespan could potentially be anchored to the Authorization Code Flow instead.