### PR TITLE
fix(openid): delete oidc session during device auth flow

### DIFF
--- a/audience_strategy.go
+++ b/audience_strategy.go
@@ -96,14 +96,14 @@ func GetAudiences(form url.Values) []string {
 }
 
 //nolint:unparam
-func (f *Fosite) validateAuthorizeAudience(ctx context.Context, r *http.Request, request *AuthorizeRequest) error {
-	audience := GetAudiences(request.Form)
+func (f *Fosite) validateAudience(ctx context.Context, r *http.Request, request Requester) error {
+	audience := GetAudiences(request.GetRequestForm())
 
 	if len(audience) == 0 && !request.GetRequestForm().Has(consts.FormParameterAudience) {
-		if client, ok := request.Client.(RequestedAudienceImplicitClient); ok && client.GetRequestedAudienceImplicit() {
+		if client, ok := request.GetClient().(RequestedAudienceImplicitClient); ok && client.GetRequestedAudienceImplicit() {
 			audience = client.GetAudience()
 		}
-	} else if err := f.Config.GetAudienceStrategy(ctx)(request.Client.GetAudience(), audience); err != nil {
+	} else if err := f.Config.GetAudienceStrategy(ctx)(request.GetClient().GetAudience(), audience); err != nil {
 		return err
 	}
 

--- a/authorize_request_handler.go
+++ b/authorize_request_handler.go
@@ -482,7 +482,7 @@ func (f *Fosite) newAuthorizeRequest(ctx context.Context, r *http.Request, isPAR
 		return request, err
 	}
 
-	if err = f.validateAuthorizeAudience(ctx, r, request); err != nil {
+	if err = f.validateAudience(ctx, r, request); err != nil {
 		return request, err
 	}
 

--- a/handler/openid/flow_device_auth.go
+++ b/handler/openid/flow_device_auth.go
@@ -90,6 +90,10 @@ func (c *OpenIDConnectDeviceAuthorizeHandler) PopulateTokenEndpointResponse(ctx 
 		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate id token because subject is an empty string."))
 	}
 
+	if err = c.OpenIDConnectRequestStorage.DeleteOpenIDConnectSession(ctx, signature); err != nil {
+		return errorsx.WithStack(oauth2.ErrServerError.WithWrap(err).WithDebugError(err))
+	}
+
 	claims.AccessTokenHash = c.GetAccessTokenHash(ctx, requester, responder)
 
 	lifespan := oauth2.GetEffectiveLifespan(requester.GetClient(), oauth2.GrantTypeDeviceCode, oauth2.IDToken, c.Config.GetIDTokenLifespan(ctx))

--- a/handler/openid/flow_device_auth_test.go
+++ b/handler/openid/flow_device_auth_test.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"authelia.com/provider/oauth2"
+	"authelia.com/provider/oauth2/internal/consts"
 	"authelia.com/provider/oauth2/testing/mock"
 	"authelia.com/provider/oauth2/token/jwt"
 )
@@ -61,7 +62,7 @@ func TestOpenIDConnectDeviceAuthorizeHandler_PopulateRFC8628UserAuthorizeEndpoin
 		{
 			description: "Success",
 			setup: func() {
-				req.GrantedScope = []string{"openid"}
+				req.GrantedScope = []string{consts.ScopeOpenID}
 				req.Client = &oauth2.DefaultClient{
 					GrantTypes: []string{string(oauth2.GrantTypeDeviceCode), string(oauth2.GrantTypeAuthorizationCode)},
 				}
@@ -78,7 +79,7 @@ func TestOpenIDConnectDeviceAuthorizeHandler_PopulateRFC8628UserAuthorizeEndpoin
 		{
 			description: "Success - client does not support device code grant type",
 			setup: func() {
-				req.GrantedScope = []string{"openid", "foobar"}
+				req.GrantedScope = []string{consts.ScopeOpenID, "foobar"}
 				req.Client = &oauth2.DefaultClient{
 					GrantTypes: []string{string(oauth2.GrantTypeImplicit)},
 				}
@@ -87,7 +88,7 @@ func TestOpenIDConnectDeviceAuthorizeHandler_PopulateRFC8628UserAuthorizeEndpoin
 		{
 			description: "Fail - request does not have device signature",
 			setup: func() {
-				req.GrantedScope = []string{"openid", "foobar"}
+				req.GrantedScope = []string{consts.ScopeOpenID, "foobar"}
 				req.Client = &oauth2.DefaultClient{
 					GrantTypes: []string{string(oauth2.GrantTypeDeviceCode)},
 				}
@@ -98,7 +99,7 @@ func TestOpenIDConnectDeviceAuthorizeHandler_PopulateRFC8628UserAuthorizeEndpoin
 		{
 			description: "Fail - failed to create OIDC session",
 			setup: func() {
-				req.GrantedScope = []string{"openid"}
+				req.GrantedScope = []string{consts.ScopeOpenID}
 				req.Client = &oauth2.DefaultClient{
 					GrantTypes: []string{string(oauth2.GrantTypeDeviceCode), string(oauth2.GrantTypeAuthorizationCode)},
 				}
@@ -176,7 +177,7 @@ func TestOpenIDConnectDeviceAuthorizeHandler_PopulateTokenEndpointResponse(t *te
 				}
 
 				req = oauth2.NewAccessRequest(nil)
-				req.GrantedScope = []string{"openid"}
+				req.GrantedScope = []string{consts.ScopeOpenID}
 				req.GrantTypes = []string{string(oauth2.GrantTypeDeviceCode)}
 				req.Session = sess
 				req.Client = &oauth2.DefaultClient{
@@ -186,18 +187,19 @@ func TestOpenIDConnectDeviceAuthorizeHandler_PopulateTokenEndpointResponse(t *te
 				resp = oauth2.NewAccessResponse()
 
 				authReq = oauth2.NewAuthorizeRequest()
-				authReq.GrantedScope = []string{"openid"}
+				authReq.GrantedScope = []string{consts.ScopeOpenID}
 				authReq.Session = sess
 
 				tokenHandler.EXPECT().DeviceCodeSignature(gomock.Any(), gomock.Any()).Return("foobar", nil)
 				oidcStore.EXPECT().GetOpenIDConnectSession(gomock.Any(), "foobar", req).Return(authReq, nil)
+				oidcStore.EXPECT().DeleteOpenIDConnectSession(gomock.Any(), "foobar").Return(nil)
 			},
 		},
 		{
 			description: "Failed - request has no device code grant type ",
 			setup: func() {
 				req = oauth2.NewAccessRequest(nil)
-				req.GrantedScope = []string{"openid"}
+				req.GrantedScope = []string{consts.ScopeOpenID}
 				req.GrantTypes = []string{string(oauth2.GrantTypeAuthorizationCode)}
 			},
 			expectErr: oauth2.ErrUnknownRequest,
@@ -254,7 +256,7 @@ func TestOpenIDConnectDeviceAuthorizeHandler_PopulateTokenEndpointResponse(t *te
 			description: "Failed - client has no device code grant type",
 			setup: func() {
 				req = oauth2.NewAccessRequest(nil)
-				req.GrantedScope = []string{"openid"}
+				req.GrantedScope = []string{consts.ScopeOpenID}
 				req.GrantTypes = []string{string(oauth2.GrantTypeDeviceCode)}
 				req.Client = &oauth2.DefaultClient{
 					GrantTypes: []string{string(oauth2.GrantTypeAuthorizationCode)},
@@ -263,7 +265,7 @@ func TestOpenIDConnectDeviceAuthorizeHandler_PopulateTokenEndpointResponse(t *te
 				resp = oauth2.NewAccessResponse()
 
 				authReq = oauth2.NewAuthorizeRequest()
-				authReq.GrantedScope = []string{"openid"}
+				authReq.GrantedScope = []string{consts.ScopeOpenID}
 
 				tokenHandler.EXPECT().DeviceCodeSignature(gomock.Any(), gomock.Any()).Return("foobar", nil)
 				oidcStore.EXPECT().GetOpenIDConnectSession(gomock.Any(), "foobar", req).Return(authReq, nil)
@@ -274,7 +276,7 @@ func TestOpenIDConnectDeviceAuthorizeHandler_PopulateTokenEndpointResponse(t *te
 			description: "Failed - no session",
 			setup: func() {
 				req = oauth2.NewAccessRequest(nil)
-				req.GrantedScope = []string{"openid"}
+				req.GrantedScope = []string{consts.ScopeOpenID}
 				req.GrantTypes = []string{string(oauth2.GrantTypeDeviceCode)}
 				req.Session = nil
 				req.Client = &oauth2.DefaultClient{
@@ -284,7 +286,7 @@ func TestOpenIDConnectDeviceAuthorizeHandler_PopulateTokenEndpointResponse(t *te
 				resp = oauth2.NewAccessResponse()
 
 				authReq = oauth2.NewAuthorizeRequest()
-				authReq.GrantedScope = []string{"openid"}
+				authReq.GrantedScope = []string{consts.ScopeOpenID}
 				authReq.Session = nil
 
 				tokenHandler.EXPECT().DeviceCodeSignature(gomock.Any(), gomock.Any()).Return("foobar", nil)
@@ -304,7 +306,7 @@ func TestOpenIDConnectDeviceAuthorizeHandler_PopulateTokenEndpointResponse(t *te
 				}
 
 				req = oauth2.NewAccessRequest(nil)
-				req.GrantedScope = []string{"openid"}
+				req.GrantedScope = []string{consts.ScopeOpenID}
 				req.GrantTypes = []string{string(oauth2.GrantTypeDeviceCode)}
 				req.Session = sess
 				req.Client = &oauth2.DefaultClient{
@@ -314,7 +316,7 @@ func TestOpenIDConnectDeviceAuthorizeHandler_PopulateTokenEndpointResponse(t *te
 				resp = oauth2.NewAccessResponse()
 
 				authReq = oauth2.NewAuthorizeRequest()
-				authReq.GrantedScope = []string{"openid"}
+				authReq.GrantedScope = []string{consts.ScopeOpenID}
 				authReq.Session = sess
 
 				tokenHandler.EXPECT().DeviceCodeSignature(gomock.Any(), gomock.Any()).Return("foobar", nil)


### PR DESCRIPTION
This ensures that the OpenID Connect 1.0 session is properly deleted during the Device Authorization Flow.