### PR TITLE
fix: introspection exp claim should match introspected token type

### DIFF
--- a/introspection_response_writer.go
+++ b/introspection_response_writer.go
@@ -218,8 +218,8 @@ func (f *Fosite) WriteIntrospectionResponse(ctx context.Context, rw http.Respons
 		}
 	}
 
-	if !r.GetAccessRequester().GetSession().GetExpiresAt(AccessToken).IsZero() {
-		response[jwt.ClaimExpirationTime] = r.GetAccessRequester().GetSession().GetExpiresAt(AccessToken).Unix()
+	if expires := r.GetAccessRequester().GetSession().GetExpiresAt(r.GetTokenUse()); !expires.IsZero() {
+		response[jwt.ClaimExpirationTime] = expires.Unix()
 	}
 	if r.GetAccessRequester().GetClient().GetID() != "" {
 		response[jwt.ClaimClientIdentifier] = r.GetAccessRequester().GetClient().GetID()

--- a/introspection_response_writer_test.go
+++ b/introspection_response_writer_test.go
@@ -129,6 +129,34 @@ func TestWriteIntrospectionResponseBody(t *testing.T) {
 			hasExp:   false,
 			hasExtra: true,
 		},
+		{
+			description: "should success for not expired refresh token",
+			setup: func() {
+				ires.Active = true
+				ires.TokenUse = RefreshToken
+				session := &DefaultSession{}
+				session.SetExpiresAt(ires.TokenUse, time.Now().Add(time.Hour*2))
+				ires.AccessRequester = NewAccessRequest(session)
+			},
+			active:   true,
+			hasExp:   true,
+			hasExtra: false,
+		},
+		{
+			description: "should not leak access token exp when introspecting refresh token",
+			setup: func() {
+				ires.Active = true
+				ires.TokenUse = RefreshToken
+				session := &DefaultSession{}
+				// Only the access token expiry is set, the refresh token has none.
+				// The introspection response must reflect the refresh token, not leak the access token expiry.
+				session.SetExpiresAt(AccessToken, time.Now().Add(time.Hour*2))
+				ires.AccessRequester = NewAccessRequest(session)
+			},
+			active:   true,
+			hasExp:   false,
+			hasExtra: false,
+		},
 	} {
 		t.Run(c.description, func(t *testing.T) {
 			c.setup()
@@ -168,6 +196,52 @@ func TestWriteIntrospectionResponseBody(t *testing.T) {
 				assert.NotEqual(t, "invalid", params.Audience)
 				assert.NotEqual(t, "invalid", params.Username)
 			}
+		})
+	}
+}
+
+func TestWriteIntrospectionResponseBodyExpiryMatchesTokenUse(t *testing.T) {
+	provider := new(Fosite)
+
+	accessExpiry := time.Now().Add(time.Hour).Truncate(time.Second)
+	refreshExpiry := time.Now().Add(time.Hour * 24).Truncate(time.Second)
+
+	for _, c := range []struct {
+		description string
+		tokenUse    TokenUse
+		expected    int64
+	}{
+		{
+			description: "access token introspection returns access token expiry",
+			tokenUse:    AccessToken,
+			expected:    accessExpiry.Unix(),
+		},
+		{
+			description: "refresh token introspection returns refresh token expiry",
+			tokenUse:    RefreshToken,
+			expected:    refreshExpiry.Unix(),
+		},
+	} {
+		t.Run(c.description, func(t *testing.T) {
+			session := &DefaultSession{}
+			session.SetExpiresAt(AccessToken, accessExpiry)
+			session.SetExpiresAt(RefreshToken, refreshExpiry)
+
+			ires := &IntrospectionResponse{
+				Active:          true,
+				TokenUse:        c.tokenUse,
+				AccessRequester: NewAccessRequest(session),
+			}
+
+			rw := httptest.NewRecorder()
+			provider.WriteIntrospectionResponse(context.Background(), rw, ires)
+
+			var params struct {
+				Exp *int64 `json:"exp"`
+			}
+			require.NoError(t, json.NewDecoder(rw.Body).Decode(&params))
+			require.NotNil(t, params.Exp)
+			assert.Equal(t, c.expected, *params.Exp)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

`WriteIntrospectionResponse` always populated the `exp` claim with the access-token expiry, even when the introspected token was a refresh token. Per [RFC 7662 §2.2](https://datatracker.ietf.org/doc/html/rfc7662#section-2.2), `exp` must indicate when *this* token expires — not a sibling token's expiry.

### Before
`introspection_response_writer.go:221-222`:
```go
if !r.GetAccessRequester().GetSession().GetExpiresAt(AccessToken).IsZero() {
    response[jwt.ClaimExpirationTime] = r.GetAccessRequester().GetSession().GetExpiresAt(AccessToken).Unix()
}
```
The session key is hard-coded to `AccessToken`, so a refresh-token introspection returns the access-token expiry. Since access-token lifespans are usually much shorter than refresh-token lifespans, callers see an `exp` that is already in the past while `active=true` — and never the actual refresh-token expiry that ` SetExpiresAt(oauth2.RefreshToken, ...)` stored at issuance time (see `flow_authorize_code_token.go:113-115`, `flow_refresh.go:148-151`).

### After
Use the responder's reported `TokenUse`:
```go
if expires := r.GetAccessRequester().GetSession().GetExpiresAt(r.GetTokenUse()); !expires.IsZero() {
    response[jwt.ClaimExpirationTime] = expires.Unix()
}
```
`TokenUse` is a type alias for `TokenType`, so no translation is needed. The two `TokenIntrospector` implementations shipped in this library both return well-defined values on success: `handler/oauth2.CoreValidator` returns `AccessToken` or `RefreshToken`, and `handler/oauth2.StatelessJWTValidator` always returns `AccessToken`. Stateless JWT behavior is therefore unchanged — only the refresh-token path through `CoreValidator` is corrected.

## Tests

- Added two cases to the existing table-driven `TestWriteIntrospectionResponseBody`:
  - `should success for not expired refresh token`
  - `should not leak access token exp when introspecting refresh token` (regression guard for the original bug — only `AccessToken` expiry is set, no `exp` should appear in the response)
- Added `TestWriteIntrospectionResponseBodyExpiryMatchesTokenUse` which sets *both* expiries and asserts the response `exp` equals the expected one for each `TokenUse`.

All existing tests still pass (`go test ./...`).

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all packages green incl. `integration`)
- [x] Verified failing without the writer change: removing the writer fix reproduces a failure in the new tests