### PR TITLE
feat: support unique assertion types

### DIFF
--- a/authorize_request_handler.go
+++ b/authorize_request_handler.go
@@ -131,17 +131,17 @@ func (f *Fosite) authorizeRequestParametersFromJAR(ctx context.Context, request 
 		return errorsx.WithStack(fmtRequestObjectDecodeError(token, client, issuer, openid, err))
 	}
 
-	optsValidHeader := []jwt.HeaderValidationOption{
+	optsHeader := []jwt.HeaderValidationOption{
+		jwt.ValidateTypes(jwt.JSONWebTokenTypeJWTSecuredAuthorizationRequest, jwt.JSONWebTokenTypeJWT),
+		jwt.ValidateAllowEmptyType(true),
 		jwt.ValidateKeyID(client.GetRequestObjectSigningKeyID()),
 		jwt.ValidateAlgorithm(client.GetRequestObjectSigningAlg()),
 		jwt.ValidateEncryptionKeyID(client.GetRequestObjectEncryptionKeyID()),
 		jwt.ValidateKeyAlgorithm(client.GetRequestObjectEncryptionAlg()),
 		jwt.ValidateContentEncryption(client.GetRequestObjectEncryptionEnc()),
-		jwt.ValidateTypes(consts.JSONWebTokenTypeJWT, consts.JSONWebTokenTypeJWTSecuredAuthorizationRequest),
-		jwt.ValidateAllowEmptyType(true),
 	}
 
-	if err = token.Valid(optsValidHeader...); err != nil {
+	if err = token.Valid(optsHeader...); err != nil {
 		return errorsx.WithStack(fmtRequestObjectDecodeError(token, client, issuer, openid, err))
 	}
 

--- a/handler/oauth2/introspector_jwt.go
+++ b/handler/oauth2/introspector_jwt.go
@@ -44,7 +44,7 @@ func (v *StatelessJWTValidator) IntrospectToken(ctx context.Context, tokenString
 		return "", err
 	}
 
-	if err = token.Valid(jwt.ValidateTypes(consts.JSONWebTokenTypeAccessToken, consts.JSONWebTokenTypeAccessTokenAlternative)); err != nil {
+	if err = token.Valid(jwt.ValidateTypes(jwt.JSONWebTokenTypeAccessToken)); err != nil {
 		return "", errorsx.WithStack(oauth2.ErrRequestUnauthorized.WithDebug("The provided token is not a valid RFC9068 JWT Profile Access Token as it is missing the header 'typ' value of 'at+jwt'."))
 	}
 

--- a/handler/oauth2/strategy_jwt_session.go
+++ b/handler/oauth2/strategy_jwt_session.go
@@ -9,7 +9,6 @@ import (
 	"github.com/mohae/deepcopy"
 
 	"authelia.com/provider/oauth2"
-	"authelia.com/provider/oauth2/internal/consts"
 	"authelia.com/provider/oauth2/token/jwt"
 )
 
@@ -43,11 +42,11 @@ func (j *JWTSession) GetJWTHeader() *jwt.Headers {
 	if j.JWTHeader == nil {
 		j.JWTHeader = &jwt.Headers{
 			Extra: map[string]any{
-				consts.JSONWebTokenHeaderType: consts.JSONWebTokenTypeAccessToken,
+				jwt.JSONWebTokenHeaderType: jwt.JSONWebTokenTypeAccessToken,
 			},
 		}
-	} else if j.JWTHeader.Extra[consts.JSONWebTokenHeaderType] == nil {
-		j.JWTHeader.Extra[consts.JSONWebTokenHeaderType] = consts.JSONWebTokenTypeAccessToken
+	} else if j.JWTHeader.Extra[jwt.JSONWebTokenHeaderType] == nil {
+		j.JWTHeader.Extra[jwt.JSONWebTokenHeaderType] = jwt.JSONWebTokenTypeAccessToken
 	}
 
 	return j.JWTHeader

--- a/handler/openid/strategy_jwt.go
+++ b/handler/openid/strategy_jwt.go
@@ -275,7 +275,7 @@ func (h DefaultStrategy) GenerateBackChannelLogoutToken(ctx context.Context, cli
 	token, _, err = h.Encode(
 		ctx,
 		claims.ToMapClaims(),
-		jwt.WithHeaders(&jwt.Headers{Extra: map[string]any{consts.JSONWebTokenHeaderType: consts.JSONWebTokenTypeLogoutToken}}),
+		jwt.WithHeaders(&jwt.Headers{Extra: map[string]any{jwt.JSONWebTokenHeaderType: jwt.JSONWebTokenTypeLogoutToken}}),
 		jwt.WithClient(jwt.NewIDTokenClient(client)),
 	)
 

--- a/handler/openid/validator.go
+++ b/handler/openid/validator.go
@@ -48,7 +48,7 @@ func NewOpenIDConnectRequestValidator(strategy jwt.Strategy, config openIDConnec
 //
 //nolint:gocyclo
 func (v *OpenIDConnectRequestValidator) ValidatePrompt(ctx context.Context, requester oauth2.AuthorizeRequester) error {
-	// Specification Note: prompt is case sensitive.
+	// Specification Note: prompt is case-sensitive.
 	requiredPrompt := oauth2.RemoveEmpty(strings.Split(requester.GetRequestForm().Get(consts.FormParameterPrompt), " "))
 
 	if requester.GetClient().IsPublic() {

--- a/internal/consts/jwt.go
+++ b/internal/consts/jwt.go
@@ -17,12 +17,32 @@ const (
 )
 
 const (
-	JSONWebTokenTypeJWT                            = "JWT"
-	JSONWebTokenTypeAccessToken                    = "at+jwt"
-	JSONWebTokenTypeLogoutToken                    = "logout+jwt"
+	JSONWebTokenTypeJWT = "JWT"
+
+	// JSONWebTokenTypeAccessToken represents the JWT type value for a JWT Profile Access Token.
+	//
+	// See: https://datatracker.ietf.org/doc/html/rfc9068#section-2.1
+	JSONWebTokenTypeAccessToken = "at+jwt"
+
+	// JSONWebTokenTypeLogoutToken represents the JWT type value for OpenID Connect Back-Channel Logout 1.0.
+	//
+	// See: https://openid.net/specs/openid-connect-backchannel-1_0.html#Security
+	JSONWebTokenTypeLogoutToken = "logout+jwt"
+
+	// JSONWebTokenTypeJWTSecuredAuthorizationRequest represents the JWT type value for JWT Secured Authorization Requests.
+	//
+	// See: https://www.rfc-editor.org/rfc/rfc9101.html#section-4
 	JSONWebTokenTypeJWTSecuredAuthorizationRequest = "oauth-authz-req+jwt" //nolint:gosec // This is a credential type, not a credential.
-	JSONWebTokenTypeAccessTokenAlternative         = "application/at+jwt"
-	JSONWebTokenTypeTokenIntrospection             = "token-introspection+jwt"
+
+	// JSONWebTokenTypeClientAuthentication represents the JWT type value for Client Assertions.
+	//
+	// See: https://www.ietf.org/archive/id/draft-ietf-oauth-rfc7523bis-02.html#section-4
+	JSONWebTokenTypeClientAuthentication = "client-authentication+jwt"
+
+	// JSONWebTokenTypeTokenIntrospection represents the JWT type value for a JWT Response for OAuth Token Introspection.
+	//
+	// See: https://www.rfc-editor.org/rfc/rfc9701.html#section-5
+	JSONWebTokenTypeTokenIntrospection = "token-introspection+jwt"
 )
 
 const (

--- a/token/jwt/consts.go
+++ b/token/jwt/consts.go
@@ -86,10 +86,32 @@ const (
 )
 
 const (
-	JSONWebTokenTypeJWT                    = consts.JSONWebTokenTypeJWT
-	JSONWebTokenTypeAccessToken            = consts.JSONWebTokenTypeAccessToken
-	JSONWebTokenTypeAccessTokenAlternative = consts.JSONWebTokenTypeAccessTokenAlternative
-	JSONWebTokenTypeTokenIntrospection     = consts.JSONWebTokenTypeTokenIntrospection
+	JSONWebTokenTypeJWT = consts.JSONWebTokenTypeJWT
+
+	// JSONWebTokenTypeAccessToken represents the JWT type value for a JWT Profile Access Token.
+	//
+	// See: https://datatracker.ietf.org/doc/html/rfc9068#section-2.1
+	JSONWebTokenTypeAccessToken = consts.JSONWebTokenTypeAccessToken
+
+	// JSONWebTokenTypeLogoutToken represents the JWT type value for OpenID Connect Back-Channel Logout 1.0.
+	//
+	// See: https://openid.net/specs/openid-connect-backchannel-1_0.html#Security
+	JSONWebTokenTypeLogoutToken = consts.JSONWebTokenTypeLogoutToken
+
+	// JSONWebTokenTypeJWTSecuredAuthorizationRequest represents the JWT type value for JWT Secured Authorization Requests.
+	//
+	// See: https://www.rfc-editor.org/rfc/rfc9101.html#section-4
+	JSONWebTokenTypeJWTSecuredAuthorizationRequest = consts.JSONWebTokenTypeJWTSecuredAuthorizationRequest
+
+	// JSONWebTokenTypeClientAuthentication represents the JWT type value for Client Assertions.
+	//
+	// See: https://www.ietf.org/archive/id/draft-ietf-oauth-rfc7523bis-02.html#section-4
+	JSONWebTokenTypeClientAuthentication = consts.JSONWebTokenTypeClientAuthentication
+
+	// JSONWebTokenTypeTokenIntrospection represents the JWT type value for a JWT Response for OAuth Token Introspection.
+	//
+	// See: https://www.rfc-editor.org/rfc/rfc9701.html#section-5
+	JSONWebTokenTypeTokenIntrospection = consts.JSONWebTokenTypeTokenIntrospection
 )
 
 const (


### PR DESCRIPTION
This adds support for the soon to be release client-authentication+jwt JSON Web Token Header Type and accompanying application/client-authentication+jwt MIME type. This type is intentional on exclusively being used for client assertions. In addition for the time being it allows client assertions to use a header absent the type.

Fixes #348