### PR TITLE
feat: authorize error field response strategy

### DIFF
--- a/authorize_error.go
+++ b/authorize_error.go
@@ -24,7 +24,11 @@ func (f *Fosite) WriteAuthorizeError(ctx context.Context, rw http.ResponseWriter
 		}
 	}
 
-	f.handleWriteAuthorizeErrorJSON(ctx, rw, ErrServerError.WithHint("The Authorization Server was unable to process the requested Response Mode."))
+	if strategy := f.Config.GetAuthorizeErrorFieldResponseStrategy(ctx); strategy != nil {
+		strategy.WriteErrorFieldResponse(ctx, rw, requester, ErrServerError.WithHint("The Authorization Server was unable to process the requested Response Mode."))
+	} else {
+		f.handleWriteAuthorizeErrorJSON(ctx, rw, ErrServerError.WithHint("The Authorization Server was unable to process the requested Response Mode."))
+	}
 }
 
 func (f *Fosite) handleWriteAuthorizeErrorJSON(ctx context.Context, rw http.ResponseWriter, rfc *RFC6749Error) {
@@ -37,6 +41,37 @@ func (f *Fosite) handleWriteAuthorizeErrorJSON(ctx context.Context, rw http.Resp
 
 	if data, err = json.Marshal(rfc); err != nil {
 		if f.Config.GetSendDebugMessagesToClients(ctx) {
+			errorMessage := EscapeJSONString(err.Error())
+			http.Error(rw, fmt.Sprintf(`{"error":"server_error","error_description":"%s"}`, errorMessage), http.StatusInternalServerError)
+		} else {
+			http.Error(rw, `{"error":"server_error"}`, http.StatusInternalServerError)
+		}
+
+		return
+	}
+
+	rw.WriteHeader(rfc.CodeField)
+	_, _ = rw.Write(data)
+}
+
+type AuthorizeErrorFieldResponseStrategy interface {
+	WriteErrorFieldResponse(ctx context.Context, rw http.ResponseWriter, requester AuthorizeRequester, rfc *RFC6749Error)
+}
+
+type JSONAuthorizeErrorFieldResponseStrategy struct {
+	Config SendDebugMessagesToClientsProvider
+}
+
+func (s *JSONAuthorizeErrorFieldResponseStrategy) WriteErrorFieldResponse(ctx context.Context, rw http.ResponseWriter, requester AuthorizeRequester, rfc *RFC6749Error) {
+	rw.Header().Set(consts.HeaderContentType, consts.ContentTypeApplicationJSON)
+
+	var (
+		data []byte
+		err  error
+	)
+
+	if data, err = json.Marshal(rfc); err != nil {
+		if s.Config.GetSendDebugMessagesToClients(ctx) {
 			errorMessage := EscapeJSONString(err.Error())
 			http.Error(rw, fmt.Sprintf(`{"error":"server_error","error_description":"%s"}`, errorMessage), http.StatusInternalServerError)
 		} else {

--- a/config.go
+++ b/config.go
@@ -398,3 +398,7 @@ type PushedAuthorizeRequestConfigProvider interface {
 	// must contain the PAR request_uri.
 	GetRequirePushedAuthorizationRequests(ctx context.Context) (enforce bool)
 }
+
+type AuthorizeErrorFieldResponseStrategyProvider interface {
+	GetAuthorizeErrorFieldResponseStrategy(ctx context.Context) (strategy AuthorizeErrorFieldResponseStrategy)
+}

--- a/config_default.go
+++ b/config_default.go
@@ -142,6 +142,12 @@ type Config struct {
 	// ClientAuthenticationStrategy indicates the Strategy to authenticate client requests
 	ClientAuthenticationStrategy ClientAuthenticationStrategy
 
+	// AuthorizeErrorFieldResponseStrategy handles authorize error responses when the user can't be redirected in a
+	// normal way for example when the redirect uri is invalid or for any other reason, just writing the fields in some
+	// way to the response. By default this happens as a JSON document but this may also be a redirect to a internal
+	// page as well.
+	AuthorizeErrorFieldResponseStrategy AuthorizeErrorFieldResponseStrategy
+
 	// ResponseModeHandlers provides the handlers for performing response mode formatting.
 	ResponseModeHandlers ResponseModeHandlers
 
@@ -626,7 +632,16 @@ func (c *Config) GetRFC8628TokenPollingInterval(_ context.Context) time.Duration
 	if c.RFC8628TokenPollingInterval == 0 {
 		return time.Second * 10
 	}
+
 	return c.RFC8628TokenPollingInterval
+}
+
+func (c *Config) GetAuthorizeErrorFieldResponseStrategy(ctx context.Context) (strategy AuthorizeErrorFieldResponseStrategy) {
+	if c.AuthorizeErrorFieldResponseStrategy == nil {
+		c.AuthorizeErrorFieldResponseStrategy = &JSONAuthorizeErrorFieldResponseStrategy{Config: c}
+	}
+
+	return c.AuthorizeErrorFieldResponseStrategy
 }
 
 var (
@@ -680,4 +695,5 @@ var (
 	_ RFC8628UserAuthorizeEndpointHandlersProvider    = (*Config)(nil)
 	_ IntrospectionIssuerProvider                     = (*Config)(nil)
 	_ IntrospectionJWTResponseStrategyProvider        = (*Config)(nil)
+	_ AuthorizeErrorFieldResponseStrategyProvider     = (*Config)(nil)
 )

--- a/fosite.go
+++ b/fosite.go
@@ -198,6 +198,7 @@ type Configurator interface {
 	IntrospectionIssuerProvider
 	IntrospectionJWTResponseStrategyProvider
 	JWTStrategyProvider
+	AuthorizeErrorFieldResponseStrategyProvider
 	UseLegacyErrorFormatProvider
 }
 


### PR DESCRIPTION
When the Authorize Error Response can't redirect the user to the application, instead of just writing the field response as JSON, this allows implementers to handle the response in any custom way for example writing a redirect to an internal page that displays the error cleanly.