### PR TITLE
refactor(openid): redirect uri validation

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -9,9 +9,9 @@
     ":separatePatchReleases"
   ],
   "ignorePresets": [
+    ":combinePatchMinorReleases",
     ":prHourlyLimit2",
-    ":semanticPrefixFixDepsChoreOthers",
-    "workarounds:all"
+    ":semanticPrefixFixDepsChoreOthers"
   ],
   "enabledManagers": [
     "gomod",
@@ -23,5 +23,17 @@
   "postUpdateOptions": [
     "gomodTidy",
     "gomodMassage"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "digest",
+        "minor",
+        "patch"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    }
   ]
 }

--- a/authorize_helper.go
+++ b/authorize_helper.go
@@ -62,13 +62,13 @@ var DefaultFormPostTemplate = template.Must(template.New("form_post").Parse(`<ht
 //     particular end-user authorization and validates this redirect URI
 //     with the redirect URI passed to the token's endpoint, such an
 //     attack is detected (see Section 5.2.4.5).
-func MatchRedirectURIWithClientRedirectURIs(rawurl string, client Client) (*url.URL, error) {
-	if rawurl == "" && len(client.GetRedirectURIs()) == 1 {
+func MatchRedirectURIWithClientRedirectURIs(raw string, client Client) (*url.URL, error) {
+	if raw == "" && len(client.GetRedirectURIs()) == 1 {
 		if redirectURIFromClient, err := url.Parse(client.GetRedirectURIs()[0]); err == nil && IsValidRedirectURI(redirectURIFromClient) {
-			// If no redirect_uri was given and the client has exactly one valid redirect_uri registered, use that instead
+			// If no redirect_uri was given and the client has exactly one valid redirect_uri registered, use that instead.
 			return redirectURIFromClient, nil
 		}
-	} else if redirectTo, ok := IsMatchingRedirectURI(rawurl, client.GetRedirectURIs()); rawurl != "" && ok {
+	} else if redirectTo, ok := IsMatchingRedirectURI(raw, client.GetRedirectURIs()); raw != "" && ok {
 		// If a redirect_uri was given and the clients knows it (simple string comparison!)
 		// return it.
 		if parsed, err := url.Parse(redirectTo); err == nil && IsValidRedirectURI(parsed) {
@@ -77,7 +77,7 @@ func MatchRedirectURIWithClientRedirectURIs(rawurl string, client Client) (*url.
 		}
 	}
 
-	return nil, errorsx.WithStack(ErrInvalidRequest.WithHint("The 'redirect_uri' parameter does not match any of the OAuth 2.0 Client's pre-registered 'redirect_uris'.").WithDebugf("The 'redirect_uris' registered with OAuth 2.0 Client with id '%s' did not match 'redirect_uri' value '%s'.", client.GetID(), rawurl))
+	return nil, errorsx.WithStack(ErrInvalidRequest.WithHint("The 'redirect_uri' parameter does not match any of the OAuth 2.0 Client's pre-registered 'redirect_uris'.").WithDebugf("The 'redirect_uris' registered with OAuth 2.0 Client with id '%s' did not match 'redirect_uri' value '%s'.", client.GetID(), raw))
 }
 
 // IsMatchingRedirectURI matches a requested redirect URI against a pool of registered client URIs.

--- a/errors.go
+++ b/errors.go
@@ -79,7 +79,7 @@ var (
 	}
 	ErrInsufficientScope = &RFC6749Error{
 		ErrorField:       errInsufficientScopeName,
-		DescriptionField: "The request requires higher privileges than provided by the access token.",
+		DescriptionField: "The request requires higher privileges than provided by the Access Token.",
 		CodeField:        http.StatusForbidden,
 	}
 	ErrServerError = &RFC6749Error{

--- a/handler/oauth2/flow_authorize_code_token.go
+++ b/handler/oauth2/flow_authorize_code_token.go
@@ -46,12 +46,12 @@ func (c *AuthorizeExplicitGrantHandler) HandleTokenEndpointRequest(ctx context.C
 
 		// TODO: Refactor this similar to the Revocation Handler. Maybe Factorize?
 		if revErr := c.TokenRevocationStorage.RevokeAccessToken(ctx, reqID); revErr != nil {
-			hint += " Additionally, an error occurred during processing the access token revocation."
+			hint += " Additionally, an error occurred during processing the Access Token revocation."
 			debug += "Revocation of access_token lead to error " + revErr.Error() + "."
 		}
 
 		if revErr := c.TokenRevocationStorage.RevokeRefreshToken(ctx, reqID); revErr != nil {
-			hint += " Additionally, an error occurred during processing the refresh token revocation."
+			hint += " Additionally, an error occurred during processing the Refresh Token revocation."
 			debug += "Revocation of refresh_token lead to error " + revErr.Error() + "."
 		}
 

--- a/handler/oauth2/flow_generic_code_token.go
+++ b/handler/oauth2/flow_generic_code_token.go
@@ -78,11 +78,11 @@ func (c *GenericCodeTokenEndpointHandler) HandleTokenEndpointRequest(ctx context
 		hint := "The authorization code has already been used."
 		debug := ""
 		if revErr := c.TokenRevocationStorage.RevokeAccessToken(ctx, reqID); revErr != nil {
-			hint += " Additionally, an error occurred during processing the access token revocation."
+			hint += " Additionally, an error occurred during processing the Access Token revocation."
 			debug += "Revocation of access_token lead to error " + revErr.Error() + "."
 		}
 		if revErr := c.TokenRevocationStorage.RevokeRefreshToken(ctx, reqID); revErr != nil {
-			hint += " Additionally, an error occurred during processing the refresh token revocation."
+			hint += " Additionally, an error occurred during processing the Refresh Token revocation."
 			debug += "Revocation of refresh_token lead to error " + revErr.Error() + "."
 		}
 		return errorsx.WithStack(oauth2.ErrInvalidGrant.WithHint(hint).WithDebug(debug))

--- a/handler/openid/flow_device_auth.go
+++ b/handler/openid/flow_device_auth.go
@@ -81,13 +81,13 @@ func (c *OpenIDConnectDeviceAuthorizeHandler) PopulateTokenEndpointResponse(ctx 
 	}
 
 	if session, ok = ar.GetSession().(Session); !ok {
-		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate id token because session must be of type 'openid.Session'."))
+		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate ID Token because the session must be of type 'openid.Session'."))
 	}
 
 	claims := session.IDTokenClaims()
 
 	if claims.Subject == "" {
-		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate id token because subject is an empty string."))
+		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate ID Token because subject is an empty string."))
 	}
 
 	if err = c.OpenIDConnectRequestStorage.DeleteOpenIDConnectSession(ctx, signature); err != nil {

--- a/handler/openid/flow_explicit_auth.go
+++ b/handler/openid/flow_explicit_auth.go
@@ -37,7 +37,7 @@ var oidcParameters = []string{
 	consts.FormParameterNonce,
 }
 
-func (c *OpenIDConnectExplicitHandler) HandleAuthorizeEndpointRequest(ctx context.Context, requester oauth2.AuthorizeRequester, responder oauth2.AuthorizeResponder) error {
+func (c *OpenIDConnectExplicitHandler) HandleAuthorizeEndpointRequest(ctx context.Context, requester oauth2.AuthorizeRequester, responder oauth2.AuthorizeResponder) (err error) {
 	if !(requester.GetGrantedScopes().Has(consts.ScopeOpenID) && requester.GetResponseTypes().ExactOne(consts.ResponseTypeAuthorizationCodeFlow)) {
 		return nil
 	}
@@ -46,22 +46,15 @@ func (c *OpenIDConnectExplicitHandler) HandleAuthorizeEndpointRequest(ctx contex
 		return errorsx.WithStack(oauth2.ErrMisconfiguration.WithDebug("The authorization code has not been issued yet, indicating a broken code configuration."))
 	}
 
-	// This ensures that the 'redirect_uri' parameter is present for OpenID Connect 1.0 authorization requests as per:
-	//
-	// Authorization Code Flow - https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
-	// Implicit Flow - https://openid.net/specs/openid-connect-core-1_0.html#ImplicitAuthRequest
-	// Hybrid Flow - https://openid.net/specs/openid-connect-core-1_0.html#HybridAuthRequest
-	//
-	// Note: as per the Hybrid Flow documentation the Hybrid Flow has the same requirements as the Authorization Code Flow.
-	if len(requester.GetRequestForm().Get(consts.FormParameterRedirectURI)) == 0 {
-		return errorsx.WithStack(oauth2.ErrInvalidRequest.WithHint("The 'redirect_uri' parameter is required when using OpenID Connect 1.0."))
-	}
-
-	if err := c.OpenIDConnectRequestValidator.ValidatePrompt(ctx, requester); err != nil {
+	if err = c.OpenIDConnectRequestValidator.ValidateRedirectURIs(ctx, requester); err != nil {
 		return err
 	}
 
-	if err := c.OpenIDConnectRequestStorage.CreateOpenIDConnectSession(ctx, responder.GetCode(), requester.Sanitize(oidcParameters)); err != nil {
+	if _, err = c.OpenIDConnectRequestValidator.ValidatePrompt(ctx, requester); err != nil {
+		return err
+	}
+
+	if err = c.OpenIDConnectRequestStorage.CreateOpenIDConnectSession(ctx, responder.GetCode(), requester.Sanitize(oidcParameters)); err != nil {
 		return errorsx.WithStack(oauth2.ErrServerError.WithWrap(err).WithDebugError(err))
 	}
 

--- a/handler/openid/flow_explicit_auth_test.go
+++ b/handler/openid/flow_explicit_auth_test.go
@@ -4,11 +4,11 @@
 package openid
 
 import (
-	"fmt"
 	"net/url"
 	"testing"
 
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
@@ -20,92 +20,149 @@ import (
 )
 
 func TestExplicit_HandleAuthorizeEndpointRequest(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	aresp := mock.NewMockAuthorizeResponder(ctrl)
-	defer ctrl.Finish()
-
-	areq := oauth2.NewAuthorizeRequest()
-
-	session := NewDefaultSession()
-	session.Claims.Subject = "foo"
-	areq.Session = session
-	areq.Form = url.Values{
-		"redirect_uri": {"https://example.com"},
-	}
-
-	for k, c := range []struct {
-		description string
-		setup       func() OpenIDConnectExplicitHandler
-		expectErr   error
+	testCases := []struct {
+		name          string
+		setup         func(ctrl *gomock.Controller, request *oauth2.AuthorizeRequest, responder *mock.MockAuthorizeResponder) (handler OpenIDConnectExplicitHandler)
+		expected      string
+		expectedField string
 	}{
 		{
-			description: "should pass because not responsible for handling an empty response type",
-			setup: func() OpenIDConnectExplicitHandler {
-				h, _ := makeOpenIDConnectExplicitHandler(ctrl, oauth2.MinParameterEntropy)
-				areq.ResponseTypes = oauth2.Arguments{""}
-				return h
-			},
-		},
-		{
-			description: "should pass because scope openid is not set",
-			setup: func() OpenIDConnectExplicitHandler {
-				h, _ := makeOpenIDConnectExplicitHandler(ctrl, oauth2.MinParameterEntropy)
-				areq.ResponseTypes = oauth2.Arguments{"code"}
-				areq.Client = &oauth2.DefaultClient{
-					ResponseTypes: oauth2.Arguments{"code"},
-				}
-				areq.RequestedScope = oauth2.Arguments{""}
-				return h
-			},
-		},
-		{
-			description: "should fail because no code set",
-			setup: func() OpenIDConnectExplicitHandler {
-				h, _ := makeOpenIDConnectExplicitHandler(ctrl, oauth2.MinParameterEntropy)
-				areq.GrantedScope = oauth2.Arguments{consts.ScopeOpenID}
-				areq.Form.Set("nonce", "11111111111111111111111111111")
-				aresp.EXPECT().GetCode().Return("")
-				return h
-			},
-			expectErr: oauth2.ErrMisconfiguration,
-		},
-		{
-			description: "should fail because lookup fails",
-			setup: func() OpenIDConnectExplicitHandler {
-				h, store := makeOpenIDConnectExplicitHandler(ctrl, oauth2.MinParameterEntropy)
-				aresp.EXPECT().GetCode().AnyTimes().Return("codeexample")
-				store.EXPECT().CreateOpenIDConnectSession(t.Context(), "codeexample", gomock.Eq(areq.Sanitize(oidcParameters))).Return(errors.New(""))
-				return h
-			},
-			expectErr: oauth2.ErrServerError,
-		},
-		{
-			description: "should pass",
-			setup: func() OpenIDConnectExplicitHandler {
-				h, store := makeOpenIDConnectExplicitHandler(ctrl, oauth2.MinParameterEntropy)
-				store.EXPECT().CreateOpenIDConnectSession(t.Context(), "codeexample", gomock.Eq(areq.Sanitize(oidcParameters))).AnyTimes().Return(nil)
-				return h
-			},
-		},
-		{
-			description: "should fail because redirect url is missing",
-			setup: func() OpenIDConnectExplicitHandler {
-				areq.Form.Del(consts.FormParameterRedirectURI)
-				h, store := makeOpenIDConnectExplicitHandler(ctrl, oauth2.MinParameterEntropy)
-				store.EXPECT().CreateOpenIDConnectSession(gomock.Any(), "codeexample", gomock.Eq(areq.Sanitize(oidcParameters))).AnyTimes().Return(nil)
-				return h
-			},
-			expectErr: oauth2.ErrInvalidRequest,
-		},
-	} {
-		t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
-			h := c.setup()
-			err := h.HandleAuthorizeEndpointRequest(t.Context(), areq, aresp)
+			name: "should pass because not responsible for handling an empty response type",
+			setup: func(ctrl *gomock.Controller, request *oauth2.AuthorizeRequest, responder *mock.MockAuthorizeResponder) (handler OpenIDConnectExplicitHandler) {
+				handler, _ = makeOpenIDConnectExplicitHandler(ctrl, oauth2.MinParameterEntropy)
+				request.ResponseTypes = oauth2.Arguments{""}
 
-			if c.expectErr != nil {
-				require.EqualError(t, err, c.expectErr.Error())
+				return
+			},
+		},
+		{
+			name: "ShouldHandleSuccessWithoutOpenIDScope",
+			setup: func(ctrl *gomock.Controller, request *oauth2.AuthorizeRequest, responder *mock.MockAuthorizeResponder) (handler OpenIDConnectExplicitHandler) {
+				handler, _ = makeOpenIDConnectExplicitHandler(ctrl, oauth2.MinParameterEntropy)
+
+				request.GrantedScope = oauth2.Arguments{}
+				request.RequestedScope = oauth2.Arguments{}
+				request.ResponseTypes = oauth2.Arguments{consts.ResponseTypeAuthorizationCodeFlow}
+				request.Client = &oauth2.DefaultClient{
+					ResponseTypes: oauth2.Arguments{consts.ResponseTypeAuthorizationCodeFlow},
+				}
+
+				return
+			},
+		},
+		{
+			name: "ShouldFailWithoutCode",
+			setup: func(ctrl *gomock.Controller, request *oauth2.AuthorizeRequest, responder *mock.MockAuthorizeResponder) (handler OpenIDConnectExplicitHandler) {
+				handler, _ = makeOpenIDConnectExplicitHandler(ctrl, oauth2.MinParameterEntropy)
+
+				request.GrantedScope = oauth2.Arguments{consts.ScopeOpenID}
+				request.Form.Set(consts.FormParameterNonce, "11111111111111111111111111111")
+
+				responder.EXPECT().GetCode().Return("")
+
+				return
+			},
+			expected:      "The request failed because of an internal error that is probably caused by misconfiguration. The authorization code has not been issued yet, indicating a broken code configuration.",
+			expectedField: "misconfiguration",
+		},
+		{
+			name: "ShouldFailWithStorageError",
+			setup: func(ctrl *gomock.Controller, request *oauth2.AuthorizeRequest, responder *mock.MockAuthorizeResponder) (handler OpenIDConnectExplicitHandler) {
+				handler, store := makeOpenIDConnectExplicitHandler(ctrl, oauth2.MinParameterEntropy)
+				responder.EXPECT().GetCode().AnyTimes().Return("codeexample")
+
+				store.EXPECT().CreateOpenIDConnectSession(t.Context(), "codeexample", gomock.Eq(request.Sanitize(oidcParameters))).Return(errors.New("connection refused"))
+
+				return
+			},
+			expected:      "The authorization server encountered an unexpected condition that prevented it from fulfilling the request. connection refused",
+			expectedField: "server_error",
+		},
+		{
+			name: "ShouldHandleSuccess",
+			setup: func(ctrl *gomock.Controller, request *oauth2.AuthorizeRequest, responder *mock.MockAuthorizeResponder) (handler OpenIDConnectExplicitHandler) {
+				handler, store := makeOpenIDConnectExplicitHandler(ctrl, oauth2.MinParameterEntropy)
+
+				responder.EXPECT().GetCode().AnyTimes().Return("codeexample")
+				store.EXPECT().CreateOpenIDConnectSession(t.Context(), "codeexample", gomock.Eq(request.Sanitize(oidcParameters))).AnyTimes().Return(nil)
+
+				return
+			},
+		},
+		{
+			name: "ShouldFailBecauseRedirectURLIsMissing",
+			setup: func(ctrl *gomock.Controller, request *oauth2.AuthorizeRequest, responder *mock.MockAuthorizeResponder) (handler OpenIDConnectExplicitHandler) {
+				request.Form.Del(consts.FormParameterRedirectURI)
+
+				handler, store := makeOpenIDConnectExplicitHandler(ctrl, oauth2.MinParameterEntropy)
+
+				responder.EXPECT().GetCode().Return("codeexample")
+				store.EXPECT().CreateOpenIDConnectSession(gomock.Any(), "codeexample", gomock.Eq(request.Sanitize(oidcParameters))).AnyTimes().Return(nil)
+
+				return
+			},
+			expected:      "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The 'redirect_uri' parameter is required when using OpenID Connect 1.0.",
+			expectedField: "invalid_request",
+		},
+		{
+			name: "ShouldFailBecausePromptNotWhitelisted",
+			setup: func(ctrl *gomock.Controller, request *oauth2.AuthorizeRequest, responder *mock.MockAuthorizeResponder) (handler OpenIDConnectExplicitHandler) {
+				request.Form.Set(consts.FormParameterPrompt, "x")
+
+				handler, store := makeOpenIDConnectExplicitHandler(ctrl, oauth2.MinParameterEntropy)
+
+				responder.EXPECT().GetCode().Return("codeexample")
+				store.EXPECT().CreateOpenIDConnectSession(gomock.Any(), "codeexample", gomock.Eq(request.Sanitize(oidcParameters))).AnyTimes().Return(nil)
+
+				return
+			},
+			expected:      "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The requested prompt value 'x' either contains unknown, unsupported, or prohibited prompt values. The permitted prompt values are 'login', 'none', 'consent', 'select_account'.",
+			expectedField: "invalid_request",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			responder := mock.NewMockAuthorizeResponder(ctrl)
+
+			session := NewDefaultSession()
+			session.Claims.Subject = "foo"
+
+			requester := oauth2.NewAuthorizeRequest()
+
+			requester.RequestedScope = oauth2.Arguments{consts.ScopeOpenID}
+			requester.GrantedScope = oauth2.Arguments{consts.ScopeOpenID}
+			requester.ResponseTypes = oauth2.Arguments{consts.ResponseTypeAuthorizationCodeFlow}
+			requester.Session = session
+			requester.RedirectURI, _ = url.ParseRequestURI("https://example.com")
+			requester.Form = url.Values{
+				consts.FormParameterRedirectURI:  {"https://example.com"},
+				consts.FormParameterScope:        {consts.ScopeOpenID},
+				consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow},
+			}
+
+			handler := tc.setup(ctrl, requester, responder)
+
+			err := handler.HandleAuthorizeEndpointRequest(t.Context(), requester, responder)
+
+			if len(tc.expected) != 0 || len(tc.expectedField) != 0 {
+				require.NotNil(t, err)
+
+				var (
+					e  *oauth2.DebugRFC6749Error
+					ok bool
+				)
+
+				e, ok = oauth2.ErrorToDebugRFC6749Error(err).(*oauth2.DebugRFC6749Error)
+				require.True(t, ok)
+
+				assert.EqualError(t, e, tc.expected)
+				assert.Equal(t, tc.expectedField, e.ErrorField)
 			} else {
-				require.NoError(t, err)
+				assert.NoError(t, oauth2.ErrorToDebugRFC6749Error(err))
 			}
 		})
 	}

--- a/handler/openid/flow_explicit_token.go
+++ b/handler/openid/flow_explicit_token.go
@@ -32,7 +32,7 @@ func (c *OpenIDConnectExplicitHandler) PopulateTokenEndpointResponse(ctx context
 	}
 
 	if !authorize.GetGrantedScopes().Has(consts.ScopeOpenID) {
-		return errorsx.WithStack(oauth2.ErrMisconfiguration.WithDebug("An OpenID Connect session was found but the openid scope is missing, probably due to a broken code configuration."))
+		return errorsx.WithStack(oauth2.ErrMisconfiguration.WithDebug("An OpenID Connect 1.0 session was found but the 'openid' scope is missing, probably due to a broken code configuration."))
 	}
 
 	if !requester.GetClient().GetGrantTypes().Has(consts.GrantTypeAuthorizationCode) {
@@ -41,12 +41,12 @@ func (c *OpenIDConnectExplicitHandler) PopulateTokenEndpointResponse(ctx context
 
 	session, ok := authorize.GetSession().(Session)
 	if !ok {
-		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate id token because session must be of type oauth2/handler/openid.Session."))
+		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate ID Token because the session is not of type 'openid.Session' which is required."))
 	}
 
 	claims := session.IDTokenClaims()
 	if claims.Subject == "" {
-		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate id token because subject is an empty string."))
+		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate ID Token because subject is an empty string."))
 	}
 
 	if err = c.OpenIDConnectRequestStorage.DeleteOpenIDConnectSession(ctx, code); err != nil {

--- a/handler/openid/flow_implicit.go
+++ b/handler/openid/flow_implicit.go
@@ -36,7 +36,7 @@ var (
 // TODO: Refactor time permitting.
 //
 //nolint:gocyclo
-func (c *OpenIDConnectImplicitHandler) HandleAuthorizeEndpointRequest(ctx context.Context, requester oauth2.AuthorizeRequester, responder oauth2.AuthorizeResponder) error {
+func (c *OpenIDConnectImplicitHandler) HandleAuthorizeEndpointRequest(ctx context.Context, requester oauth2.AuthorizeRequester, responder oauth2.AuthorizeResponder) (err error) {
 	if !(requester.GetGrantedScopes().Has(consts.ScopeOpenID) && (requester.GetResponseTypes().Has(consts.ResponseTypeImplicitFlowToken, consts.ResponseTypeImplicitFlowIDToken) || requester.GetResponseTypes().ExactOne(consts.ResponseTypeImplicitFlowIDToken))) {
 		return nil
 	} else if requester.GetResponseTypes().Has(consts.ResponseTypeAuthorizationCodeFlow) {
@@ -50,17 +50,14 @@ func (c *OpenIDConnectImplicitHandler) HandleAuthorizeEndpointRequest(ctx contex
 		return errorsx.WithStack(oauth2.ErrInvalidGrant.WithHint("The OAuth 2.0 Client is not allowed to use the authorization grant 'implicit'."))
 	}
 
-	// There is no need to check response types here as this is validated in the oauth2.AuthorizeRequestHandler.
+	if err = c.OpenIDConnectRequestValidator.ValidateRedirectURIs(ctx, requester); err != nil {
+		return err
+	}
 
-	// This ensures that the 'redirect_uri' parameter is present for OpenID Connect 1.0 authorization requests as per:
-	//
-	// Authorization Code Flow - https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
-	// Implicit Flow - https://openid.net/specs/openid-connect-core-1_0.html#ImplicitAuthRequest
-	// Hybrid Flow - https://openid.net/specs/openid-connect-core-1_0.html#HybridAuthRequest
-	//
-	// Note: as per the Hybrid Flow documentation the Hybrid Flow has the same requirements as the Authorization Code Flow.
-	if len(requester.GetRequestForm().Get(consts.FormParameterRedirectURI)) == 0 {
-		return errorsx.WithStack(oauth2.ErrInvalidRequest.WithHint("The 'redirect_uri' parameter is required when using OpenID Connect 1.0."))
+	var session Session
+
+	if session, err = c.OpenIDConnectRequestValidator.ValidatePrompt(ctx, requester); err != nil {
+		return err
 	}
 
 	if nonce := requester.GetRequestForm().Get(consts.FormParameterNonce); len(nonce) == 0 {
@@ -76,24 +73,17 @@ func (c *OpenIDConnectImplicitHandler) HandleAuthorizeEndpointRequest(ctx contex
 		}
 	}
 
-	session, ok := requester.GetSession().(Session)
-	if !ok {
-		return errorsx.WithStack(ErrInvalidSession)
-	}
-
-	if err := c.OpenIDConnectRequestValidator.ValidatePrompt(ctx, requester); err != nil {
-		return err
-	}
-
 	claims := session.IDTokenClaims()
 	if requester.GetResponseTypes().Has(consts.ResponseTypeImplicitFlowToken) {
-		if err := c.AuthorizeImplicitGrantTypeHandler.IssueImplicitAccessToken(ctx, requester, responder); err != nil {
+		if err = c.AuthorizeImplicitGrantTypeHandler.IssueImplicitAccessToken(ctx, requester, responder); err != nil {
 			return errorsx.WithStack(err)
 		}
 
 		requester.SetResponseTypeHandled(consts.ResponseTypeImplicitFlowToken)
-		hash, err := c.ComputeHash(ctx, session, responder.GetParameters().Get(consts.AccessResponseAccessToken))
-		if err != nil {
+
+		var hash string
+
+		if hash, err = c.ComputeHash(ctx, session, responder.GetParameters().Get(consts.AccessResponseAccessToken)); err != nil {
 			return err
 		}
 
@@ -104,7 +94,7 @@ func (c *OpenIDConnectImplicitHandler) HandleAuthorizeEndpointRequest(ctx contex
 
 	lifespan := oauth2.GetEffectiveLifespan(requester.GetClient(), oauth2.GrantTypeImplicit, oauth2.IDToken, c.Config.GetIDTokenLifespan(ctx))
 
-	if err := c.IssueImplicitIDToken(ctx, lifespan, requester, responder); err != nil {
+	if err = c.IssueImplicitIDToken(ctx, lifespan, requester, responder); err != nil {
 		return errorsx.WithStack(err)
 	}
 

--- a/handler/openid/flow_implicit_test.go
+++ b/handler/openid/flow_implicit_test.go
@@ -4,12 +4,12 @@
 package openid
 
 import (
-	"fmt"
 	"net/url"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"authelia.com/provider/oauth2"
@@ -19,6 +19,268 @@ import (
 	"authelia.com/provider/oauth2/storage"
 	"authelia.com/provider/oauth2/token/jwt"
 )
+
+func TestImplicit_HandleAuthorizeEndpointRequest(t *testing.T) {
+	testCases := []struct {
+		name          string
+		setup         func(requester *oauth2.AuthorizeRequest, responder *oauth2.AuthorizeResponse) (handler OpenIDConnectImplicitHandler)
+		expected      string
+		expectedField string
+		check         func(t *testing.T, requester *oauth2.AuthorizeRequest, responder *oauth2.AuthorizeResponse)
+	}{
+		{
+			name: "ShouldPassBecauseHandlerNotResponsibleOAuth2EmptyFlow",
+			setup: func(requester *oauth2.AuthorizeRequest, responder *oauth2.AuthorizeResponse) (handler OpenIDConnectImplicitHandler) {
+				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
+			},
+		},
+		{
+			name: "ShouldPassBecauseHandlerNotResponsibleForOAuth2AuthorizeCodeFlow",
+			setup: func(requester *oauth2.AuthorizeRequest, responder *oauth2.AuthorizeResponse) (handler OpenIDConnectImplicitHandler) {
+				requester.ResponseTypes = oauth2.Arguments{consts.ResponseTypeImplicitFlowIDToken}
+				requester.State = "foostate"
+				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
+			},
+		},
+		{
+			name: "ShouldPassBecauseHandlerNotResponsibleForOAuth2ImplicitFlow",
+			setup: func(requester *oauth2.AuthorizeRequest, responder *oauth2.AuthorizeResponse) (handler OpenIDConnectImplicitHandler) {
+				requester.ResponseTypes = oauth2.Arguments{consts.ResponseTypeImplicitFlowToken, consts.ResponseTypeImplicitFlowIDToken}
+				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
+			},
+		},
+		{
+			name: "ShouldPassBecauseHandlerNotResponsibleForOpenIDEmptyFlow",
+			setup: func(requester *oauth2.AuthorizeRequest, responder *oauth2.AuthorizeResponse) (handler OpenIDConnectImplicitHandler) {
+				requester.ResponseTypes = oauth2.Arguments{}
+				requester.GrantedScope = oauth2.Arguments{consts.ScopeOpenID}
+				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
+			},
+		},
+		{
+			name: "ShouldPassBecauseHandlerNotResponsibleForOpenIDImplicitFlowTokenIDToken",
+			setup: func(requester *oauth2.AuthorizeRequest, responder *oauth2.AuthorizeResponse) (handler OpenIDConnectImplicitHandler) {
+				requester.ResponseTypes = oauth2.Arguments{consts.ResponseTypeImplicitFlowToken, consts.ResponseTypeImplicitFlowIDToken}
+				requester.RequestedScope = oauth2.Arguments{consts.ScopeOpenID}
+				requester.Client = &oauth2.DefaultClient{
+					GrantTypes:    oauth2.Arguments{},
+					ResponseTypes: oauth2.Arguments{},
+					Scopes:        []string{consts.ScopeOpenID, "oauth2"},
+				}
+				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
+			},
+			expected:      "The provided authorization grant (e.g., authorization code, resource owner credentials) or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client. The OAuth 2.0 Client is not allowed to use the authorization grant 'implicit'.",
+			expectedField: "invalid_grant",
+		},
+		{
+			name: "ShouldPassBecauseHandlerNotResponsibleForOpenIDImplicitFlowIDToken",
+			setup: func(requester *oauth2.AuthorizeRequest, responder *oauth2.AuthorizeResponse) (handler OpenIDConnectImplicitHandler) {
+				requester.Form = url.Values{consts.FormParameterNonce: {"short"}, consts.FormParameterRedirectURI: {"https://example.com"}}
+				requester.ResponseTypes = oauth2.Arguments{consts.ResponseTypeImplicitFlowIDToken}
+				requester.RequestedScope = oauth2.Arguments{consts.ScopeOpenID}
+				requester.Client = &oauth2.DefaultClient{
+					GrantTypes:    oauth2.Arguments{consts.GrantTypeImplicit},
+					ResponseTypes: oauth2.Arguments{consts.ResponseTypeImplicitFlowToken, consts.ResponseTypeImplicitFlowIDToken},
+					Scopes:        []string{consts.ScopeOpenID, "oauth2"},
+				}
+				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
+			},
+			expected:      "The request used a security parameter (e.g., anti-replay, anti-csrf) with insufficient entropy. Parameter 'nonce' is set but does not satisfy the minimum entropy of 8 characters.",
+			expectedField: "insufficient_entropy",
+		},
+		{
+			name: "ShouldFailBecauseSessionNotSet",
+			setup: func(requester *oauth2.AuthorizeRequest, responder *oauth2.AuthorizeResponse) (handler OpenIDConnectImplicitHandler) {
+				requester.Form = url.Values{consts.FormParameterNonce: {"long-enough"}, consts.FormParameterRedirectURI: {"https://example.com"}}
+				requester.ResponseTypes = oauth2.Arguments{consts.ResponseTypeImplicitFlowIDToken}
+				requester.RequestedScope = oauth2.Arguments{consts.ScopeOpenID}
+				requester.Client = &oauth2.DefaultClient{
+					GrantTypes:    oauth2.Arguments{consts.GrantTypeImplicit},
+					ResponseTypes: oauth2.Arguments{consts.ResponseTypeImplicitFlowToken, consts.ResponseTypeImplicitFlowIDToken},
+					Scopes:        []string{consts.ScopeOpenID, "oauth2"},
+				}
+
+				requester.Session = nil
+
+				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
+			},
+			expected:      "The authorization server encountered an unexpected condition that prevented it from fulfilling the request. Failed to validate OpenID Connect 1.0 request because the session is not of type 'openid.Session' which is required.",
+			expectedField: "server_error",
+		},
+		{
+			name: "should pass because nonce set",
+			setup: func(requester *oauth2.AuthorizeRequest, responder *oauth2.AuthorizeResponse) (handler OpenIDConnectImplicitHandler) {
+				requester.Session = &DefaultSession{
+					Claims: &jwt.IDTokenClaims{
+						Subject: testSubjectPeter,
+					},
+					Headers: &jwt.Headers{},
+					Subject: testSubjectPeter,
+				}
+				requester.Form.Add(consts.FormParameterNonce, "some-random-foo-nonce-wow")
+				requester.Form.Add(consts.FormParameterRedirectURI, "https://example.com")
+				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
+			},
+		},
+		{
+			name: "ShouldPassImplicitFlowIDToken",
+			setup: func(requester *oauth2.AuthorizeRequest, responder *oauth2.AuthorizeResponse) (handler OpenIDConnectImplicitHandler) {
+				requester.ResponseTypes = oauth2.Arguments{consts.ResponseTypeImplicitFlowIDToken}
+				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
+			},
+			check: func(t *testing.T, requester *oauth2.AuthorizeRequest, responder *oauth2.AuthorizeResponse) {
+				assert.Empty(t, responder.GetParameters().Get(consts.FormParameterState))
+				assert.Empty(t, responder.GetParameters().Get(consts.AccessResponseAccessToken))
+				require.NotEmpty(t, responder.GetParameters().Get(consts.AccessResponseIDToken))
+
+				exp := internal.ExtractJwtExpClaim(t, responder.GetParameters().Get(consts.AccessResponseIDToken))
+				internal.RequireEqualTime(t, time.Now().Add(time.Hour), *exp, time.Minute)
+			},
+		},
+		{
+			name: "ShouldPassWithCustomLifespan",
+			setup: func(requester *oauth2.AuthorizeRequest, responder *oauth2.AuthorizeResponse) (handler OpenIDConnectImplicitHandler) {
+				responder = oauth2.NewAuthorizeResponse()
+				requester.Session = &DefaultSession{
+					Claims: &jwt.IDTokenClaims{
+						Subject: testSubjectPeter,
+					},
+					Headers: &jwt.Headers{},
+					Subject: testSubjectPeter,
+				}
+				requester.ResponseTypes = oauth2.Arguments{consts.ResponseTypeImplicitFlowIDToken}
+				requester.Client = &oauth2.DefaultClientWithCustomTokenLifespans{
+					DefaultClient: &oauth2.DefaultClient{
+						GrantTypes:    oauth2.Arguments{consts.GrantTypeImplicit},
+						ResponseTypes: oauth2.Arguments{consts.ResponseTypeImplicitFlowToken, consts.ResponseTypeImplicitFlowIDToken},
+						Scopes:        []string{consts.ScopeOpenID, "oauth2"},
+					},
+				}
+				requester.Client.(*oauth2.DefaultClientWithCustomTokenLifespans).SetTokenLifespans(&internal.TestLifespans)
+				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
+			},
+			check: func(t *testing.T, requester *oauth2.AuthorizeRequest, responder *oauth2.AuthorizeResponse) {
+				idToken := responder.GetParameters().Get(consts.AccessResponseIDToken)
+				assert.NotEmpty(t, idToken)
+				assert.Empty(t, responder.GetParameters().Get(consts.FormParameterState))
+				assert.Empty(t, responder.GetParameters().Get(consts.AccessResponseAccessToken))
+				idTokenExp := internal.ExtractJwtExpClaim(t, idToken)
+				internal.RequireEqualTime(t, time.Now().Add(*internal.TestLifespans.ImplicitGrantIDTokenLifespan), *idTokenExp, time.Minute)
+			},
+		},
+		{
+			name: "should pass",
+			setup: func(requester *oauth2.AuthorizeRequest, responder *oauth2.AuthorizeResponse) (handler OpenIDConnectImplicitHandler) {
+				responder = oauth2.NewAuthorizeResponse()
+				requester.ResponseTypes = oauth2.Arguments{consts.ResponseTypeImplicitFlowToken, consts.ResponseTypeImplicitFlowIDToken}
+
+				requester.Client.(*oauth2.DefaultClientWithCustomTokenLifespans).SetTokenLifespans(&internal.TestLifespans)
+
+				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
+			},
+			check: func(t *testing.T, requester *oauth2.AuthorizeRequest, responder *oauth2.AuthorizeResponse) {
+				assert.Empty(t, responder.GetParameters().Get(consts.FormParameterState))
+
+				idToken := responder.GetParameters().Get(consts.AccessResponseIDToken)
+				assert.NotEmpty(t, idToken)
+				internal.RequireEqualTime(t, time.Now().Add(*internal.TestLifespans.ImplicitGrantIDTokenLifespan).UTC(), *internal.ExtractJwtExpClaim(t, idToken), time.Minute)
+
+				assert.NotEmpty(t, responder.GetParameters().Get(consts.AccessResponseAccessToken))
+				internal.RequireEqualTime(t, time.Now().Add(*internal.TestLifespans.ImplicitGrantAccessTokenLifespan).UTC(), requester.Session.GetExpiresAt(oauth2.AccessToken), time.Minute)
+			},
+		},
+		{
+			name: "ShouldPassDefaultValues",
+			setup: func(requester *oauth2.AuthorizeRequest, responder *oauth2.AuthorizeResponse) (handler OpenIDConnectImplicitHandler) {
+				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
+			},
+			check: func(t *testing.T, requester *oauth2.AuthorizeRequest, responder *oauth2.AuthorizeResponse) {
+				assert.NotEmpty(t, responder.GetParameters().Get(consts.AccessResponseIDToken))
+				assert.NotEmpty(t, responder.GetParameters().Get(consts.AccessResponseAccessToken))
+				assert.Empty(t, responder.GetParameters().Get(consts.FormParameterNonce))
+
+				assert.Equal(t, oauth2.ResponseModeFragment, requester.GetResponseMode())
+			},
+		},
+		{
+			name: "ShouldPassWithLowMinEntropy",
+			setup: func(requester *oauth2.AuthorizeRequest, responder *oauth2.AuthorizeResponse) (handler OpenIDConnectImplicitHandler) {
+				requester.Form.Set(consts.FormParameterNonce, "short")
+
+				return makeOpenIDConnectImplicitHandler(4)
+			},
+			check: func(t *testing.T, requester *oauth2.AuthorizeRequest, responder *oauth2.AuthorizeResponse) {
+				assert.NotEmpty(t, responder.GetParameters().Get(consts.AccessResponseIDToken))
+				assert.NotEmpty(t, responder.GetParameters().Get(consts.AccessResponseAccessToken))
+				assert.Empty(t, responder.GetParameters().Get(consts.FormParameterNonce))
+			},
+		},
+		{
+			name: "ShouldFailWithoutRedirectURI",
+			setup: func(requester *oauth2.AuthorizeRequest, responder *oauth2.AuthorizeResponse) (handler OpenIDConnectImplicitHandler) {
+				requester.Form.Del(consts.FormParameterRedirectURI)
+				requester.RedirectURI = nil
+
+				return makeOpenIDConnectImplicitHandler(4)
+			},
+			expected:      "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The 'redirect_uri' parameter is required when using OpenID Connect 1.0.",
+			expectedField: "invalid_request",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			responder := oauth2.NewAuthorizeResponse()
+			requester := oauth2.NewAuthorizeRequest()
+
+			requester.Session = &DefaultSession{
+				Claims: &jwt.IDTokenClaims{
+					Subject: testSubjectPeter,
+				},
+				Headers: &jwt.Headers{},
+				Subject: testSubjectPeter,
+			}
+
+			requester.Client = &oauth2.DefaultClientWithCustomTokenLifespans{
+				DefaultClient: &oauth2.DefaultClient{
+					Scopes:        oauth2.Arguments{consts.ScopeOpenID},
+					ResponseTypes: oauth2.Arguments{consts.ResponseTypeImplicitFlowToken, consts.ResponseTypeImplicitFlowIDToken, consts.ResponseTypeImplicitFlowBoth},
+					GrantTypes:    oauth2.Arguments{consts.GrantTypeImplicit},
+				},
+			}
+
+			requester.ResponseTypes = oauth2.Arguments{consts.ResponseTypeImplicitFlowIDToken, consts.ResponseTypeImplicitFlowToken}
+			requester.RequestedScope = oauth2.Arguments{consts.ScopeOpenID}
+			requester.GrantedScope = oauth2.Arguments{consts.ScopeOpenID}
+
+			requester.Form = url.Values{
+				consts.FormParameterRedirectURI: {"https://example.com"},
+				consts.FormParameterState:       {"test-state-value"},
+				consts.FormParameterNonce:       {"test-nonce-value"},
+			}
+
+			requester.RedirectURI, _ = url.Parse("https://example.com")
+
+			h := tc.setup(requester, responder)
+			err := h.HandleAuthorizeEndpointRequest(t.Context(), requester, responder)
+
+			if len(tc.expected) != 0 || len(tc.expectedField) != 0 {
+				e := oauth2.ErrorToDebugRFC6749Error(err).(*oauth2.DebugRFC6749Error)
+
+				assert.EqualError(t, e, tc.expected)
+				assert.Equal(t, e.ErrorField, tc.expectedField)
+			} else {
+				assert.NoError(t, err)
+				if tc.check != nil {
+					tc.check(t, requester, responder)
+				}
+			}
+		})
+	}
+}
 
 func makeOpenIDConnectImplicitHandler(minParameterEntropy int) OpenIDConnectImplicitHandler {
 	config := &oauth2.Config{
@@ -54,237 +316,5 @@ func makeOpenIDConnectImplicitHandler(minParameterEntropy int) OpenIDConnectImpl
 		},
 		OpenIDConnectRequestValidator: NewOpenIDConnectRequestValidator(j.Strategy, config),
 		Config:                        config,
-	}
-}
-
-func TestImplicit_HandleAuthorizeEndpointRequest(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	responder := oauth2.NewAuthorizeResponse()
-	requester := oauth2.NewAuthorizeRequest()
-	requester.Session = new(oauth2.DefaultSession)
-
-	for k, c := range []struct {
-		description string
-		setup       func() OpenIDConnectImplicitHandler
-		expectErr   error
-		check       func()
-	}{
-		{
-			description: "should not do anything because request requirements are not met",
-			setup: func() OpenIDConnectImplicitHandler {
-				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
-			},
-		},
-		{
-			description: "should not do anything because request requirements are not met",
-			setup: func() OpenIDConnectImplicitHandler {
-				requester.ResponseTypes = oauth2.Arguments{consts.ResponseTypeImplicitFlowIDToken}
-				requester.State = "foostate"
-				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
-			},
-		},
-		{
-			description: "should not do anything because request requirements are not met",
-			setup: func() OpenIDConnectImplicitHandler {
-				requester.ResponseTypes = oauth2.Arguments{consts.ResponseTypeImplicitFlowToken, consts.ResponseTypeImplicitFlowIDToken}
-				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
-			},
-		},
-		{
-			description: "should not do anything because request requirements are not met",
-			setup: func() OpenIDConnectImplicitHandler {
-				requester.ResponseTypes = oauth2.Arguments{}
-				requester.GrantedScope = oauth2.Arguments{consts.ScopeOpenID}
-				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
-			},
-		},
-		{
-			description: "should not do anything because request requirements are not met",
-			setup: func() OpenIDConnectImplicitHandler {
-				requester.ResponseTypes = oauth2.Arguments{consts.ResponseTypeImplicitFlowToken, consts.ResponseTypeImplicitFlowIDToken}
-				requester.RequestedScope = oauth2.Arguments{consts.ScopeOpenID}
-				requester.Client = &oauth2.DefaultClient{
-					GrantTypes:    oauth2.Arguments{},
-					ResponseTypes: oauth2.Arguments{},
-					Scopes:        []string{consts.ScopeOpenID, "oauth2"},
-				}
-				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
-			},
-			expectErr: oauth2.ErrInvalidGrant,
-		},
-		{
-			description: "should not do anything because request requirements are not met",
-			setup: func() OpenIDConnectImplicitHandler {
-				requester.ResponseTypes = oauth2.Arguments{consts.ResponseTypeImplicitFlowIDToken}
-				requester.RequestedScope = oauth2.Arguments{consts.ScopeOpenID}
-				requester.Client = &oauth2.DefaultClient{
-					GrantTypes: oauth2.Arguments{consts.GrantTypeImplicit},
-					//ResponseTypes: oauth2.Arguments{consts.ResponseTypeImplicitFlowToken, consts.ResponseTypeImplicitFlowIDToken},
-					Scopes: []string{consts.ScopeOpenID, "oauth2"},
-				}
-				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
-			},
-			expectErr: oauth2.ErrInvalidRequest,
-		},
-		{
-			description: "should not do anything because request requirements are not met",
-			setup: func() OpenIDConnectImplicitHandler {
-				requester.Form = url.Values{consts.FormParameterNonce: {"short"}, consts.FormParameterRedirectURI: {"https://example.com"}}
-				requester.ResponseTypes = oauth2.Arguments{consts.ResponseTypeImplicitFlowIDToken}
-				requester.RequestedScope = oauth2.Arguments{consts.ScopeOpenID}
-				requester.Client = &oauth2.DefaultClient{
-					GrantTypes:    oauth2.Arguments{consts.GrantTypeImplicit},
-					ResponseTypes: oauth2.Arguments{consts.ResponseTypeImplicitFlowToken, consts.ResponseTypeImplicitFlowIDToken},
-					Scopes:        []string{consts.ScopeOpenID, "oauth2"},
-				}
-				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
-			},
-			expectErr: oauth2.ErrInsufficientEntropy,
-		},
-		{
-			description: "should fail because session not set",
-			setup: func() OpenIDConnectImplicitHandler {
-				requester.Form = url.Values{consts.FormParameterNonce: {"long-enough"}, consts.FormParameterRedirectURI: {"https://example.com"}}
-				requester.ResponseTypes = oauth2.Arguments{consts.ResponseTypeImplicitFlowIDToken}
-				requester.RequestedScope = oauth2.Arguments{consts.ScopeOpenID}
-				requester.Client = &oauth2.DefaultClient{
-					GrantTypes:    oauth2.Arguments{consts.GrantTypeImplicit},
-					ResponseTypes: oauth2.Arguments{consts.ResponseTypeImplicitFlowToken, consts.ResponseTypeImplicitFlowIDToken},
-					Scopes:        []string{consts.ScopeOpenID, "oauth2"},
-				}
-				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
-			},
-			expectErr: ErrInvalidSession,
-		},
-		{
-			description: "should pass because nonce set",
-			setup: func() OpenIDConnectImplicitHandler {
-				requester.Session = &DefaultSession{
-					Claims: &jwt.IDTokenClaims{
-						Subject: testSubjectPeter,
-					},
-					Headers: &jwt.Headers{},
-					Subject: testSubjectPeter,
-				}
-				requester.Form.Add(consts.FormParameterNonce, "some-random-foo-nonce-wow")
-				requester.Form.Add(consts.FormParameterRedirectURI, "https://example.com")
-				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
-			},
-		},
-		{
-			description: "should pass",
-			setup: func() OpenIDConnectImplicitHandler {
-				requester.ResponseTypes = oauth2.Arguments{consts.ResponseTypeImplicitFlowIDToken}
-				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
-			},
-			check: func() {
-				assert.NotEmpty(t, responder.GetParameters().Get(consts.FormParameterState))
-				assert.Empty(t, responder.GetParameters().Get(consts.AccessResponseAccessToken))
-
-				idToken := responder.GetParameters().Get(consts.AccessResponseIDToken)
-				assert.NotEmpty(t, idToken)
-				idTokenExp := internal.ExtractJwtExpClaim(t, idToken)
-				internal.RequireEqualTime(t, time.Now().Add(time.Hour), *idTokenExp, time.Minute)
-			},
-		},
-		{
-			description: "should pass with nondefault id token lifespan",
-			setup: func() OpenIDConnectImplicitHandler {
-				responder = oauth2.NewAuthorizeResponse()
-				requester.Session = &DefaultSession{
-					Claims: &jwt.IDTokenClaims{
-						Subject: testSubjectPeter,
-					},
-					Headers: &jwt.Headers{},
-					Subject: testSubjectPeter,
-				}
-				requester.ResponseTypes = oauth2.Arguments{consts.ResponseTypeImplicitFlowIDToken}
-				requester.Client = &oauth2.DefaultClientWithCustomTokenLifespans{
-					DefaultClient: &oauth2.DefaultClient{
-						GrantTypes:    oauth2.Arguments{consts.GrantTypeImplicit},
-						ResponseTypes: oauth2.Arguments{consts.ResponseTypeImplicitFlowToken, consts.ResponseTypeImplicitFlowIDToken},
-						Scopes:        []string{consts.ScopeOpenID, "oauth2"},
-					},
-				}
-				requester.Client.(*oauth2.DefaultClientWithCustomTokenLifespans).SetTokenLifespans(&internal.TestLifespans)
-				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
-			},
-			check: func() {
-				idToken := responder.GetParameters().Get(consts.AccessResponseIDToken)
-				assert.NotEmpty(t, idToken)
-				assert.NotEmpty(t, responder.GetParameters().Get(consts.FormParameterState))
-				assert.Empty(t, responder.GetParameters().Get(consts.AccessResponseAccessToken))
-				idTokenExp := internal.ExtractJwtExpClaim(t, idToken)
-				internal.RequireEqualTime(t, time.Now().Add(*internal.TestLifespans.ImplicitGrantIDTokenLifespan), *idTokenExp, time.Minute)
-			},
-		},
-		{
-			description: "should pass",
-			setup: func() OpenIDConnectImplicitHandler {
-				responder = oauth2.NewAuthorizeResponse()
-				requester.ResponseTypes = oauth2.Arguments{consts.ResponseTypeImplicitFlowToken, consts.ResponseTypeImplicitFlowIDToken}
-				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
-			},
-			check: func() {
-				assert.NotEmpty(t, responder.GetParameters().Get(consts.FormParameterState))
-
-				idToken := responder.GetParameters().Get(consts.AccessResponseIDToken)
-				assert.NotEmpty(t, idToken)
-				internal.RequireEqualTime(t, time.Now().Add(*internal.TestLifespans.ImplicitGrantIDTokenLifespan).UTC(), *internal.ExtractJwtExpClaim(t, idToken), time.Minute)
-
-				assert.NotEmpty(t, responder.GetParameters().Get(consts.AccessResponseAccessToken))
-				internal.RequireEqualTime(t, time.Now().Add(*internal.TestLifespans.ImplicitGrantAccessTokenLifespan).UTC(), requester.Session.GetExpiresAt(oauth2.AccessToken), time.Minute)
-			},
-		},
-		{
-			description: "should pass",
-			setup: func() OpenIDConnectImplicitHandler {
-				requester.ResponseTypes = oauth2.Arguments{consts.ResponseTypeImplicitFlowIDToken, consts.ResponseTypeImplicitFlowToken}
-				requester.RequestedScope = oauth2.Arguments{"oauth2", consts.ScopeOpenID}
-				return makeOpenIDConnectImplicitHandler(oauth2.MinParameterEntropy)
-			},
-			check: func() {
-				assert.NotEmpty(t, responder.GetParameters().Get(consts.AccessResponseIDToken))
-				assert.NotEmpty(t, responder.GetParameters().Get(consts.FormParameterState))
-				assert.NotEmpty(t, responder.GetParameters().Get(consts.AccessResponseAccessToken))
-				assert.Equal(t, oauth2.ResponseModeFragment, requester.GetResponseMode())
-			},
-		},
-		{
-			description: "should pass with low min entropy",
-			setup: func() OpenIDConnectImplicitHandler {
-				requester.Form.Set(consts.FormParameterNonce, "short")
-				return makeOpenIDConnectImplicitHandler(4)
-			},
-			check: func() {
-				assert.NotEmpty(t, responder.GetParameters().Get(consts.AccessResponseIDToken))
-				assert.NotEmpty(t, responder.GetParameters().Get(consts.FormParameterState))
-				assert.NotEmpty(t, responder.GetParameters().Get(consts.AccessResponseAccessToken))
-			},
-		},
-		{
-			description: "should fail without redirect_uri",
-			setup: func() OpenIDConnectImplicitHandler {
-				requester.Form.Del(consts.FormParameterRedirectURI)
-				return makeOpenIDConnectImplicitHandler(4)
-			},
-			expectErr: oauth2.ErrInvalidRequest,
-		},
-	} {
-		t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
-			h := c.setup()
-			err := h.HandleAuthorizeEndpointRequest(t.Context(), requester, responder)
-
-			if c.expectErr != nil {
-				assert.EqualError(t, err, c.expectErr.Error())
-			} else {
-				assert.NoError(t, err)
-				if c.check != nil {
-					c.check()
-				}
-			}
-		})
 	}
 }

--- a/handler/openid/flow_refresh_token.go
+++ b/handler/openid/flow_refresh_token.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 
 	"authelia.com/provider/oauth2"
 	"authelia.com/provider/oauth2/internal/consts"
@@ -46,7 +45,8 @@ func (c *OpenIDConnectRefreshHandler) HandleTokenEndpointRequest(ctx context.Con
 
 	sess, ok := request.GetSession().(Session)
 	if !ok {
-		return errors.New("Failed to generate id token because session must be of type oauth2/handler/openid.Session")
+		return errorsx.WithStack(oauth2.ErrServerError.
+			WithDebug("Failed to generate ID Token because the session is not of type 'openid.Session' which is required."))
 	}
 
 	// We need to reset the expires at value as this would be the previous expiry.
@@ -82,12 +82,12 @@ func (c *OpenIDConnectRefreshHandler) PopulateTokenEndpointResponse(ctx context.
 
 	sess, ok := requester.GetSession().(Session)
 	if !ok {
-		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate id token because session must be of type oauth2/handler/openid.Session."))
+		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate ID Token because the session is not of type 'openid.Session' which is required."))
 	}
 
 	claims := sess.IDTokenClaims()
 	if claims.Subject == "" {
-		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate id token because subject is an empty string."))
+		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate ID Token because subject is an empty string."))
 	}
 
 	claims.AccessTokenHash = c.GetAccessTokenHash(ctx, requester, responder)

--- a/handler/openid/strategy_jwt.go
+++ b/handler/openid/strategy_jwt.go
@@ -145,12 +145,12 @@ func (h DefaultStrategy) GenerateIDToken(ctx context.Context, lifespan time.Dura
 
 	session, ok := requester.GetSession().(Session)
 	if !ok {
-		return "", errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate id token because session must be of type oauth2/handler/openid.Session."))
+		return "", errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate ID Token because the session is not of type 'openid.Session' which is required"))
 	}
 
 	claims := session.IDTokenClaims()
 	if claims.Subject == "" {
-		return "", errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate id token because subject is an empty string."))
+		return "", errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate ID Token because subject is an empty string."))
 	}
 
 	jwtClient := jwt.NewIDTokenClient(requester.GetClient())
@@ -172,18 +172,18 @@ func (h DefaultStrategy) GenerateIDToken(ctx context.Context, lifespan time.Dura
 		if maxAge > 0 {
 			switch {
 			case claims.AuthTime == nil, claims.AuthTime.IsZero():
-				return "", errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate id token because authentication time claim is required when max_age is set."))
+				return "", errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate ID Token because authentication time claim is required when max_age is set."))
 			case rat.IsZero():
-				return "", errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate id token because requested at value is required when max_age is set."))
+				return "", errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate ID Token because requested at value is required when max_age is set."))
 			case claims.AuthTime.Add(time.Second * time.Duration(maxAge)).Before(rat):
-				return "", errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate id token because authentication time does not satisfy max_age time."))
+				return "", errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate ID Token because authentication time does not satisfy max_age time."))
 			}
 		}
 
 		prompt := requester.GetRequestForm().Get(consts.FormParameterPrompt)
 		if prompt != "" {
 			if claims.AuthTime == nil || claims.AuthTime.IsZero() {
-				return "", errorsx.WithStack(oauth2.ErrServerError.WithDebug("Unable to determine validity of prompt parameter because auth_time is missing in id token claims."))
+				return "", errorsx.WithStack(oauth2.ErrServerError.WithDebug("Unable to determine validity of prompt parameter because auth_time is missing in ID Token claims."))
 			}
 		}
 
@@ -191,12 +191,12 @@ func (h DefaultStrategy) GenerateIDToken(ctx context.Context, lifespan time.Dura
 		case consts.PromptTypeNone:
 			if !claims.GetAuthTimeSafe().Equal(rat) && claims.GetAuthTimeSafe().After(rat) {
 				return "", errorsx.WithStack(oauth2.ErrServerError.
-					WithDebugf("Failed to generate id token because prompt was set to 'none' but auth_time ('%s') happened after the authorization request ('%s') was registered, indicating that the user was logged in during this request which is not allowed.", claims.GetAuthTimeSafe(), rat))
+					WithDebugf("Failed to generate ID Token because prompt was set to 'none' but auth_time ('%s') happened after the authorization request ('%s') was registered, indicating that the user was logged in during this request which is not allowed.", claims.GetAuthTimeSafe(), rat))
 			}
 		case consts.PromptTypeLogin:
 			if !claims.GetAuthTimeSafe().Equal(rat) && claims.GetAuthTimeSafe().Before(rat) {
 				return "", errorsx.WithStack(oauth2.ErrServerError.
-					WithDebugf("Failed to generate id token because prompt was set to 'login' but auth_time ('%s') happened before the authorization request ('%s') was registered, indicating that the user was not re-authenticated which is forbidden.", claims.GetAuthTimeSafe(), rat))
+					WithDebugf("Failed to generate ID Token because prompt was set to 'login' but auth_time ('%s') happened before the authorization request ('%s') was registered, indicating that the user was not re-authenticated which is forbidden.", claims.GetAuthTimeSafe(), rat))
 			}
 		}
 
@@ -215,15 +215,15 @@ func (h DefaultStrategy) GenerateIDToken(ctx context.Context, lifespan time.Dura
 			if errors.As(err, &ve) && ve.Has(jwt.ValidationErrorExpired) {
 				// Expired ID Tokens are allowed as values to id_token_hint
 			} else if err != nil {
-				return "", errorsx.WithStack(oauth2.ErrServerError.WithWrap(err).WithDebugf("Unable to decode id token from 'id_token_hint' parameter because %s.", err.Error()))
+				return "", errorsx.WithStack(oauth2.ErrServerError.WithWrap(err).WithDebugf("Unable to decode ID Token from 'id_token_hint' parameter because %s.", err.Error()))
 			}
 
 			var subHint string
 
 			if subHint, err = tokenHint.Claims.GetSubject(); subHint == "" || err != nil {
-				return "", errorsx.WithStack(oauth2.ErrServerError.WithDebug("Provided id token from 'id_token_hint' does not have a subject."))
+				return "", errorsx.WithStack(oauth2.ErrServerError.WithDebug("Provided ID Token from 'id_token_hint' does not have a subject."))
 			} else if subHint != claims.Subject {
-				return "", errorsx.WithStack(oauth2.ErrServerError.WithDebug("Subject from authorization mismatches id token subject from 'id_token_hint'."))
+				return "", errorsx.WithStack(oauth2.ErrServerError.WithDebug("Subject from authorization mismatches ID Token subject from 'id_token_hint'."))
 			}
 		}
 	}
@@ -233,7 +233,7 @@ func (h DefaultStrategy) GenerateIDToken(ctx context.Context, lifespan time.Dura
 	}
 
 	if claims.ExpirationTime.Before(time.Now().UTC()) {
-		return "", errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate id token because expiry claim can not be in the past."))
+		return "", errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate ID Token because expiry claim can not be in the past."))
 	}
 
 	if claims.AuthTime == nil || claims.AuthTime.IsZero() {

--- a/handler/openid/strategy_jwt_test.go
+++ b/handler/openid/strategy_jwt_test.go
@@ -110,7 +110,7 @@ func TestJWTStrategy_GenerateIDToken(t *testing.T) {
 
 				return requester
 			},
-			err: "The authorization server encountered an unexpected condition that prevented it from fulfilling the request. Failed to generate id token because expiry claim can not be in the past.",
+			err: "The authorization server encountered an unexpected condition that prevented it from fulfilling the request. Failed to generate ID Token because expiry claim can not be in the past.",
 		},
 		{
 			name: "ShouldFailAuthMaxAgeNoAuthTime",
@@ -127,7 +127,7 @@ func TestJWTStrategy_GenerateIDToken(t *testing.T) {
 
 				return requester
 			},
-			err: "The authorization server encountered an unexpected condition that prevented it from fulfilling the request. Failed to generate id token because authentication time claim is required when max_age is set.",
+			err: "The authorization server encountered an unexpected condition that prevented it from fulfilling the request. Failed to generate ID Token because authentication time claim is required when max_age is set.",
 		},
 		{
 			name: "ShouldFailEmptySubject",
@@ -140,7 +140,7 @@ func TestJWTStrategy_GenerateIDToken(t *testing.T) {
 
 				return requester
 			},
-			err: "The authorization server encountered an unexpected condition that prevented it from fulfilling the request. Failed to generate id token because subject is an empty string.",
+			err: "The authorization server encountered an unexpected condition that prevented it from fulfilling the request. Failed to generate ID Token because subject is an empty string.",
 		},
 		{
 			name: "ShouldPassWithSubject",
@@ -189,7 +189,7 @@ func TestJWTStrategy_GenerateIDToken(t *testing.T) {
 
 				return requester
 			},
-			err: "The authorization server encountered an unexpected condition that prevented it from fulfilling the request. Failed to generate id token because authentication time does not satisfy max_age time.",
+			err: "The authorization server encountered an unexpected condition that prevented it from fulfilling the request. Failed to generate ID Token because authentication time does not satisfy max_age time.",
 		},
 		{
 			name: "ShouldFailPromptNoneAndAuthTimeIndicatesFreshLogin",
@@ -209,7 +209,7 @@ func TestJWTStrategy_GenerateIDToken(t *testing.T) {
 
 				return requester
 			},
-			err: "The authorization server encountered an unexpected condition that prevented it from fulfilling the request. Failed to generate id token because prompt was set to 'none' but auth_time ('2001-09-09 01:46:40 +0000 UTC') happened after the authorization request ('2001-09-09 01:45:40 +0000 UTC') was registered, indicating that the user was logged in during this request which is not allowed.",
+			err: "The authorization server encountered an unexpected condition that prevented it from fulfilling the request. Failed to generate ID Token because prompt was set to 'none' but auth_time ('2001-09-09 01:46:40 +0000 UTC') happened after the authorization request ('2001-09-09 01:45:40 +0000 UTC') was registered, indicating that the user was logged in during this request which is not allowed.",
 		},
 		{
 			name: "ShouldPassPromptNoneWithAuthTimeFreshLoginFlowRefresh",
@@ -280,7 +280,7 @@ func TestJWTStrategy_GenerateIDToken(t *testing.T) {
 
 				return requester
 			},
-			err: "The authorization server encountered an unexpected condition that prevented it from fulfilling the request. Failed to generate id token because prompt was set to 'login' but auth_time ('2001-09-09 00:46:40 +0000 UTC') happened before the authorization request ('2001-09-09 01:45:40 +0000 UTC') was registered, indicating that the user was not re-authenticated which is forbidden.",
+			err: "The authorization server encountered an unexpected condition that prevented it from fulfilling the request. Failed to generate ID Token because prompt was set to 'login' but auth_time ('2001-09-09 00:46:40 +0000 UTC') happened before the authorization request ('2001-09-09 01:45:40 +0000 UTC') was registered, indicating that the user was not re-authenticated which is forbidden.",
 		},
 		{
 			name: "ShouldPassIDTokenHintSubjectMatches",
@@ -347,7 +347,7 @@ func TestJWTStrategy_GenerateIDToken(t *testing.T) {
 
 				return requester
 			},
-			err: "The authorization server encountered an unexpected condition that prevented it from fulfilling the request. Subject from authorization mismatches id token subject from 'id_token_hint'.",
+			err: "The authorization server encountered an unexpected condition that prevented it from fulfilling the request. Subject from authorization mismatches ID Token subject from 'id_token_hint'.",
 		},
 	}
 

--- a/handler/openid/validator.go
+++ b/handler/openid/validator.go
@@ -42,12 +42,27 @@ func NewOpenIDConnectRequestValidator(strategy jwt.Strategy, config openIDConnec
 	}
 }
 
+func (v *OpenIDConnectRequestValidator) ValidateRedirectURIs(ctx context.Context, requester oauth2.AuthorizeRequester) (err error) {
+	// This ensures that the 'redirect_uri' parameter is present for OpenID Connect 1.0 authorization requests as per:
+	//
+	// Authorization Code Flow - https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
+	// Implicit Flow - https://openid.net/specs/openid-connect-core-1_0.html#ImplicitAuthRequest
+	// Hybrid Flow - https://openid.net/specs/openid-connect-core-1_0.html#HybridAuthRequest
+	//
+	// Note: as per the Hybrid Flow documentation the Hybrid Flow has the same requirements as the Authorization Code Flow.
+	if requester.GetRedirectURI() == nil || len(requester.GetRequestForm().Get(consts.FormParameterRedirectURI)) == 0 {
+		return errorsx.WithStack(oauth2.ErrInvalidRequest.WithHint("The 'redirect_uri' parameter is required when using OpenID Connect 1.0."))
+	}
+
+	return nil
+}
+
 // ValidatePrompt ensures the prompt is valid for the OpenID Connect 1.0 Flows.
 //
 // TODO: Refactor time permitting.
 //
 //nolint:gocyclo
-func (v *OpenIDConnectRequestValidator) ValidatePrompt(ctx context.Context, requester oauth2.AuthorizeRequester) error {
+func (v *OpenIDConnectRequestValidator) ValidatePrompt(ctx context.Context, requester oauth2.AuthorizeRequester) (session Session, err error) {
 	// Specification Note: prompt is case-sensitive.
 	requiredPrompt := oauth2.RemoveEmpty(strings.Split(requester.GetRequestForm().Get(consts.FormParameterPrompt), " "))
 
@@ -73,7 +88,7 @@ func (v *OpenIDConnectRequestValidator) ValidatePrompt(ctx context.Context, requ
 		checker := v.Config.GetRedirectSecureChecker(ctx)
 		if stringslice.Has(requiredPrompt, consts.PromptTypeNone) {
 			if !checker(ctx, requester.GetRedirectURI()) {
-				return errorsx.WithStack(oauth2.ErrConsentRequired.WithHint("OAuth 2.0 Client is marked public and redirect uri is not considered secure (https missing), but 'prompt' type 'none' was requested."))
+				return nil, errorsx.WithStack(oauth2.ErrConsentRequired.WithHint("OAuth 2.0 Client is marked public and redirect uri is not considered secure (https missing), but 'prompt' type 'none' was requested."))
 			}
 		}
 	}
@@ -84,12 +99,12 @@ func (v *OpenIDConnectRequestValidator) ValidatePrompt(ctx context.Context, requ
 	}
 
 	if !isWhitelisted(requiredPrompt, availablePrompts) {
-		return errorsx.WithStack(oauth2.ErrInvalidRequest.WithHintf("Used unknown value '%s' for prompt parameter", requiredPrompt))
+		return nil, errorsx.WithStack(oauth2.ErrInvalidRequest.WithHintf("The requested prompt value '%s' either contains unknown, unsupported, or prohibited prompt values.", strings.Join(requiredPrompt, " ")).WithDebugf("The permitted prompt values are '%s'.", strings.Join(availablePrompts, "', '")))
 	}
 
 	if stringslice.Has(requiredPrompt, consts.PromptTypeNone) && len(requiredPrompt) > 1 {
 		// If this parameter contains none with any other value, an error is returned.
-		return errorsx.WithStack(oauth2.ErrInvalidRequest.WithHint("Parameter 'prompt' was set to 'none', but contains other values as well which is not allowed."))
+		return nil, errorsx.WithStack(oauth2.ErrInvalidRequest.WithHint("Parameter 'prompt' was set to 'none', but contains other values as well which is not allowed."))
 	}
 
 	maxAge, err := strconv.ParseInt(requester.GetRequestForm().Get(consts.FormParameterMaximumAge), 10, 64)
@@ -99,17 +114,17 @@ func (v *OpenIDConnectRequestValidator) ValidatePrompt(ctx context.Context, requ
 
 	session, ok := requester.GetSession().(Session)
 	if !ok {
-		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to validate OpenID Connect request because session is not of type oauth2/handler/openid.Session."))
+		return nil, errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to validate OpenID Connect 1.0 request because the session is not of type 'openid.Session' which is required."))
 	}
 
 	claims := session.IDTokenClaims()
 	if claims.Subject == "" {
-		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to validate OpenID Connect request because session subject is empty."))
+		return nil, errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to validate OpenID Connect 1.0 request because the session subject is empty."))
 	}
 
 	// Adds a bit of wiggle room for timing issues
 	if claims.GetAuthTimeSafe().After(time.Now().UTC().Add(time.Second * 5)) {
-		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to validate OpenID Connect request because authentication time is in the future."))
+		return nil, errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to validate OpenID Connect 1.0 request because authentication time is in the future."))
 	}
 
 	rat := session.GetRequestedAt()
@@ -117,34 +132,34 @@ func (v *OpenIDConnectRequestValidator) ValidatePrompt(ctx context.Context, requ
 	if maxAge > 0 {
 		switch {
 		case claims.AuthTime == nil, claims.AuthTime.IsZero():
-			return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to validate OpenID Connect request because authentication time claim is required when max_age is set."))
+			return nil, errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to validate OpenID Connect request because authentication time claim is required when max_age is set."))
 		case rat.IsZero():
-			return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to validate OpenID Connect request because requested at claim is required when max_age is set."))
+			return nil, errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to validate OpenID Connect request because requested at claim is required when max_age is set."))
 		case claims.GetAuthTimeSafe().Add(time.Second * time.Duration(maxAge)).Before(rat):
-			return errorsx.WithStack(oauth2.ErrLoginRequired.WithDebug("Failed to validate OpenID Connect request because authentication time does not satisfy max_age time."))
+			return nil, errorsx.WithStack(oauth2.ErrLoginRequired.WithDebug("Failed to validate OpenID Connect request because authentication time does not satisfy max_age time."))
 		}
 	}
 
 	if stringslice.Has(requiredPrompt, consts.PromptTypeNone) {
 		if claims.AuthTime == nil || claims.AuthTime.IsZero() {
-			return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to validate OpenID Connect request because because auth_time is missing from session."))
+			return nil, errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to validate OpenID Connect request because because auth_time is missing from session."))
 		}
 
 		if !claims.GetAuthTimeSafe().Equal(rat) && claims.GetAuthTimeSafe().After(rat) {
 			// !claims.AuthTime.Truncate(time.Second).Equal(claims.RequestedAt) && claims.AuthTime.Truncate(time.Second).Before(claims.RequestedAt) {
-			return errorsx.WithStack(oauth2.ErrLoginRequired.WithHintf("Failed to validate OpenID Connect request because prompt was set to 'none' but auth_time ('%s') happened after the authorization request ('%s') was registered, indicating that the user was logged in during this request which is not allowed.", claims.GetAuthTimeSafe(), rat))
+			return nil, errorsx.WithStack(oauth2.ErrLoginRequired.WithHintf("Failed to validate OpenID Connect request because prompt was set to 'none' but auth_time ('%s') happened after the authorization request ('%s') was registered, indicating that the user was logged in during this request which is not allowed.", claims.GetAuthTimeSafe(), rat))
 		}
 	}
 
 	if stringslice.Has(requiredPrompt, consts.PromptTypeLogin) {
 		if claims.GetAuthTimeSafe().Before(rat) {
-			return errorsx.WithStack(oauth2.ErrLoginRequired.WithHintf("Failed to validate OpenID Connect request because prompt was set to 'login' but auth_time ('%s') happened before the authorization request ('%s') was registered, indicating that the user was not re-authenticated which is forbidden.", claims.GetAuthTimeSafe(), rat))
+			return nil, errorsx.WithStack(oauth2.ErrLoginRequired.WithHintf("Failed to validate OpenID Connect request because prompt was set to 'login' but auth_time ('%s') happened before the authorization request ('%s') was registered, indicating that the user was not re-authenticated which is forbidden.", claims.GetAuthTimeSafe(), rat))
 		}
 	}
 
 	idTokenHint := requester.GetRequestForm().Get(consts.FormParameterIDTokenHint)
 	if idTokenHint == "" {
-		return nil
+		return session, nil
 	}
 
 	var tokenHint *jwt.Token
@@ -155,18 +170,18 @@ func (v *OpenIDConnectRequestValidator) ValidatePrompt(ctx context.Context, requ
 	if errors.As(err, &ve) && ve.Has(jwt.ValidationErrorExpired) {
 		// Expired tokens are ok
 	} else if err != nil {
-		return errorsx.WithStack(oauth2.ErrInvalidRequest.WithHint("Failed to validate OpenID Connect request as decoding id token from id_token_hint parameter failed.").WithWrap(err).WithDebugError(err))
+		return nil, errorsx.WithStack(oauth2.ErrInvalidRequest.WithHint("Failed to validate OpenID Connect request as decoding ID Token from id_token_hint parameter failed.").WithWrap(err).WithDebugError(err))
 	}
 
 	var subHint string
 
 	if subHint, err = tokenHint.Claims.GetSubject(); subHint == "" || err != nil {
-		return errorsx.WithStack(oauth2.ErrInvalidRequest.WithHint("Failed to validate OpenID Connect request because provided id token from id_token_hint does not have a subject."))
+		return nil, errorsx.WithStack(oauth2.ErrInvalidRequest.WithHint("Failed to validate OpenID Connect request because provided ID Token from id_token_hint does not have a subject."))
 	} else if subHint != claims.Subject {
-		return errorsx.WithStack(oauth2.ErrLoginRequired.WithHint("Failed to validate OpenID Connect request because the subject from provided id token from id_token_hint does not match the current session's subject."))
+		return nil, errorsx.WithStack(oauth2.ErrLoginRequired.WithHint("Failed to validate OpenID Connect request because the subject from provided ID Token from id_token_hint does not match the current session's subject."))
 	}
 
-	return nil
+	return session, nil
 }
 
 func isWhitelisted(items []string, whiteList []string) bool {

--- a/handler/openid/validator_test.go
+++ b/handler/openid/validator_test.go
@@ -152,7 +152,7 @@ func TestValidatePrompt(t *testing.T) {
 			name:     "ShouldFailPromptFoo",
 			prompt:   "foo",
 			isPublic: false,
-			err:      "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Used unknown value '[foo]' for prompt parameter",
+			err:      "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The requested prompt value 'foo' either contains unknown, unsupported, or prohibited prompt values. The permitted prompt values are 'login', 'none', 'consent', 'select_account'.",
 			session: &DefaultSession{
 				Subject: "foo",
 				Claims: &jwt.IDTokenClaims{
@@ -249,7 +249,7 @@ func TestValidatePrompt(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := v.ValidatePrompt(t.Context(), &oauth2.AuthorizeRequest{
+			session, err := v.ValidatePrompt(t.Context(), &oauth2.AuthorizeRequest{
 				Request: oauth2.Request{
 					Form:    url.Values{"prompt": {tc.prompt}, "id_token_hint": {tc.idTokenHint}},
 					Client:  &oauth2.DefaultClient{Public: tc.isPublic},
@@ -260,8 +260,10 @@ func TestValidatePrompt(t *testing.T) {
 
 			if tc.err != "" {
 				assert.EqualError(t, oauth2.ErrorToDebugRFC6749Error(err), tc.err)
+				assert.Nil(t, session)
 			} else {
 				assert.NoError(t, oauth2.ErrorToDebugRFC6749Error(err))
+				assert.NotNil(t, session)
 			}
 		})
 	}

--- a/handler/rfc8693/id_token_type_handler.go
+++ b/handler/rfc8693/id_token_type_handler.go
@@ -125,12 +125,12 @@ func (c *IDTokenTypeHandler) issue(ctx context.Context, request oauth2.AccessReq
 	sess, ok := request.GetSession().(openid.Session)
 	if !ok {
 		return errorsx.WithStack(oauth2.ErrServerError.WithDebug(
-			"Failed to generate id token because session must be of type 'openid.Session'."))
+			"Failed to generate ID Token because session must be of type 'openid.Session'."))
 	}
 
 	claims := sess.IDTokenClaims()
 	if claims.Subject == "" {
-		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate id token because subject is an empty string."))
+		return errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate ID Token because subject is an empty string."))
 	}
 
 	token, err := c.IssueStrategy.GenerateIDToken(ctx, c.Config.GetIDTokenLifespan(ctx), request)

--- a/internal/test_helpers.go
+++ b/internal/test_helpers.go
@@ -49,6 +49,8 @@ func RequireEqualDuration(t *testing.T, expected time.Duration, actual time.Dura
 }
 
 func RequireEqualTime(t *testing.T, expected time.Time, actual time.Time, precision time.Duration) {
+	t.Helper()
+
 	delta := expected.Sub(actual)
 	if delta < 0 {
 		delta = -delta

--- a/oauth2.go
+++ b/oauth2.go
@@ -354,8 +354,8 @@ type AuthorizeRequester interface {
 	// DidHandleAllResponseTypes returns if all requested response types have been handled correctly
 	DidHandleAllResponseTypes() (didHandle bool)
 
-	// GetRedirectURI returns the requested redirect URI
-	GetRedirectURI() (redirectURL *url.URL)
+	// GetRedirectURI returns the requested redirect URI.
+	GetRedirectURI() (uri *url.URL)
 
 	// IsRedirectURIValid returns false if the redirect is not rfc-conform (i.e. missing client, not on white list,
 	// or malformed)
@@ -364,13 +364,13 @@ type AuthorizeRequester interface {
 	// GetState returns the request's state.
 	GetState() (state string)
 
-	// GetResponseMode returns response_mode of the authorization request
+	// GetResponseMode returns response_mode of the authorization request.
 	GetResponseMode() (responseMode ResponseModeType)
 
-	// SetDefaultResponseMode sets default response mode for a response type in a flow
+	// SetDefaultResponseMode sets default response mode for a response type in a flow.
 	SetDefaultResponseMode(responseMode ResponseModeType)
 
-	// GetDefaultResponseMode gets default response mode for a response type in a flow
+	// GetDefaultResponseMode gets default response mode for a response type in a flow.
 	GetDefaultResponseMode() (responseMode ResponseModeType)
 
 	Requester
@@ -378,16 +378,16 @@ type AuthorizeRequester interface {
 
 // DeviceAuthorizeRequester is a device authorization endpoint's request context.
 type DeviceAuthorizeRequester interface {
-	// SetDeviceCodeSignature set the device code signature
+	// SetDeviceCodeSignature set the device code signature.
 	SetDeviceCodeSignature(signature string)
 
-	// GetDeviceCodeSignature returns the device code signature
+	// GetDeviceCodeSignature returns the device code signature.
 	GetDeviceCodeSignature() (signature string)
 
-	// SetUserCodeSignature set the user code signature
+	// SetUserCodeSignature set the user code signature.
 	SetUserCodeSignature(signature string)
 
-	// GetUserCodeSignature returns the user code signature
+	// GetUserCodeSignature returns the user code signature.
 	GetUserCodeSignature() (signature string)
 
 	SetStatus(status DeviceAuthorizeStatus)
@@ -416,7 +416,7 @@ type AccessResponder interface {
 	// SetAccessToken sets the responses mandatory access token.
 	SetAccessToken(token string)
 
-	// SetTokenType set's the responses mandatory token type
+	// SetTokenType set's the responses mandatory token type.
 	SetTokenType(tokenType string)
 
 	// GetAccessToken returns the responses access token.
@@ -434,37 +434,37 @@ type AuthorizeResponder interface {
 	// GetCode returns the response's authorize code if set.
 	GetCode() (code string)
 
-	// GetHeader returns the response's header
+	// GetHeader returns the response's header.
 	GetHeader() (header http.Header)
 
-	// AddHeader adds a header key value pair to the response
+	// AddHeader adds a header key value pair to the response.
 	AddHeader(key, value string)
 
-	// GetParameters returns the response's parameters
+	// GetParameters returns the response's parameters.
 	GetParameters() (query url.Values)
 
-	// AddParameter adds key value pair to the response
+	// AddParameter adds key value pair to the response.
 	AddParameter(key, value string)
 }
 
-// PushedAuthorizeResponder is the response object for PAR
+// PushedAuthorizeResponder is the response object for PAR.
 type PushedAuthorizeResponder interface {
 	// GetRequestURI returns the request_uri
 	GetRequestURI() (uri string)
 
-	// SetRequestURI sets the request_uri
+	// SetRequestURI sets the request_uri.
 	SetRequestURI(requestURI string)
 
-	// GetExpiresIn gets the expires_in
+	// GetExpiresIn gets the expires_in.
 	GetExpiresIn() (expires int)
 
-	// SetExpiresIn sets the expires_in
+	// SetExpiresIn sets the expires_in.
 	SetExpiresIn(seconds int)
 
-	// GetHeader returns the response's header
+	// GetHeader returns the response's header.
 	GetHeader() (header http.Header)
 
-	// AddHeader adds a header key value pair to the response
+	// AddHeader adds a header key value pair to the response.
 	AddHeader(key, value string)
 
 	// SetExtra sets a key value pair for the response.
@@ -482,10 +482,10 @@ type DeviceAuthorizeResponder interface {
 
 	SetDeviceCode(code string)
 
-	// GetHeader returns the response's header
+	// GetHeader returns the response's header.
 	GetHeader() (header http.Header)
 
-	// AddHeader adds an header key value pair to the response
+	// AddHeader adds an header key value pair to the response.
 	AddHeader(key, value string)
 
 	GetUserCode() (code string)
@@ -520,22 +520,22 @@ type DeviceAuthorizeResponder interface {
 
 // DeviceUserAuthorizeResponder is device grant user verification endpoint response.
 type DeviceUserAuthorizeResponder interface {
-	// GetHeader returns the response's header
+	// GetHeader returns the response's header.
 	GetHeader() (header http.Header)
 
-	// AddHeader adds an header key value pair to the response
+	// AddHeader adds an header key value pair to the response.
 	AddHeader(key, value string)
 
-	// GetParameters returns the response's parameters
+	// GetParameters returns the response's parameters.
 	GetParameters() (query url.Values)
 
-	// AddParameter adds key value pair to the response
+	// AddParameter adds key value pair to the response.
 	AddParameter(key, value string)
 
-	// GetStatus returns the device grant user verification status
+	// GetStatus returns the device grant user verification status.
 	GetStatus() (status string)
 
-	// SetStatus sets the device grant user verification status
+	// SetStatus sets the device grant user verification status.
 	SetStatus(status string)
 
 	// SetExtra sets a key value pair for the access response.
@@ -548,9 +548,9 @@ type DeviceUserAuthorizeResponder interface {
 	ToMap() (values map[string]any)
 }
 
-// G11NContext is the globalization context
+// G11NContext is the globalization context.
 type G11NContext interface {
-	// GetLang returns the current language in the context
+	// GetLang returns the current language in the context.
 	GetLang() (lang language.Tag)
 }
 


### PR DESCRIPTION
This adjusts the specifics of validating the existence of redirect URIs to the appropriate location. Specifically while we could assume the request is an OpenID Connect 1.0 flow based on the scope, it may not be based on the configuration of the provider. Thus moving this into a specific OpenID Connect 1.0 validator ensures compatibility with that use case.