### PR TITLE
fix: ensure low detail errors for client auth

### DIFF
--- a/access_request_handler_test.go
+++ b/access_request_handler_test.go
@@ -79,7 +79,7 @@ func TestNewAccessRequest(t *testing.T) {
 				consts.FormParameterGrantType: {"foo"},
 			},
 			expectErr:    ErrInvalidClient,
-			expectStrErr: "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method).",
+			expectStrErr: "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect.",
 			mock: func(ctx gomock.Matcher, handler *mock.MockTokenEndpointHandler, store *mock.MockStorage, client *DefaultClient) {
 				store.EXPECT().GetClient(gomock.Any(), gomock.Eq("foo")).Return(nil, errors.New(""))
 			},
@@ -516,7 +516,7 @@ func TestNewAccessRequestWithMixedClientAuth(t *testing.T) {
 				handlerWithoutClientAuth.EXPECT().HandleTokenEndpointRequest(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			method: "POST",
-			err:    "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). Client Credentials missing or malformed. The Client ID was missing from the request but it is required when there is no client assertion.",
+			err:    "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The Client ID was missing from the request but it is required when there is no client assertion.",
 		},
 	}
 

--- a/access_request_handler_test.go
+++ b/access_request_handler_test.go
@@ -516,7 +516,7 @@ func TestNewAccessRequestWithMixedClientAuth(t *testing.T) {
 				handlerWithoutClientAuth.EXPECT().HandleTokenEndpointRequest(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			method: "POST",
-			err:    "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Client Credentials missing or malformed. The Client ID was missing from the request but it is required when there is no client assertion.",
+			err:    "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). Client Credentials missing or malformed. The Client ID was missing from the request but it is required when there is no client assertion.",
 		},
 	}
 

--- a/client_authentication.go
+++ b/client_authentication.go
@@ -102,30 +102,30 @@ func getClientCredentialsSecretBasic(r *http.Request) (id, secret string, ok boo
 
 	c, err := base64.StdEncoding.DecodeString(value)
 	if err != nil {
-		return "", "", false, errorsx.WithStack(ErrInvalidClient.WithHint("The client credentials from the HTTP authorization header could not be parsed.").WithWrap(err).WithDebugf("Error occurred performing a base64 decode: %+v.", err))
+		return "", "", false, errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithWrap(err).WithDebugf("Error occurred performing a base64 decode: %+v.", err))
 	}
 
 	cs := string(c)
 
 	id, secret, ok = strings.Cut(cs, ":")
 	if !ok {
-		return "", "", false, errorsx.WithStack(ErrInvalidRequest.WithHint("The client credentials from the HTTP authorization header could not be parsed.").WithDebug("The basic scheme value was not separated by a colon."))
+		return "", "", false, errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebug("The basic scheme value was not separated by a colon."))
 	}
 
 	if id, err = url.QueryUnescape(id); err != nil {
-		return "", "", false, errorsx.WithStack(ErrInvalidRequest.WithHint("The client id in the HTTP authorization header could not be decoded from 'application/x-www-form-urlencoded'.").WithWrap(err).WithDebugError(err))
+		return "", "", false, errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebug("The client id in the HTTP authorization header could not be decoded from 'application/x-www-form-urlencoded'.").WithWrap(err))
 	}
 
 	if secret, err = url.QueryUnescape(secret); err != nil {
-		return "", "", false, errorsx.WithStack(ErrInvalidRequest.WithHint("The client secret in the HTTP authorization header could not be decoded from 'application/x-www-form-urlencoded'.").WithWrap(err).WithDebugError(err))
+		return "", "", false, errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebug("The client secret in the HTTP authorization header could not be decoded from 'application/x-www-form-urlencoded'.").WithWrap(err))
 	}
 
 	if len(id) != 0 && !RegexSpecificationVSCHAR.MatchString(id) {
-		return "", "", false, errorsx.WithStack(ErrInvalidRequest.WithHint("The client id in the HTTP request had an invalid character."))
+		return "", "", false, errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebug("The client id in the HTTP request had an invalid character."))
 	}
 
 	if len(secret) != 0 && !RegexSpecificationVSCHAR.MatchString(secret) {
-		return "", "", false, errorsx.WithStack(ErrInvalidRequest.WithHint("The client secret in the HTTP request had an invalid character."))
+		return "", "", false, errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebug("The client secret in the HTTP request had an invalid character."))
 	}
 
 	return id, secret, secret != "", nil
@@ -140,7 +140,7 @@ func getClientCredentialsClientAssertion(form url.Values) (assertion, assertionT
 func getClientCredentialsClientIDValid(post, header string, assertion *ClientAssertion) (id string, err error) {
 	if len(post) != 0 && len(header) != 0 && post != header {
 		return "", errorsx.WithStack(ErrInvalidClient.
-			WithHint("The 'client_id' in the request body did not match the 'client_id' supplied via the HTTP Basic Authorization header.").
+			WithHint(hintClientCredentialsInvalid).
 			WithDebugf("The HTTP Basic Authorization header specified the 'client_id' value '%s' but the request body specified the 'client_id' value '%s'. Per RFC 6749 Section 2.3 a client MUST NOT use more than one authentication method.", header, post))
 	}
 
@@ -155,11 +155,11 @@ func getClientCredentialsClientIDValid(post, header string, assertion *ClientAss
 			return assertion.ID, nil
 		}
 
-		return id, errorsx.WithStack(ErrInvalidClient.WithHint("Client Credentials missing or malformed.").WithDebug("The Client ID was missing from the request but it is required when there is no client assertion."))
+		return id, errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebug("The Client ID was missing from the request but it is required when there is no client assertion."))
 	}
 
 	if !RegexSpecificationVSCHAR.MatchString(id) {
-		return id, errorsx.WithStack(ErrInvalidRequest.WithHint("The client id in the request had an invalid character."))
+		return id, errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebug("The client id in the request had an invalid character."))
 	}
 
 	return id, nil

--- a/client_authentication.go
+++ b/client_authentication.go
@@ -93,16 +93,16 @@ func getClientCredentialsSecretBasic(r *http.Request) (id, secret string, ok boo
 	scheme, value, ok := strings.Cut(auth, " ")
 
 	if !ok {
-		return "", "", false, errorsx.WithStack(ErrInvalidRequest.WithHint("The client credentials from the HTTP authorization header could not be parsed.").WithWrap(err).WithDebug("The header value is either missing a scheme, value, or the separator between them."))
+		return "", "", false, errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithWrap(err).WithDebug("The header value is either missing a scheme, value, or the separator between them."))
 	}
 
 	if !strings.EqualFold(scheme, "Basic") {
-		return "", "", false, errorsx.WithStack(ErrInvalidRequest.WithHint("The client credentials from the HTTP authorization header had an unknown scheme.").WithDebugf("The scheme '%s' is not known for client authentication.", scheme))
+		return "", "", false, errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebugf("The scheme '%s' is not known for client authentication.", scheme))
 	}
 
 	c, err := base64.StdEncoding.DecodeString(value)
 	if err != nil {
-		return "", "", false, errorsx.WithStack(ErrInvalidRequest.WithHint("The client credentials from the HTTP authorization header could not be parsed.").WithWrap(err).WithDebugf("Error occurred performing a base64 decode: %+v.", err))
+		return "", "", false, errorsx.WithStack(ErrInvalidClient.WithHint("The client credentials from the HTTP authorization header could not be parsed.").WithWrap(err).WithDebugf("Error occurred performing a base64 decode: %+v.", err))
 	}
 
 	cs := string(c)
@@ -138,6 +138,12 @@ func getClientCredentialsClientAssertion(form url.Values) (assertion, assertionT
 }
 
 func getClientCredentialsClientIDValid(post, header string, assertion *ClientAssertion) (id string, err error) {
+	if len(post) != 0 && len(header) != 0 && post != header {
+		return "", errorsx.WithStack(ErrInvalidClient.
+			WithHint("The 'client_id' in the request body did not match the 'client_id' supplied via the HTTP Basic Authorization header.").
+			WithDebugf("The HTTP Basic Authorization header specified the 'client_id' value '%s' but the request body specified the 'client_id' value '%s'. Per RFC 6749 Section 2.3 a client MUST NOT use more than one authentication method.", header, post))
+	}
+
 	if len(post) != 0 {
 		id = post
 	} else if len(header) != 0 {
@@ -149,7 +155,7 @@ func getClientCredentialsClientIDValid(post, header string, assertion *ClientAss
 			return assertion.ID, nil
 		}
 
-		return id, errorsx.WithStack(ErrInvalidRequest.WithHint("Client Credentials missing or malformed.").WithDebug("The Client ID was missing from the request but it is required when there is no client assertion."))
+		return id, errorsx.WithStack(ErrInvalidClient.WithHint("Client Credentials missing or malformed.").WithDebug("The Client ID was missing from the request but it is required when there is no client assertion."))
 	}
 
 	if !RegexSpecificationVSCHAR.MatchString(id) {

--- a/client_authentication_strategy.go
+++ b/client_authentication_strategy.go
@@ -43,7 +43,7 @@ func (s *DefaultClientAuthenticationStrategy) AuthenticateClient(ctx context.Con
 
 	idBasic, secretBasic, hasBasic, err = getClientCredentialsSecretBasic(r)
 	if err != nil {
-		return nil, "", errorsx.WithStack(ErrInvalidRequest.WithHint("The client credentials in the HTTP authorization header could not be parsed. Either the scheme was missing, the scheme was invalid, or the value had malformed data.").WithWrap(err).WithDebugError(err))
+		return nil, "", err
 	}
 
 	id, secret, hasPost = s.getClientCredentialsSecretPost(form)
@@ -104,7 +104,7 @@ func (s *DefaultClientAuthenticationStrategy) authenticate(ctx context.Context, 
 	case 0:
 		// The 0 case means no authentication information at all exists even if the client is a public client. This
 		// likely only occurs on requests where the client_id is not known.
-		return nil, "", errorsx.WithStack(ErrInvalidRequest.WithHint("Client Authentication failed with no known authentication method."))
+		return nil, "", errorsx.WithStack(ErrInvalidClient.WithHint("Client Authentication failed with no known authentication method."))
 	case 1:
 		// Proper authentication has occurred.
 		break
@@ -153,7 +153,7 @@ func NewClientAssertion(ctx context.Context, strategy jwt.Strategy, store Client
 			return &ClientAssertion{Assertion: assertion, Type: assertionType}, errorsx.WithStack(ErrInvalidRequest.WithHintf("The request parameter 'client_assertion' must be set when using 'client_assertion_type' of '%s'.", consts.ClientAssertionTypeJWTBearer))
 		}
 	default:
-		return &ClientAssertion{Assertion: assertion, Type: assertionType}, errorsx.WithStack(ErrInvalidRequest.WithHintf("Unknown client_assertion_type '%s'.", assertionType))
+		return &ClientAssertion{Assertion: assertion, Type: assertionType}, errorsx.WithStack(ErrInvalidClient.WithHintf("Unknown client_assertion_type '%s'.", assertionType))
 	}
 
 	if token, err = strategy.Decode(ctx, assertion, jwt.WithAllowUnverified(), jwt.WithSigAlgorithm(jwt.SignatureAlgorithmsNone...)); err != nil {
@@ -256,7 +256,7 @@ func (s *DefaultClientAuthenticationStrategy) doAuthenticateAssertionJWTBearer(c
 	)
 
 	if c, ok = client.(AuthenticationMethodClient); !ok {
-		return "", errorsx.WithStack(ErrInvalidRequest.WithHint("The registered client does not support OAuth 2.0 JWT Profile Client Authentication RFC7523 or OpenID Connect 1.0 specific authentication methods."))
+		return "", errorsx.WithStack(ErrInvalidClient.WithHint("The registered client does not support OAuth 2.0 JWT Profile Client Authentication RFC7523 or OpenID Connect 1.0 specific authentication methods."))
 	}
 
 	if method, _, _, token, err = s.doAuthenticateAssertionParseAssertionJWTBearer(ctx, c, assertion, handler); err != nil {
@@ -273,10 +273,13 @@ func (s *DefaultClientAuthenticationStrategy) doAuthenticateAssertionJWTBearer(c
 
 	claims.FromMapClaims(token.Claims.ToMapClaims())
 
+	issOK := subtle.ConstantTimeCompare([]byte(claims.Issuer), clientID) == 1
+	subOK := subtle.ConstantTimeCompare([]byte(claims.Subject), clientID) == 1
+
 	switch {
-	case subtle.ConstantTimeCompare([]byte(claims.Issuer), clientID) == 0:
+	case !issOK:
 		return "", errorsx.WithStack(ErrInvalidClient.WithHint("The client assertion had invalid claims.").WithDebug("Claim 'iss' from 'client_assertion' must match the 'client_id' of the OAuth 2.0 Client."))
-	case subtle.ConstantTimeCompare([]byte(claims.Subject), clientID) == 0:
+	case !subOK:
 		return "", errorsx.WithStack(ErrInvalidClient.WithHint("The client assertion had invalid claims.").WithDebug("Claim 'sub' from 'client_assertion' must match the 'client_id' of the OAuth 2.0 Client."))
 	case claims.JTI == "":
 		return "", errorsx.WithStack(ErrInvalidClient.WithHint("The client assertion had invalid claims.").WithDebug("Claim 'jti' from 'client_assertion' must be set but is not."))

--- a/client_authentication_strategy.go
+++ b/client_authentication_strategy.go
@@ -96,7 +96,7 @@ func (s *DefaultClientAuthenticationStrategy) authenticate(ctx context.Context, 
 
 	if client == nil {
 		if client, err = s.Store.GetClient(ctx, id); err != nil {
-			return nil, "", errorsx.WithStack(ErrInvalidClient.WithWrap(err).WithDebugError(err))
+			return nil, "", errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithWrap(err).WithDebugError(err))
 		}
 	}
 
@@ -104,7 +104,7 @@ func (s *DefaultClientAuthenticationStrategy) authenticate(ctx context.Context, 
 	case 0:
 		// The 0 case means no authentication information at all exists even if the client is a public client. This
 		// likely only occurs on requests where the client_id is not known.
-		return nil, "", errorsx.WithStack(ErrInvalidClient.WithHint("Client Authentication failed with no known authentication method."))
+		return nil, "", errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebug("Client Authentication failed with no known authentication method."))
 	case 1:
 		// Proper authentication has occurred.
 		break
@@ -117,9 +117,7 @@ func (s *DefaultClientAuthenticationStrategy) authenticate(ctx context.Context, 
 			break
 		}
 
-		return nil, "", errorsx.WithStack(ErrInvalidRequest.
-			WithHintf("Client Authentication failed with more than one known authentication method included in the request which is not permitted.").
-			WithDebugf("The registered client with id '%s' and the authorization server policy does not permit this malformed request. The `%s_endpoint_auth_method` methods determined to be used were '%s'.", client.GetID(), handler.Name(), strings.Join(methods, "', '")))
+		return nil, "", errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebugf("Client Authentication failed with more than one known authentication method included in the request which is not permitted. The registered client with id '%s' and the authorization server policy does not permit this malformed request. The `%s_endpoint_auth_method` methods determined to be used were '%s'.", client.GetID(), handler.Name(), strings.Join(methods, "', '")))
 	}
 
 	switch {
@@ -150,10 +148,10 @@ func NewClientAssertion(ctx context.Context, strategy jwt.Strategy, store Client
 	switch assertionType {
 	case consts.ClientAssertionTypeJWTBearer:
 		if len(assertion) == 0 {
-			return &ClientAssertion{Assertion: assertion, Type: assertionType}, errorsx.WithStack(ErrInvalidRequest.WithHintf("The request parameter 'client_assertion' must be set when using 'client_assertion_type' of '%s'.", consts.ClientAssertionTypeJWTBearer))
+			return &ClientAssertion{Assertion: assertion, Type: assertionType}, errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebugf("The request parameter 'client_assertion' must be set when using 'client_assertion_type' of '%s'.", consts.ClientAssertionTypeJWTBearer))
 		}
 	default:
-		return &ClientAssertion{Assertion: assertion, Type: assertionType}, errorsx.WithStack(ErrInvalidClient.WithHintf("Unknown client_assertion_type '%s'.", assertionType))
+		return &ClientAssertion{Assertion: assertion, Type: assertionType}, errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebugf("Unknown client_assertion_type '%s'.", assertionType))
 	}
 
 	if token, err = strategy.Decode(ctx, assertion, jwt.WithAllowUnverified(), jwt.WithSigAlgorithm(jwt.SignatureAlgorithmsNone...)); err != nil {
@@ -198,18 +196,12 @@ type ClientAssertion struct {
 func (s *DefaultClientAuthenticationStrategy) doAuthenticateNone(_ context.Context, client Client, handler EndpointClientAuthHandler) (method string, err error) {
 	if c, ok := client.(AuthenticationMethodClient); ok {
 		if method = handler.GetAuthMethod(c); method != consts.ClientAuthMethodNone {
-			return "", errorsx.WithStack(
-				ErrInvalidClient.
-					WithHintf("The request was determined to be using '%s_endpoint_auth_method' method '%s', however the OAuth 2.0 client registration does not allow this method.", handler.Name(), consts.ClientAuthMethodNone).
-					WithDebugf("The registered client with id '%s' is configured to only support '%s_endpoint_auth_method' method '%s'. Either the Authorization Server client registration will need to have the '%s_endpoint_auth_method' updated to '%s' or the Relying Party will need to be configured to use '%s'.", client.GetID(), handler.Name(), method, handler.Name(), consts.ClientAuthMethodNone, method))
+			return "", errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebugf("The registered client with id '%s' is configured to only support '%s_endpoint_auth_method' method '%s', but the method '%s' was determined to be used. Either the Authorization Server client registration will need to have the '%s_endpoint_auth_method' updated to '%s' or the Relying Party will need to be configured to use '%s'.", client.GetID(), handler.Name(), method, consts.ClientAuthMethodNone, handler.Name(), consts.ClientAuthMethodNone, method))
 		}
 	}
 
 	if !client.IsPublic() {
-		return "", errorsx.WithStack(
-			ErrInvalidClient.
-				WithHintf("The request was determined to be using '%s_endpoint_auth_method' method '%s', however the OAuth 2.0 client registration does not allow this method.", consts.ClientAuthMethodNone, handler.Name()).
-				WithDebugf("The registered client with id '%s' is configured with a confidential client type but only client registrations with a public client type can use this '%s_endpoint_auth_method'.", client.GetID(), handler.Name()))
+		return "", errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebugf("The '%s_endpoint_auth_method' method 'none' was determined to be used, but the registered client with id '%s' is configured with a confidential client type but only client registrations with a public client type can use this '%s_endpoint_auth_method'.", handler.Name(), client.GetID(), handler.Name()))
 	}
 
 	return consts.ClientAuthMethodNone, nil
@@ -229,8 +221,8 @@ func (s *DefaultClientAuthenticationStrategy) doAuthenticateClientSecret(ctx con
 		case cmethod != method:
 			return "", errorsx.WithStack(
 				ErrInvalidClient.
-					WithHintf("The request was determined to be using '%s_endpoint_auth_method' method '%s', however the OAuth 2.0 client registration does not allow this method.", handler.Name(), method).
-					WithDebugf("The registered client with id '%s' is configured to only support '%s_endpoint_auth_method' method '%s'. Either the Authorization Server client registration will need to have the '%s_endpoint_auth_method' updated to '%s' or the Relying Party will need to be configured to use '%s'.", client.GetID(), handler.Name(), cmethod, handler.Name(), method, cmethod))
+					WithHint(hintClientCredentialsInvalid).
+					WithDebugf("The request was determined to be using '%s_endpoint_auth_method' method '%s', however the registered client with id '%s' is configured to only support '%s_endpoint_auth_method' method '%s'. Either the Authorization Server client registration will need to have the '%s_endpoint_auth_method' updated to '%s' or the Relying Party will need to be configured to use '%s'.", handler.Name(), method, client.GetID(), handler.Name(), cmethod, handler.Name(), method, cmethod))
 		}
 	}
 
@@ -240,8 +232,8 @@ func (s *DefaultClientAuthenticationStrategy) doAuthenticateClientSecret(ctx con
 	case errors.Is(err, ErrClientSecretNotRegistered):
 		return "", errorsx.WithStack(
 			ErrInvalidClient.
-				WithHintf("The request was determined to be using '%s_endpoint_auth_method' method '%s', however the OAuth 2.0 client registration does not allow this method.", handler.Name(), method).
-				WithDebugf("The registered client with id '%s' has no 'client_secret' however this is required to process the particular request.", client.GetID()),
+				WithHint(hintClientCredentialsInvalid).
+				WithDebugf("The request was determined to be using '%s_endpoint_auth_method' method '%s', however the registered client with id '%s' has no 'client_secret' which is required to process this method.", handler.Name(), method, client.GetID()),
 		)
 	default:
 		return "", errorsx.WithStack(ErrInvalidClient.WithWrap(err).WithDebugError(err))
@@ -256,7 +248,7 @@ func (s *DefaultClientAuthenticationStrategy) doAuthenticateAssertionJWTBearer(c
 	)
 
 	if c, ok = client.(AuthenticationMethodClient); !ok {
-		return "", errorsx.WithStack(ErrInvalidClient.WithHint("The registered client does not support OAuth 2.0 JWT Profile Client Authentication RFC7523 or OpenID Connect 1.0 specific authentication methods."))
+		return "", errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebug("The registered client does not support OAuth 2.0 JWT Profile Client Authentication RFC7523 or OpenID Connect 1.0 specific authentication methods."))
 	}
 
 	if method, _, _, token, err = s.doAuthenticateAssertionParseAssertionJWTBearer(ctx, c, assertion, handler); err != nil {
@@ -264,7 +256,7 @@ func (s *DefaultClientAuthenticationStrategy) doAuthenticateAssertionJWTBearer(c
 	}
 
 	if token == nil || !assertion.Parsed {
-		return "", errorsx.WithStack(ErrInvalidClient.WithDebug("The client assertion did not result in a parsed token."))
+		return "", errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebug("The client assertion did not result in a parsed token."))
 	}
 
 	clientID := []byte(client.GetID())
@@ -278,11 +270,11 @@ func (s *DefaultClientAuthenticationStrategy) doAuthenticateAssertionJWTBearer(c
 
 	switch {
 	case !issOK:
-		return "", errorsx.WithStack(ErrInvalidClient.WithHint("The client assertion had invalid claims.").WithDebug("Claim 'iss' from 'client_assertion' must match the 'client_id' of the OAuth 2.0 Client."))
+		return "", errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebug("The client assertion had invalid claims. Claim 'iss' from 'client_assertion' must match the 'client_id' of the OAuth 2.0 Client."))
 	case !subOK:
-		return "", errorsx.WithStack(ErrInvalidClient.WithHint("The client assertion had invalid claims.").WithDebug("Claim 'sub' from 'client_assertion' must match the 'client_id' of the OAuth 2.0 Client."))
+		return "", errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebug("The client assertion had invalid claims. Claim 'sub' from 'client_assertion' must match the 'client_id' of the OAuth 2.0 Client."))
 	case claims.JTI == "":
-		return "", errorsx.WithStack(ErrInvalidClient.WithHint("The client assertion had invalid claims.").WithDebug("Claim 'jti' from 'client_assertion' must be set but is not."))
+		return "", errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebug("The client assertion had invalid claims. Claim 'jti' from 'client_assertion' must be set but is not."))
 	default:
 		switch cmethod := handler.GetAuthMethod(c); {
 		case cmethod == "" && handler.AllowAuthMethodAny():
@@ -290,16 +282,16 @@ func (s *DefaultClientAuthenticationStrategy) doAuthenticateAssertionJWTBearer(c
 		case cmethod != method:
 			return "", errorsx.WithStack(
 				ErrInvalidClient.
-					WithHintf("The request was determined to be using '%s_endpoint_auth_method' method '%s', however the OAuth 2.0 client registration does not allow this method.", handler.Name(), method).
-					WithDebugf("The registered client with id '%s' is configured to only support '%s_endpoint_auth_method' method '%s'. Either the Authorization Server client registration will need to have the '%s_endpoint_auth_method' updated to '%s' or the Relying Party will need to be configured to use '%s'.", client.GetID(), handler.Name(), cmethod, handler.Name(), method, cmethod))
+					WithHint(hintClientCredentialsInvalid).
+					WithDebugf("The request was determined to be using '%s_endpoint_auth_method' method '%s', however the registered client with id '%s' is configured to only support '%s_endpoint_auth_method' method '%s'. Either the Authorization Server client registration will need to have the '%s_endpoint_auth_method' updated to '%s' or the Relying Party will need to be configured to use '%s'.", handler.Name(), method, client.GetID(), handler.Name(), cmethod, handler.Name(), method, cmethod))
 		}
 
 		if !assertion.Parsed {
-			return "", errorsx.WithStack(ErrInvalidClient.WithDebug("The client assertion was not able to be parsed."))
+			return "", errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebug("The client assertion was not able to be parsed."))
 		}
 
 		if err = s.Store.ClientAssertionJWTValid(ctx, claims.JTI); err != nil {
-			return "", errorsx.WithStack(ErrJTIKnown.WithHint("Claim 'jti' from 'client_assertion' MUST only be used once.").WithDebugError(err))
+			return "", errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebug("Claim 'jti' from 'client_assertion' MUST only be used once.").WithWrap(err))
 		}
 
 		if err = s.Store.SetClientAssertionJWT(ctx, claims.JTI, time.Unix(claims.ExpiresAt.Unix(), 0)); err != nil {
@@ -314,7 +306,7 @@ func (s *DefaultClientAuthenticationStrategy) doAuthenticateAssertionParseAssert
 	audience := s.Config.GetAllowedJWTAssertionAudiences(ctx)
 
 	if len(audience) == 0 {
-		return "", "", "", nil, errorsx.WithStack(ErrMisconfiguration.WithHint("The authorization server does not support OAuth 2.0 JWT Profile Client Authentication RFC7523 or OpenID Connect 1.0 specific authentication methods.").WithDebug("The authorization server could not determine any safe value for it's audience but it's required to validate the RFC7523 client assertions."))
+		return "", "", "", nil, errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebug("The authorization server does not support OAuth 2.0 JWT Profile Client Authentication RFC7523 or OpenID Connect 1.0 specific authentication methods as it could not determine any safe value for it's audience but it's required to validate the RFC7523 client assertions."))
 	}
 
 	if token, err = s.Config.GetJWTStrategy(ctx).Decode(ctx, assertion.Assertion, jwt.WithClient(&EndpointClientAuthJWTClient{client: client, handler: handler}), jwt.WithSigAlgorithm(jwt.SignatureAlgorithmsNone...)); err != nil {
@@ -392,22 +384,22 @@ func resolveJWTErrorToRFCError(err error) (rfc error) {
 		switch {
 		case errJWTValidation.Has(jwt.ValidationErrorMalformed):
 			e = ErrInvalidClient.
-				WithHint("OAuth 2.0 client provided a client assertion which could not be decoded or validated.").
+				WithHint(hintClientCredentialsInvalid).
 				WithWrap(err).
 				WithDebugf("OAuth 2.0 client provided a client assertion that was malformed. %s.", strings.TrimPrefix(errJWTValidation.Error(), "go-jose/go-jose: "))
 		case errJWTValidation.Has(jwt.ValidationErrorMalformedNotCompactSerialized):
 			e = ErrInvalidClient.
-				WithHint("OAuth 2.0 client provided a client assertion which could not be decoded or validated.").
+				WithHint(hintClientCredentialsInvalid).
 				WithWrap(err).
 				WithDebugf("OAuth 2.0 client provided a client assertion that was malformed. The client assertion does not appear to be a JWE or JWS compact serialized JWT.")
 		case errJWTValidation.Has(jwt.ValidationErrorUnverifiable):
 			e = ErrInvalidClient.
-				WithHint("OAuth 2.0 client provided a client assertion which could not be decoded or validated.").
+				WithHint(hintClientCredentialsInvalid).
 				WithWrap(err).
 				WithDebugf("OAuth 2.0 client provided a client assertion that was not able to be verified. %s.", strings.TrimPrefix(errJWTValidation.Error(), "go-jose/go-jose: "))
 		default:
 			e = ErrInvalidClient.
-				WithHint("OAuth 2.0 client provided a client assertion which could not be decoded or validated.").
+				WithHint(hintClientCredentialsInvalid).
 				WithWrap(err).
 				WithDebugf("Unknown error occurred handling the client assertion.")
 		}
@@ -418,7 +410,7 @@ func resolveJWTErrorToRFCError(err error) (rfc error) {
 
 //nolint:gocyclo
 func fmtClientAssertionDecodeError(token *jwt.Token, client AuthenticationMethodClient, handler EndpointClientAuthHandler, audience []string, inner error) (outer *RFC6749Error) {
-	outer = ErrInvalidClient.WithWrap(inner).WithHintf("OAuth 2.0 client with id '%s' provided a client assertion which could not be decoded or validated.", client.GetID())
+	outer = ErrInvalidClient.WithWrap(inner).WithHint(hintClientCredentialsInvalid)
 
 	if errJWTValidation := new(jwt.ValidationError); errors.As(inner, &errJWTValidation) {
 		switch {

--- a/client_authentication_test.go
+++ b/client_authentication_test.go
@@ -91,7 +91,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form:      url.Values{},
 			r:         new(http.Request),
-			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). Client Credentials missing or malformed. The Client ID was missing from the request but it is required when there is no client assertion.",
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The Client ID was missing from the request but it is required when there is no client assertion.",
 			expectErr: ErrInvalidClient,
 		},
 		{
@@ -101,7 +101,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form: url.Values{consts.FormParameterClientID: {"bar"}},
 			r:    new(http.Request),
-			err:  "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). Could not find the requested resource(s).",
+			err:  "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. Could not find the requested resource(s).",
 		},
 		{
 			name: "ShouldPassBecauseClientIsPublicAndAuthenticationRequirementsAreMet",
@@ -134,7 +134,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form: url.Values{},
 			r:    &http.Request{Header: clientBasicAuthHeader("foo", "")},
-			err:  "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The request was determined to be using 'token_endpoint_auth_method' method 'none', however the OAuth 2.0 client registration does not allow this method. The registered client with id 'foo' is configured to only support 'token_endpoint_auth_method' method 'client_secret_basic'. Either the Authorization Server client registration will need to have the 'token_endpoint_auth_method' updated to 'none' or the Relying Party will need to be configured to use 'client_secret_basic'.",
+			err:  "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The registered client with id 'foo' is configured to only support 'token_endpoint_auth_method' method 'client_secret_basic', but the method 'none' was determined to be used. Either the Authorization Server client registration will need to have the 'token_endpoint_auth_method' updated to 'none' or the Relying Party will need to be configured to use 'client_secret_basic'.",
 		},
 		{
 			name: "ShouldPassWithClientCredentialsContainingSpecialCharacters",
@@ -151,7 +151,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form: url.Values{consts.FormParameterClientID: {"abc"}, "client_secret": {complexSecretRaw}},
 			r:    &http.Request{Header: clientBasicAuthHeader("abc", complexSecretRaw)},
-			err:  "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Client Authentication failed with more than one known authentication method included in the request which is not permitted. The registered client with id 'abc' and the authorization server policy does not permit this malformed request. The `token_endpoint_auth_method` methods determined to be used were 'client_secret_basic', 'client_secret_post'.",
+			err:  "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. Client Authentication failed with more than one known authentication method included in the request which is not permitted. The registered client with id 'abc' and the authorization server policy does not permit this malformed request. The `token_endpoint_auth_method` methods determined to be used were 'client_secret_basic', 'client_secret_post'.",
 		},
 		{
 			name: "ShouldFailWithMultipleAuthenticationMethodsClientMethodPost",
@@ -160,7 +160,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form: url.Values{consts.FormParameterClientID: {"abc"}, "client_secret": {complexSecretRaw}},
 			r:    &http.Request{Header: clientBasicAuthHeader("abc", complexSecretRaw)},
-			err:  "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Client Authentication failed with more than one known authentication method included in the request which is not permitted. The registered client with id 'abc' and the authorization server policy does not permit this malformed request. The `token_endpoint_auth_method` methods determined to be used were 'client_secret_basic', 'client_secret_post'.",
+			err:  "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. Client Authentication failed with more than one known authentication method included in the request which is not permitted. The registered client with id 'abc' and the authorization server policy does not permit this malformed request. The `token_endpoint_auth_method` methods determined to be used were 'client_secret_basic', 'client_secret_post'.",
 		},
 		{
 			name: "ShouldPassWithMultipleAuthenticationMethods",
@@ -180,7 +180,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form:      url.Values{consts.FormParameterClientID: {"abc"}, "client_secret": {complexSecretRaw}},
 			r:         &http.Request{Header: clientBasicAuthHeader("xyz", "")},
-			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The 'client_id' in the request body did not match the 'client_id' supplied via the HTTP Basic Authorization header. The HTTP Basic Authorization header specified the 'client_id' value 'xyz' but the request body specified the 'client_id' value 'abc'. Per RFC 6749 Section 2.3 a client MUST NOT use more than one authentication method.",
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The HTTP Basic Authorization header specified the 'client_id' value 'xyz' but the request body specified the 'client_id' value 'abc'. Per RFC 6749 Section 2.3 a client MUST NOT use more than one authentication method.",
 			expectErr: ErrInvalidClient,
 		},
 		{
@@ -190,7 +190,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form:      url.Values{consts.FormParameterClientID: {"foo"}},
 			r:         new(http.Request),
-			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The request was determined to be using 'token_endpoint_auth_method' method 'none', however the OAuth 2.0 client registration does not allow this method. The registered client with id 'foo' is configured to only support 'token_endpoint_auth_method' method 'client_secret_basic'. Either the Authorization Server client registration will need to have the 'token_endpoint_auth_method' updated to 'none' or the Relying Party will need to be configured to use 'client_secret_basic'.",
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The registered client with id 'foo' is configured to only support 'token_endpoint_auth_method' method 'client_secret_basic', but the method 'none' was determined to be used. Either the Authorization Server client registration will need to have the 'token_endpoint_auth_method' updated to 'none' or the Relying Party will need to be configured to use 'client_secret_basic'.",
 			expectErr: ErrInvalidClient,
 		},
 		{
@@ -242,7 +242,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form:      url.Values{},
 			r:         &http.Request{Header: clientBasicAuthHeader("foo", "bar")},
-			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The request was determined to be using 'token_endpoint_auth_method' method 'client_secret_basic', however the OAuth 2.0 client registration does not allow this method. The registered client with id 'foo' has no 'client_secret' however this is required to process the particular request.",
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The request was determined to be using 'token_endpoint_auth_method' method 'client_secret_basic', however the registered client with id 'foo' has no 'client_secret' which is required to process this method.",
 			expectErr: ErrInvalidClient,
 		},
 		{
@@ -296,8 +296,8 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form:      url.Values{},
 			r:         &http.Request{Header: http.Header{consts.HeaderAuthorization: {prefixSchemeBasic + base64.StdEncoding.EncodeToString([]byte("%%%%%%:foo"))}}},
-			err:       "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client id in the HTTP authorization header could not be decoded from 'application/x-www-form-urlencoded'. invalid URL escape '%%%'",
-			expectErr: ErrInvalidRequest,
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The client id in the HTTP authorization header could not be decoded from 'application/x-www-form-urlencoded'.",
+			expectErr: ErrInvalidClient,
 		},
 		{
 			name: "ShouldFailBecauseClientSecretIsNotValid",
@@ -306,8 +306,8 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form:      url.Values{},
 			r:         &http.Request{Header: http.Header{consts.HeaderAuthorization: {prefixSchemeBasic + base64.StdEncoding.EncodeToString([]byte("foo:%%%%%%%"))}}},
-			err:       "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client secret in the HTTP authorization header could not be decoded from 'application/x-www-form-urlencoded'. invalid URL escape '%%%'",
-			expectErr: ErrInvalidRequest,
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The client secret in the HTTP authorization header could not be decoded from 'application/x-www-form-urlencoded'.",
+			expectErr: ErrInvalidClient,
 		},
 		{
 			name: "ShouldFailBecauseBasicValueIsNotValid",
@@ -316,8 +316,8 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form:      url.Values{},
 			r:         &http.Request{Header: http.Header{consts.HeaderAuthorization: {prefixSchemeBasic + base64.StdEncoding.EncodeToString([]byte("foo"))}}},
-			err:       "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client credentials from the HTTP authorization header could not be parsed. The basic scheme value was not separated by a colon.",
-			expectErr: ErrInvalidRequest,
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The basic scheme value was not separated by a colon.",
+			expectErr: ErrInvalidClient,
 		},
 		{
 			name: "ShouldFailBecauseSchemeIsNotValid",
@@ -326,7 +326,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form:      url.Values{},
 			r:         &http.Request{Header: http.Header{consts.HeaderAuthorization: {"NotBasic " + base64.StdEncoding.EncodeToString([]byte("foo:bar"))}}},
-			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The client credentials from the HTTP authorization header had an unknown scheme. The scheme 'NotBasic' is not known for client authentication.",
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The scheme 'NotBasic' is not known for client authentication.",
 			expectErr: ErrInvalidClient,
 		},
 		{
@@ -336,8 +336,8 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form:      url.Values{},
 			r:         &http.Request{Header: http.Header{consts.HeaderAuthorization: {prefixSchemeBasic + "foo:bar"}}},
-			err:       "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client credentials from the HTTP authorization header could not be parsed. Error occurred performing a base64 decode: illegal base64 data at input byte 3.",
-			expectErr: ErrInvalidRequest,
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. Error occurred performing a base64 decode: illegal base64 data at input byte 3.",
+			expectErr: ErrInvalidClient,
 		},
 		{
 			name: "ShouldFailBecauseAuthorizationHeaderIsNotValid",
@@ -346,8 +346,8 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form:      url.Values{},
 			r:         &http.Request{Header: http.Header{consts.HeaderAuthorization: {"Basic" + base64.StdEncoding.EncodeToString([]byte("foo:bar"))}}},
-			err:       "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client credentials from the HTTP authorization header could not be parsed. The header value is either missing a scheme, value, or the separator between them.",
-			expectErr: ErrInvalidRequest,
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The header value is either missing a scheme, value, or the separator between them.",
+			expectErr: ErrInvalidClient,
 		},
 		{
 			name: "ShouldFailBecauseNonVSCHARClientID",
@@ -356,8 +356,8 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form:      url.Values{},
 			r:         &http.Request{Header: clientBasicAuthHeader("\x19foo", "bar")},
-			err:       "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client id in the HTTP request had an invalid character.",
-			expectErr: ErrInvalidRequest,
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The client id in the HTTP request had an invalid character.",
+			expectErr: ErrInvalidClient,
 		},
 		{
 			name: "ShouldFailBecauseNonVSCHARClientSecret",
@@ -366,8 +366,8 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form:      url.Values{},
 			r:         &http.Request{Header: clientBasicAuthHeader("foo", "\x19bar")},
-			err:       "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client secret in the HTTP request had an invalid character.",
-			expectErr: ErrInvalidRequest,
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The client secret in the HTTP request had an invalid character.",
+			expectErr: ErrInvalidClient,
 		},
 		{
 			name: "ShouldFailBecauseClientIsConfidentialAndIdDoesNotExistInHeader",
@@ -377,7 +377,7 @@ func TestAuthenticateClient(t *testing.T) {
 			form:      url.Values{},
 			r:         &http.Request{Header: http.Header{consts.HeaderAuthorization: {prefixSchemeBasic + base64.StdEncoding.EncodeToString([]byte("foo:bar"))}}},
 			expectErr: ErrInvalidClient,
-			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). Could not find the requested resource(s).",
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. Could not find the requested resource(s).",
 		},
 		{
 			name: "ShouldFailBecauseClientAssertionButClientAssertionIsMissing",
@@ -386,8 +386,8 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form:      url.Values{consts.FormParameterClientID: {"foo"}, consts.FormParameterClientAssertionType: {consts.ClientAssertionTypeJWTBearer}},
 			r:         new(http.Request),
-			expectErr: ErrInvalidRequest,
-			err:       "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The request parameter 'client_assertion' must be set when using 'client_assertion_type' of 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'.",
+			expectErr: ErrInvalidClient,
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The request parameter 'client_assertion' must be set when using 'client_assertion_type' of 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'.",
 		},
 		{
 			name: "ShouldFailBecauseClientAssertionTypeIsUnknown",
@@ -397,7 +397,7 @@ func TestAuthenticateClient(t *testing.T) {
 			form:      url.Values{consts.FormParameterClientID: {"foo"}, consts.FormParameterClientAssertionType: {"foobar"}},
 			r:         new(http.Request),
 			expectErr: ErrInvalidClient,
-			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). Unknown client_assertion_type 'foobar'.",
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. Unknown client_assertion_type 'foobar'.",
 		},
 		{
 			name: "ShouldPassWithProperRSAAssertionWhenJWKsAreSetWithinTheClientAndClientIdIsNotSetInTheRequest",
@@ -456,7 +456,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			r:         new(http.Request),
 			expectErr: ErrInvalidClient,
-			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). OAuth 2.0 client with id 'bar' provided a client assertion which could not be decoded or validated. OAuth 2.0 client with id 'bar' expects client assertions to be signed with the 'alg' header value 'ES256' due to the client registration 'request_object_signing_alg' value but the client assertion was signed with the 'alg' header value 'RS256'.",
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. OAuth 2.0 client with id 'bar' expects client assertions to be signed with the 'alg' header value 'ES256' due to the client registration 'request_object_signing_alg' value but the client assertion was signed with the 'alg' header value 'RS256'.",
 		},
 		{
 			name: "ShouldFailBecauseWrongJSONWebKeyHeaderTypeValue",
@@ -477,7 +477,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			r:         new(http.Request),
 			expectErr: ErrInvalidClient,
-			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). OAuth 2.0 client with id 'bar' provided a client assertion which could not be decoded or validated. OAuth 2.0 client with id 'bar' expects client assertions to be signed with the 'typ' header value 'client-authentication+jwt' or 'JWT' but the client assertion was signed with the 'typ' header value 'at+jwt'.",
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. OAuth 2.0 client with id 'bar' expects client assertions to be signed with the 'typ' header value 'client-authentication+jwt' or 'JWT' but the client assertion was signed with the 'typ' header value 'at+jwt'.",
 		},
 		{
 			name: "ShouldFailBecauseMalformedAssertionUsed",
@@ -487,7 +487,7 @@ func TestAuthenticateClient(t *testing.T) {
 			form:      url.Values{consts.FormParameterClientAssertion: {"bad.assertion"}, consts.FormParameterClientAssertionType: {consts.ClientAssertionTypeJWTBearer}},
 			r:         new(http.Request),
 			expectErr: ErrInvalidClient,
-			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). OAuth 2.0 client provided a client assertion which could not be decoded or validated. OAuth 2.0 client provided a client assertion that was malformed. The client assertion does not appear to be a JWE or JWS compact serialized JWT.",
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. OAuth 2.0 client provided a client assertion that was malformed. The client assertion does not appear to be a JWE or JWS compact serialized JWT.",
 		},
 		{
 			name: "ShouldFailBecauseExpired",
@@ -508,7 +508,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			r:         new(http.Request),
 			expectErr: ErrInvalidClient,
-			errRegexp: regexp.MustCompile(`^Client authentication failed \(e\.g\., unknown client, no client authentication included, or unsupported authentication method\)\. OAuth 2\.0 client with id 'bar' provided a client assertion which could not be decoded or validated\. OAuth 2\.0 client with id 'bar' provided a client assertion that was expired\. The client assertion expired at \d+\.$`),
+			errRegexp: regexp.MustCompile(`^Client authentication failed \(e\.g\., unknown client, no client authentication included, or unsupported authentication method\)\. The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect\. OAuth 2\.0 client with id 'bar' provided a client assertion that was expired\. The client assertion expired at \d+\.$`),
 		},
 		{
 			name: "ShouldFailBecauseNotBefore",
@@ -530,7 +530,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			r:         new(http.Request),
 			expectErr: ErrInvalidClient,
-			errRegexp: regexp.MustCompile(`^Client authentication failed \(e\.g\., unknown client, no client authentication included, or unsupported authentication method\)\. OAuth 2\.0 client with id 'bar' provided a client assertion which could not be decoded or validated\. OAuth 2\.0 client with id 'bar' provided a client assertion that was issued in the future\. The client assertion is not valid before \d+\.$`),
+			errRegexp: regexp.MustCompile(`^Client authentication failed \(e\.g\., unknown client, no client authentication included, or unsupported authentication method\)\. The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect\. OAuth 2\.0 client with id 'bar' provided a client assertion that was issued in the future\. The client assertion is not valid before \d+\.$`),
 		},
 		{
 			name: "ShouldFailBecauseIssuedInFuture",
@@ -552,7 +552,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			r:         new(http.Request),
 			expectErr: ErrInvalidClient,
-			errRegexp: regexp.MustCompile(`^Client authentication failed \(e\.g\., unknown client, no client authentication included, or unsupported authentication method\)\. OAuth 2\.0 client with id 'bar' provided a client assertion which could not be decoded or validated. OAuth 2\.0 client with id 'bar' provided a client assertion that was issued in the future\. The client assertion was issued at \d+\.$`),
+			errRegexp: regexp.MustCompile(`^Client authentication failed \(e\.g\., unknown client, no client authentication included, or unsupported authentication method\)\. The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect\. OAuth 2\.0 client with id 'bar' provided a client assertion that was issued in the future\. The client assertion was issued at \d+\.$`),
 		},
 		{
 			name: "ShouldFailBecauseNoKeys",
@@ -573,7 +573,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			r:         new(http.Request),
 			expectErr: ErrInvalidClient,
-			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). OAuth 2.0 client with id 'bar' provided a client assertion which could not be decoded or validated. OAuth 2.0 client with id 'bar' provided a client assertion that was not able to be verified. Error occurred retrieving the JSON Web Key. No JWKs have been registered for the client.",
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. OAuth 2.0 client with id 'bar' provided a client assertion that was not able to be verified. Error occurred retrieving the JSON Web Key. No JWKs have been registered for the client.",
 		},
 		{
 			name: "ShouldFailBecauseNotBeforeAlternative",
@@ -595,7 +595,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			r:         new(http.Request),
 			expectErr: ErrInvalidClient,
-			errRegexp: regexp.MustCompile(`^Client authentication failed \(e\.g\., unknown client, no client authentication included, or unsupported authentication method\)\. OAuth 2\.0 client with id 'bar' provided a client assertion which could not be decoded or validated\. OAuth 2\.0 client with id 'bar' provided a client assertion that was issued in the future\. The client assertion is not valid before \d+\.$`),
+			errRegexp: regexp.MustCompile(`^Client authentication failed \(e\.g\., unknown client, no client authentication included, or unsupported authentication method\)\. The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect\. OAuth 2\.0 client with id 'bar' provided a client assertion that was issued in the future\. The client assertion is not valid before \d+\.$`),
 		},
 		{
 			name: "ShouldFailBecauseTokenAuthMethodIsNotPrivateKeyJwtButClientSecretJwt",
@@ -616,7 +616,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			r:         new(http.Request),
 			expectErr: ErrInvalidClient,
-			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The request was determined to be using 'token_endpoint_auth_method' method 'private_key_jwt', however the OAuth 2.0 client registration does not allow this method. The registered client with id 'bar' is configured to only support 'token_endpoint_auth_method' method 'client_secret_jwt'. Either the Authorization Server client registration will need to have the 'token_endpoint_auth_method' updated to 'private_key_jwt' or the Relying Party will need to be configured to use 'client_secret_jwt'.",
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The request was determined to be using 'token_endpoint_auth_method' method 'private_key_jwt', however the registered client with id 'bar' is configured to only support 'token_endpoint_auth_method' method 'client_secret_jwt'. Either the Authorization Server client registration will need to have the 'token_endpoint_auth_method' updated to 'private_key_jwt' or the Relying Party will need to be configured to use 'client_secret_jwt'.",
 		},
 		{
 			name: "ShouldFailBecauseTokenAuthMethodIsNotPrivateKeyJwtButNone",
@@ -637,7 +637,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			r:         new(http.Request),
 			expectErr: ErrInvalidClient,
-			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The request was determined to be using 'token_endpoint_auth_method' method 'private_key_jwt', however the OAuth 2.0 client registration does not allow this method. The registered client with id 'bar' is configured to only support 'token_endpoint_auth_method' method 'none'. Either the Authorization Server client registration will need to have the 'token_endpoint_auth_method' updated to 'private_key_jwt' or the Relying Party will need to be configured to use 'none'.",
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The request was determined to be using 'token_endpoint_auth_method' method 'private_key_jwt', however the registered client with id 'bar' is configured to only support 'token_endpoint_auth_method' method 'none'. Either the Authorization Server client registration will need to have the 'token_endpoint_auth_method' updated to 'private_key_jwt' or the Relying Party will need to be configured to use 'none'.",
 		},
 		{
 			name: "ShouldFailBecauseTokenAuthMethodIsNotPrivateKeyJwtButClientSecretPost",
@@ -658,7 +658,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			r:         new(http.Request),
 			expectErr: ErrInvalidClient,
-			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The request was determined to be using 'token_endpoint_auth_method' method 'private_key_jwt', however the OAuth 2.0 client registration does not allow this method. The registered client with id 'bar' is configured to only support 'token_endpoint_auth_method' method 'client_secret_post'. Either the Authorization Server client registration will need to have the 'token_endpoint_auth_method' updated to 'private_key_jwt' or the Relying Party will need to be configured to use 'client_secret_post'.",
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The request was determined to be using 'token_endpoint_auth_method' method 'private_key_jwt', however the registered client with id 'bar' is configured to only support 'token_endpoint_auth_method' method 'client_secret_post'. Either the Authorization Server client registration will need to have the 'token_endpoint_auth_method' updated to 'private_key_jwt' or the Relying Party will need to be configured to use 'client_secret_post'.",
 		},
 		{
 			name: "ShouldFailBecauseTokenAuthMethodIsNotPrivateKeyJwtButClientSecretBasic",
@@ -679,7 +679,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			r:         new(http.Request),
 			expectErr: ErrInvalidClient,
-			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The request was determined to be using 'token_endpoint_auth_method' method 'private_key_jwt', however the OAuth 2.0 client registration does not allow this method. The registered client with id 'bar' is configured to only support 'token_endpoint_auth_method' method 'client_secret_basic'. Either the Authorization Server client registration will need to have the 'token_endpoint_auth_method' updated to 'private_key_jwt' or the Relying Party will need to be configured to use 'client_secret_basic'.",
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The request was determined to be using 'token_endpoint_auth_method' method 'private_key_jwt', however the registered client with id 'bar' is configured to only support 'token_endpoint_auth_method' method 'client_secret_basic'. Either the Authorization Server client registration will need to have the 'token_endpoint_auth_method' updated to 'private_key_jwt' or the Relying Party will need to be configured to use 'client_secret_basic'.",
 		},
 		{
 			name: "ShouldFailBecauseTokenAuthMethodIsNotPrivateKeyJwtButFoobar",
@@ -740,7 +740,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			r:         new(http.Request),
 			expectErr: ErrInvalidClient,
-			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). OAuth 2.0 client with id 'bar' provided a client assertion which could not be decoded or validated. OAuth 2.0 client with id 'bar' provided a client assertion that has an invalid audience. The client assertion was expected to have an 'aud' claim which matches one of the values 'token-url' but the 'aud' claim had the values 'token-url-1', 'token-url-2'.",
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. OAuth 2.0 client with id 'bar' provided a client assertion that has an invalid audience. The client assertion was expected to have an 'aud' claim which matches one of the values 'token-url' but the 'aud' claim had the values 'token-url-1', 'token-url-2'.",
 		},
 		{
 			name: "ShouldPassWithProperAssertionWhenJWKsAreSetWithinTheClient",
@@ -815,7 +815,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			r:         new(http.Request),
 			expectErr: ErrInvalidClient,
-			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). OAuth 2.0 client with id 'bar' provided a client assertion which could not be decoded or validated. OAuth 2.0 client with id 'bar' expects client assertions to be signed with the 'alg' header value 'RS256' due to the client registration 'request_object_signing_alg' value but the client assertion was signed with the 'alg' header value 'none'.",
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. OAuth 2.0 client with id 'bar' expects client assertions to be signed with the 'alg' header value 'RS256' due to the client registration 'request_object_signing_alg' value but the client assertion was signed with the 'alg' header value 'none'.",
 		},
 		{
 			name: "ShouldPassWithProperAssertionWhenJWKsURIIsSet",
@@ -857,7 +857,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			r:         new(http.Request),
 			expectErr: ErrInvalidClient,
-			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The client assertion had invalid claims. Claim 'sub' from 'client_assertion' must match the 'client_id' of the OAuth 2.0 Client.",
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The client assertion had invalid claims. Claim 'sub' from 'client_assertion' must match the 'client_id' of the OAuth 2.0 Client.",
 		},
 		{
 			name: "ShouldFailBecauseClientAssertionIssDoesNotMatchClient",
@@ -879,7 +879,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			r:         new(http.Request),
 			expectErr: ErrInvalidClient,
-			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The client assertion had invalid claims. Claim 'iss' from 'client_assertion' must match the 'client_id' of the OAuth 2.0 Client.",
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The client assertion had invalid claims. Claim 'iss' from 'client_assertion' must match the 'client_id' of the OAuth 2.0 Client.",
 		},
 		{
 			name: "ShouldFailBecauseClientAssertionJTIClaimIsNotSet",
@@ -900,7 +900,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			r:         new(http.Request),
 			expectErr: ErrInvalidClient,
-			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The client assertion had invalid claims. Claim 'jti' from 'client_assertion' must be set but is not.",
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The client assertion had invalid claims. Claim 'jti' from 'client_assertion' must be set but is not.",
 		},
 		{
 			name: "ShouldFailBecauseClientAssertionAudIsNotSet",
@@ -1063,11 +1063,11 @@ func TestAuthenticateClientTwice(t *testing.T) {
 				_, _, err := provider.AuthenticateClient(t.Context(), new(http.Request), formValues)
 				require.NoError(t, ErrorToDebugRFC6749Error(err))
 
-				// Replay the same assertion and expect ErrJTIKnown.
+				// Replay the same assertion and expect ErrInvalidClient with the jti-replay debug.
 				actual, _, err := provider.AuthenticateClient(t.Context(), new(http.Request), formValues)
 				require.Error(t, err)
-				assert.EqualError(t, err, ErrJTIKnown.Error())
-				assert.EqualError(t, ErrorToDebugRFC6749Error(err), "The jti was already used. Claim 'jti' from 'client_assertion' MUST only be used once. The jti was already used.")
+				assert.EqualError(t, err, ErrInvalidClient.Error())
+				assert.EqualError(t, ErrorToDebugRFC6749Error(err), "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. Claim 'jti' from 'client_assertion' MUST only be used once.")
 				assert.Nil(t, actual)
 			},
 		},

--- a/client_authentication_test.go
+++ b/client_authentication_test.go
@@ -89,9 +89,10 @@ func TestAuthenticateClient(t *testing.T) {
 			client: func(ts *httptest.Server) Client {
 				return &DefaultJARClient{DefaultClient: &DefaultClient{ID: "foo"}, TokenEndpointAuthMethod: "client_secret_basic"}
 			},
-			form: url.Values{},
-			r:    new(http.Request),
-			err:  "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Client Credentials missing or malformed. The Client ID was missing from the request but it is required when there is no client assertion.",
+			form:      url.Values{},
+			r:         new(http.Request),
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). Client Credentials missing or malformed. The Client ID was missing from the request but it is required when there is no client assertion.",
+			expectErr: ErrInvalidClient,
 		},
 		{
 			name: "ShouldFailBecauseClientDoesNotExist",
@@ -171,6 +172,16 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form: url.Values{consts.FormParameterClientID: {"abc"}, "client_secret": {complexSecretRaw}},
 			r:    &http.Request{Header: clientBasicAuthHeader("abc", complexSecretRaw)},
+		},
+		{
+			name: "ShouldFailWhenBasicAndPostClientIDsDiffer",
+			client: func(ts *httptest.Server) Client {
+				return &DefaultJARClient{DefaultClient: &DefaultClient{ID: "abc", ClientSecret: testClientSecretComplex}, TokenEndpointAuthMethod: "client_secret_post"}
+			},
+			form:      url.Values{consts.FormParameterClientID: {"abc"}, "client_secret": {complexSecretRaw}},
+			r:         &http.Request{Header: clientBasicAuthHeader("xyz", "")},
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The 'client_id' in the request body did not match the 'client_id' supplied via the HTTP Basic Authorization header. The HTTP Basic Authorization header specified the 'client_id' value 'xyz' but the request body specified the 'client_id' value 'abc'. Per RFC 6749 Section 2.3 a client MUST NOT use more than one authentication method.",
+			expectErr: ErrInvalidClient,
 		},
 		{
 			name: "ShouldFailBecauseAuthMethodIsNotNone",
@@ -285,7 +296,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form:      url.Values{},
 			r:         &http.Request{Header: http.Header{consts.HeaderAuthorization: {prefixSchemeBasic + base64.StdEncoding.EncodeToString([]byte("%%%%%%:foo"))}}},
-			err:       "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client credentials in the HTTP authorization header could not be parsed. Either the scheme was missing, the scheme was invalid, or the value had malformed data. The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client id in the HTTP authorization header could not be decoded from 'application/x-www-form-urlencoded'. invalid URL escape '%%%'",
+			err:       "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client id in the HTTP authorization header could not be decoded from 'application/x-www-form-urlencoded'. invalid URL escape '%%%'",
 			expectErr: ErrInvalidRequest,
 		},
 		{
@@ -295,7 +306,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form:      url.Values{},
 			r:         &http.Request{Header: http.Header{consts.HeaderAuthorization: {prefixSchemeBasic + base64.StdEncoding.EncodeToString([]byte("foo:%%%%%%%"))}}},
-			err:       "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client credentials in the HTTP authorization header could not be parsed. Either the scheme was missing, the scheme was invalid, or the value had malformed data. The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client secret in the HTTP authorization header could not be decoded from 'application/x-www-form-urlencoded'. invalid URL escape '%%%'",
+			err:       "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client secret in the HTTP authorization header could not be decoded from 'application/x-www-form-urlencoded'. invalid URL escape '%%%'",
 			expectErr: ErrInvalidRequest,
 		},
 		{
@@ -305,7 +316,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form:      url.Values{},
 			r:         &http.Request{Header: http.Header{consts.HeaderAuthorization: {prefixSchemeBasic + base64.StdEncoding.EncodeToString([]byte("foo"))}}},
-			err:       "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client credentials in the HTTP authorization header could not be parsed. Either the scheme was missing, the scheme was invalid, or the value had malformed data. The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client credentials from the HTTP authorization header could not be parsed. The basic scheme value was not separated by a colon.",
+			err:       "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client credentials from the HTTP authorization header could not be parsed. The basic scheme value was not separated by a colon.",
 			expectErr: ErrInvalidRequest,
 		},
 		{
@@ -315,8 +326,8 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form:      url.Values{},
 			r:         &http.Request{Header: http.Header{consts.HeaderAuthorization: {"NotBasic " + base64.StdEncoding.EncodeToString([]byte("foo:bar"))}}},
-			err:       "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client credentials in the HTTP authorization header could not be parsed. Either the scheme was missing, the scheme was invalid, or the value had malformed data. The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client credentials from the HTTP authorization header had an unknown scheme. The scheme 'NotBasic' is not known for client authentication.",
-			expectErr: ErrInvalidRequest,
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The client credentials from the HTTP authorization header had an unknown scheme. The scheme 'NotBasic' is not known for client authentication.",
+			expectErr: ErrInvalidClient,
 		},
 		{
 			name: "ShouldFailBecauseHeaderIsNotEncoded",
@@ -325,7 +336,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form:      url.Values{},
 			r:         &http.Request{Header: http.Header{consts.HeaderAuthorization: {prefixSchemeBasic + "foo:bar"}}},
-			err:       "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client credentials in the HTTP authorization header could not be parsed. Either the scheme was missing, the scheme was invalid, or the value had malformed data. The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client credentials from the HTTP authorization header could not be parsed. Error occurred performing a base64 decode: illegal base64 data at input byte 3.",
+			err:       "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client credentials from the HTTP authorization header could not be parsed. Error occurred performing a base64 decode: illegal base64 data at input byte 3.",
 			expectErr: ErrInvalidRequest,
 		},
 		{
@@ -335,7 +346,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form:      url.Values{},
 			r:         &http.Request{Header: http.Header{consts.HeaderAuthorization: {"Basic" + base64.StdEncoding.EncodeToString([]byte("foo:bar"))}}},
-			err:       "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client credentials in the HTTP authorization header could not be parsed. Either the scheme was missing, the scheme was invalid, or the value had malformed data. The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client credentials from the HTTP authorization header could not be parsed. The header value is either missing a scheme, value, or the separator between them.",
+			err:       "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client credentials from the HTTP authorization header could not be parsed. The header value is either missing a scheme, value, or the separator between them.",
 			expectErr: ErrInvalidRequest,
 		},
 		{
@@ -345,7 +356,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form:      url.Values{},
 			r:         &http.Request{Header: clientBasicAuthHeader("\x19foo", "bar")},
-			err:       "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client credentials in the HTTP authorization header could not be parsed. Either the scheme was missing, the scheme was invalid, or the value had malformed data. The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client id in the HTTP request had an invalid character.",
+			err:       "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client id in the HTTP request had an invalid character.",
 			expectErr: ErrInvalidRequest,
 		},
 		{
@@ -355,7 +366,7 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form:      url.Values{},
 			r:         &http.Request{Header: clientBasicAuthHeader("foo", "\x19bar")},
-			err:       "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client credentials in the HTTP authorization header could not be parsed. Either the scheme was missing, the scheme was invalid, or the value had malformed data. The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client secret in the HTTP request had an invalid character.",
+			err:       "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The client secret in the HTTP request had an invalid character.",
 			expectErr: ErrInvalidRequest,
 		},
 		{
@@ -385,8 +396,8 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form:      url.Values{consts.FormParameterClientID: {"foo"}, consts.FormParameterClientAssertionType: {"foobar"}},
 			r:         new(http.Request),
-			expectErr: ErrInvalidRequest,
-			err:       "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Unknown client_assertion_type 'foobar'.",
+			expectErr: ErrInvalidClient,
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). Unknown client_assertion_type 'foobar'.",
 		},
 		{
 			name: "ShouldPassWithProperRSAAssertionWhenJWKsAreSetWithinTheClientAndClientIdIsNotSetInTheRequest",

--- a/errors.go
+++ b/errors.go
@@ -289,6 +289,7 @@ const (
 )
 
 const (
+	hintClientCredentialsInvalid                    = "The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect."
 	hintRequestObjectClientCapabilities             = "%s parameter '%s' was used, but the OAuth 2.0 Client does not implement advanced authorization capabilities."
 	hintRequestObjectPrefixOpenID                   = "OpenID Connect 1.0"
 	hintRequestObjectPrefixJAR                      = "OAuth 2.0 JWT-Secured Authorization Request"

--- a/pushed_authorize_request_handler_test.go
+++ b/pushed_authorize_request_handler_test.go
@@ -41,19 +41,19 @@ func TestNewPushedAuthorizeRequest(t *testing.T) {
 			r: &http.Request{
 				Method: "POST",
 			},
-			err:  "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). Client Credentials missing or malformed. The Client ID was missing from the request but it is required when there is no client assertion.",
+			err:  "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The Client ID was missing from the request but it is required when there is no client assertion.",
 			mock: func(store *mock.MockStorage) {},
 		},
 		{
 			name:  "ShouldFailInvalidRedirectURI",
 			query: url.Values{consts.FormParameterRedirectURI: []string{"invalid"}},
-			err:   "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). Client Credentials missing or malformed. The Client ID was missing from the request but it is required when there is no client assertion.",
+			err:   "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The Client ID was missing from the request but it is required when there is no client assertion.",
 			mock:  func(store *mock.MockStorage) {},
 		},
 		{
 			name:  "ShouldFailInvalidClient",
 			query: url.Values{consts.FormParameterRedirectURI: []string{"https://foo.bar/cb"}},
-			err:   "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). Client Credentials missing or malformed. The Client ID was missing from the request but it is required when there is no client assertion.",
+			err:   "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The Client ID was missing from the request but it is required when there is no client assertion.",
 			mock:  func(store *mock.MockStorage) {},
 		},
 		{

--- a/pushed_authorize_request_handler_test.go
+++ b/pushed_authorize_request_handler_test.go
@@ -41,19 +41,19 @@ func TestNewPushedAuthorizeRequest(t *testing.T) {
 			r: &http.Request{
 				Method: "POST",
 			},
-			err:  "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The requested OAuth 2.0 Client could not be authenticated. The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Client Credentials missing or malformed. The Client ID was missing from the request but it is required when there is no client assertion.",
+			err:  "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). Client Credentials missing or malformed. The Client ID was missing from the request but it is required when there is no client assertion.",
 			mock: func(store *mock.MockStorage) {},
 		},
 		{
 			name:  "ShouldFailInvalidRedirectURI",
 			query: url.Values{consts.FormParameterRedirectURI: []string{"invalid"}},
-			err:   "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The requested OAuth 2.0 Client could not be authenticated. The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Client Credentials missing or malformed. The Client ID was missing from the request but it is required when there is no client assertion.",
+			err:   "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). Client Credentials missing or malformed. The Client ID was missing from the request but it is required when there is no client assertion.",
 			mock:  func(store *mock.MockStorage) {},
 		},
 		{
 			name:  "ShouldFailInvalidClient",
 			query: url.Values{consts.FormParameterRedirectURI: []string{"https://foo.bar/cb"}},
-			err:   "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The requested OAuth 2.0 Client could not be authenticated. The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Client Credentials missing or malformed. The Client ID was missing from the request but it is required when there is no client assertion.",
+			err:   "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). Client Credentials missing or malformed. The Client ID was missing from the request but it is required when there is no client assertion.",
 			mock:  func(store *mock.MockStorage) {},
 		},
 		{

--- a/revoke_handler_test.go
+++ b/revoke_handler_test.go
@@ -68,7 +68,7 @@ func TestNewRevocationRequest(t *testing.T) {
 				consts.FormParameterToken: {"foo"},
 			},
 			mock: func(store *mock.MockStorage, handler *mock.MockRevocationHandler, client *DefaultClient) {},
-			err:  "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Client Credentials missing or malformed. The Client ID was missing from the request but it is required when there is no client assertion.",
+			err:  "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). Client Credentials missing or malformed. The Client ID was missing from the request but it is required when there is no client assertion.",
 		},
 		{
 			name: "ShouldFailWhenClientLookupFails",

--- a/revoke_handler_test.go
+++ b/revoke_handler_test.go
@@ -68,7 +68,7 @@ func TestNewRevocationRequest(t *testing.T) {
 				consts.FormParameterToken: {"foo"},
 			},
 			mock: func(store *mock.MockStorage, handler *mock.MockRevocationHandler, client *DefaultClient) {},
-			err:  "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). Client Credentials missing or malformed. The Client ID was missing from the request but it is required when there is no client assertion.",
+			err:  "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The Client ID was missing from the request but it is required when there is no client assertion.",
 		},
 		{
 			name: "ShouldFailWhenClientLookupFails",
@@ -82,7 +82,7 @@ func TestNewRevocationRequest(t *testing.T) {
 			mock: func(store *mock.MockStorage, handler *mock.MockRevocationHandler, client *DefaultClient) {
 				store.EXPECT().GetClient(gomock.Any(), gomock.Eq("foo")).Return(nil, errors.New(""))
 			},
-			err: "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method).",
+			err: "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect.",
 		},
 		{
 			name: "ShouldFailWhenClientSecretInvalid",

--- a/rfc8628_device_authorize_request_handler_test.go
+++ b/rfc8628_device_authorize_request_handler_test.go
@@ -30,7 +30,7 @@ func TestNewDeviceAuthorizeRequest(t *testing.T) {
 	}{
 		{
 			name: "ShouldFailEmptyRequest",
-			err:  "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The requested OAuth 2.0 Client could not be authenticated. The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Client Credentials missing or malformed. The Client ID was missing from the request but it is required when there is no client assertion.",
+			err:  "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). Client Credentials missing or malformed. The Client ID was missing from the request but it is required when there is no client assertion.",
 			mock: func(store *mock.MockStorage) {},
 		},
 		{

--- a/rfc8628_device_authorize_request_handler_test.go
+++ b/rfc8628_device_authorize_request_handler_test.go
@@ -30,7 +30,7 @@ func TestNewDeviceAuthorizeRequest(t *testing.T) {
 	}{
 		{
 			name: "ShouldFailEmptyRequest",
-			err:  "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). Client Credentials missing or malformed. The Client ID was missing from the request but it is required when there is no client assertion.",
+			err:  "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The Client ID was missing from the request but it is required when there is no client assertion.",
 			mock: func(store *mock.MockStorage) {},
 		},
 		{
@@ -58,7 +58,7 @@ func TestNewDeviceAuthorizeRequest(t *testing.T) {
 					consts.FormParameterScope:    {"foo bar"},
 				},
 			},
-			err: "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). foo",
+			err: "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. foo",
 			mock: func(store *mock.MockStorage) {
 				store.EXPECT().GetClient(gomock.Any(), "1234").Return(nil, errors.New("foo"))
 			},
@@ -79,7 +79,7 @@ func TestNewDeviceAuthorizeRequest(t *testing.T) {
 					Scopes:     []string{"foo", "bar"},
 				}, nil)
 			},
-			err: "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The request was determined to be using 'none_endpoint_auth_method' method 'token', however the OAuth 2.0 client registration does not allow this method. The registered client with id '1234' is configured with a confidential client type but only client registrations with a public client type can use this 'token_endpoint_auth_method'.",
+			err: "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The 'token_endpoint_auth_method' method 'none' was determined to be used, but the registered client with id '1234' is configured with a confidential client type but only client registrations with a public client type can use this 'token_endpoint_auth_method'.",
 		},
 		{
 			name: "ShouldFailConfidentialClientWrongSecretBasic",


### PR DESCRIPTION
This hardens the implementation to ensure the errors returned for client auth in specific are only detailed with debug messages turned on, or deliberately logged on the AS side. This keeps this process obscure to attackers which aides in defence in depth.