### PR TITLE
fix: authorize error not using strategy

### DIFF
--- a/authorize_error.go
+++ b/authorize_error.go
@@ -24,14 +24,19 @@ func (f *Fosite) WriteAuthorizeError(ctx context.Context, rw http.ResponseWriter
 		}
 	}
 
+	f.handleWriteAuthorizeErrorFieldResponse(ctx, rw, requester, ErrServerError.WithHint("The Authorization Server was unable to process the requested Response Mode."))
+
+}
+
+func (f *Fosite) handleWriteAuthorizeErrorFieldResponse(ctx context.Context, rw http.ResponseWriter, requester AuthorizeRequester, rfc *RFC6749Error) {
 	if strategy := f.Config.GetAuthorizeErrorFieldResponseStrategy(ctx); strategy != nil {
-		strategy.WriteErrorFieldResponse(ctx, rw, requester, ErrServerError.WithHint("The Authorization Server was unable to process the requested Response Mode."))
+		strategy.WriteErrorFieldResponse(ctx, rw, requester, rfc)
 	} else {
-		f.handleWriteAuthorizeErrorJSON(ctx, rw, ErrServerError.WithHint("The Authorization Server was unable to process the requested Response Mode."))
+		f.handleWriteAuthorizeErrorFieldResponseJSON(ctx, rw, rfc)
 	}
 }
 
-func (f *Fosite) handleWriteAuthorizeErrorJSON(ctx context.Context, rw http.ResponseWriter, rfc *RFC6749Error) {
+func (f *Fosite) handleWriteAuthorizeErrorFieldResponseJSON(ctx context.Context, rw http.ResponseWriter, rfc *RFC6749Error) {
 	rw.Header().Set(consts.HeaderContentType, consts.ContentTypeApplicationJSON)
 
 	var (

--- a/authorize_write.go
+++ b/authorize_write.go
@@ -17,5 +17,5 @@ func (f *Fosite) WriteAuthorizeResponse(ctx context.Context, rw http.ResponseWri
 		}
 	}
 
-	f.handleWriteAuthorizeErrorJSON(ctx, rw, ErrServerError.WithHint("The Authorization Server was unable to process the requested Response Mode."))
+	f.handleWriteAuthorizeErrorFieldResponse(ctx, rw, requester, ErrServerError.WithHint("The Authorization Server was unable to process the requested Response Mode."))
 }


### PR DESCRIPTION
This fixes an issue where the authorize error is not written using the strategy.