### PR TITLE
refactor: rename request object to jar

### DIFF
--- a/authorize_request_handler.go
+++ b/authorize_request_handler.go
@@ -23,7 +23,7 @@ import (
 // TODO: Refactor time permitting.
 //
 //nolint:gocyclo
-func (f *Fosite) authorizeRequestParametersFromOpenIDConnectRequestObject(ctx context.Context, request *AuthorizeRequest, isPARRequest bool) error {
+func (f *Fosite) authorizeRequestParametersFromJAR(ctx context.Context, request *AuthorizeRequest, isPARRequest bool) error {
 	var scope Arguments = RemoveEmpty(strings.Split(request.Form.Get(consts.FormParameterScope), " "))
 
 	openid := scope.Has(consts.ScopeOpenID)
@@ -460,7 +460,7 @@ func (f *Fosite) newAuthorizeRequest(ctx context.Context, r *http.Request, isPAR
 	//
 	// All other parse methods should come afterwards so that we ensure that the data is taken
 	// from the request_object if set.
-	if err = f.authorizeRequestParametersFromOpenIDConnectRequestObject(ctx, request, isPARRequest); err != nil {
+	if err = f.authorizeRequestParametersFromJAR(ctx, request, isPARRequest); err != nil {
 		return request, err
 	}
 

--- a/authorize_request_handler_oidc_request_test.go
+++ b/authorize_request_handler_oidc_request_test.go
@@ -591,7 +591,7 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequestObject(t *testing.T) 
 
 			provider := &Fosite{Config: &Config{JWKSFetcherStrategy: NewDefaultJWKSFetcherStrategy(), IDTokenIssuer: "https://auth.example.com", JWTStrategy: strategy}}
 
-			err = provider.authorizeRequestParametersFromOpenIDConnectRequestObject(context.Background(), r, tc.par)
+			err = provider.authorizeRequestParametersFromJAR(context.Background(), r, tc.par)
 			if tc.err != nil {
 				assert.EqualError(t, err, tc.err.Error())
 				if tc.errString != "" {


### PR DESCRIPTION
Since the introduction of OAuth 2.0 JAR this needs a minor rename to indicate its usage.