### PR TITLE
fix(pkce): session stored needlessly

### DIFF
--- a/handler/pkce/handler.go
+++ b/handler/pkce/handler.go
@@ -43,8 +43,11 @@ func (c *Handler) HandleAuthorizeEndpointRequest(ctx context.Context, requester 
 		return err
 	}
 
-	// We don't need a session if it's not enforced and the PKCE parameters are not provided by the client.
-	if len(challenge) == 0 && len(method) == 0 {
+	if len(challenge) == 0 {
+		if len(method) != 0 {
+			return errorsx.WithStack(oauth2.ErrInvalidRequest.WithDebug("The client requested PKCE but no challenge was provided in the authorize request."))
+		}
+
 		return nil
 	}
 

--- a/handler/pkce/handler_test.go
+++ b/handler/pkce/handler_test.go
@@ -104,6 +104,24 @@ func TestHandler_HandleAuthorizeEndpointRequest(t *testing.T) {
 			"The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Clients must include a 'code_challenge' when performing the authorize code flow, but it is missing. The authorization server is configured in a way that enforces PKCE for all clients.",
 		},
 		{
+			// Covers handler.go:46-49 — a client that sends 'code_challenge_method' without
+			// 'code_challenge' has signalled PKCE intent (RFC 7636 §4.3) but omitted the proof
+			// to verify it. Even with no enforcement policy in effect (the validate() call above
+			// returns nil), this partial PKCE request is rejected with 'invalid_request'.
+			"ShouldFailMethodWithoutChallenge",
+			&oauth2.AuthorizeRequest{
+				ResponseTypes: oauth2.Arguments{consts.ResponseTypeAuthorizationCodeFlow},
+				Request: oauth2.Request{
+					Client: &TestPKCEClient{EnforcePKCE: false, DefaultClient: &oauth2.DefaultClient{ID: "test"}},
+					Form:   url.Values{consts.FormParameterCodeChallengeMethod: []string{consts.PKCEChallengeMethodSHA256}},
+				},
+			},
+			nil,
+			nil,
+			oauth2.ErrInvalidRequest,
+			"The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Make sure that the various parameters are correct, be aware of case sensitivity and trim your parameters. Make sure that the client you are using has exactly whitelisted the redirect_uri you specified. The client requested PKCE but no challenge was provided in the authorize request.",
+		},
+		{
 			"ShouldFailNoPKCEButRequiredForPublicClient",
 			&oauth2.AuthorizeRequest{
 				ResponseTypes: oauth2.Arguments{consts.ResponseTypeAuthorizationCodeFlow},


### PR DESCRIPTION
This fixes an issue where the PKCE session was stored needlessly, and an issue where a missing challenge did not result in an error.