### PR TITLE
feat: custom endpoint auth strategy

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -46,7 +46,7 @@ jobs:
       - name: 'Setup (pnpm)'
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 10
+          version: 11
       - name: 'Run Prettier'
         run: |
           make format-prettier

--- a/access_request_handler.go
+++ b/access_request_handler.go
@@ -80,7 +80,7 @@ func (f *Fosite) NewAccessRequest(ctx context.Context, r *http.Request, session 
 		return requester, errorsx.WithStack(ErrInvalidRequest.WithHint("Request parameter 'grant_type' is missing"))
 	}
 
-	client, _, clientErr := f.AuthenticateClientWithAuthHandler(ctx, r, r.PostForm, &TokenEndpointClientAuthHandler{})
+	client, _, clientErr := f.AuthenticateClientWithAuthHandler(ctx, r, r.PostForm, f.Config.GetTokenEndpointClientAuthStrategy(ctx))
 	if clientErr == nil {
 		requester.Client = client
 	}

--- a/client_authentication.go
+++ b/client_authentication.go
@@ -314,7 +314,7 @@ func (s *TokenEndpointClientAuthStrategy) AllowAuthMethodAny() bool {
 	return false
 }
 
-// AllowPublicClients returns true as the token endpoint permits public clients to authenticate using the 'none' method.
+// AllowMethodNone returns true as the token endpoint permits clients to authenticate using the 'none' method.
 func (s *TokenEndpointClientAuthStrategy) AllowMethodNone() bool {
 	return true
 }
@@ -366,7 +366,7 @@ func (s *IntrospectionEndpointClientAuthStrategy) AllowAuthMethodAny() bool {
 	return true
 }
 
-// AllowPublicClients returns false as the introspection endpoint does not permit public clients to authenticate using
+// AllowMethodNone returns false as the introspection endpoint does not permit clients to authenticate using
 // the 'none' method.
 func (s *IntrospectionEndpointClientAuthStrategy) AllowMethodNone() bool {
 	return false
@@ -418,7 +418,7 @@ func (s *RevocationEndpointClientAuthStrategy) AllowAuthMethodAny() bool {
 	return true
 }
 
-// AllowPublicClients returns true as the revocation endpoint permits public clients to authenticate using the 'none'
+// AllowMethodNone returns true as the revocation endpoint permits public clients to authenticate using the 'none'
 // method.
 func (s *RevocationEndpointClientAuthStrategy) AllowMethodNone() bool {
 	return true

--- a/client_authentication.go
+++ b/client_authentication.go
@@ -21,7 +21,7 @@ import (
 
 // ClientAuthenticationStrategy describes a client authentication strategy implementation.
 type ClientAuthenticationStrategy interface {
-	AuthenticateClient(ctx context.Context, r *http.Request, form url.Values, handler EndpointClientAuthHandler) (client Client, method string, err error)
+	AuthenticateClient(ctx context.Context, r *http.Request, form url.Values, strategy EndpointClientAuthStrategy) (client Client, method string, err error)
 }
 
 var (
@@ -31,20 +31,20 @@ var (
 // AuthenticateClient authenticates client requests using the configured strategy returned by the oauth2.Configurator
 // function GetClientAuthenticationStrategy, if nil it uses `oauth2.DefaultClientAuthenticationStrategy`.
 func (f *Fosite) AuthenticateClient(ctx context.Context, r *http.Request, form url.Values) (client Client, method string, err error) {
-	return f.AuthenticateClientWithAuthHandler(ctx, r, form, &TokenEndpointClientAuthHandler{})
+	return f.AuthenticateClientWithAuthHandler(ctx, r, form, f.Config.GetTokenEndpointClientAuthStrategy(ctx))
 }
 
 // AuthenticateClientWithAuthHandler authenticates a client at the endpoint represented by handler using the configured
 // ClientAuthenticationStrategy, falling back to DefaultClientAuthenticationStrategy if none is configured. Use this in
 // preference to AuthenticateClient when the request is not destined for the token endpoint.
-func (f *Fosite) AuthenticateClientWithAuthHandler(ctx context.Context, r *http.Request, form url.Values, handler EndpointClientAuthHandler) (client Client, method string, err error) {
+func (f *Fosite) AuthenticateClientWithAuthHandler(ctx context.Context, r *http.Request, form url.Values, strategyECA EndpointClientAuthStrategy) (client Client, method string, err error) {
 	var strategy ClientAuthenticationStrategy
 
 	if strategy = f.Config.GetClientAuthenticationStrategy(ctx); strategy == nil {
 		strategy = &DefaultClientAuthenticationStrategy{Store: f.Store, Config: f.Config}
 	}
 
-	return strategy.AuthenticateClient(ctx, r, form, handler)
+	return strategy.AuthenticateClient(ctx, r, form, strategyECA)
 }
 
 // CompareClientSecret compares a raw secret input from a client to the registered client secret. If the secret is valid
@@ -165,178 +165,262 @@ func getClientCredentialsClientIDValid(post, header string, assertion *ClientAss
 	return id, nil
 }
 
-// EndpointClientAuthHandler is a helper implementation to assist with producing the correct values while using multiple
-// endpoint implementations.
-type EndpointClientAuthHandler interface {
-	// GetAuthMethod returns the appropriate auth method for this client.
+// EndpointClientAuthStrategy abstracts the per-endpoint client authentication configuration so that a single
+// ClientAuthenticationStrategy implementation can authenticate clients across the various endpoints that support client
+// authentication (i.e. the token, introspection, and revocation endpoints). Each endpoint reads different client
+// metadata (for example the 'token_endpoint_auth_method' versus the 'introspection_endpoint_auth_method') and enforces
+// a different policy, and this strategy resolves the correct values and policy for the endpoint it represents.
+type EndpointClientAuthStrategy interface {
+	// GetAuthMethod returns the registered client authentication method configured for this endpoint (for example the
+	// value of the client's 'token_endpoint_auth_method').
 	GetAuthMethod(client AuthenticationMethodClient) string
 
-	// GetAuthSigningKeyID returns the appropriate auth signature key id for this client.
+	// GetAuthSigningKeyID returns the registered signing key id used to verify client assertions at this endpoint.
 	GetAuthSigningKeyID(client AuthenticationMethodClient) string
 
-	// GetAuthSigningAlg returns the appropriate auth signature algorithm for this client.
+	// GetAuthSigningAlg returns the registered signing algorithm used to verify client assertions at this endpoint.
 	GetAuthSigningAlg(client AuthenticationMethodClient) string
 
-	// GetAuthEncryptionKeyID returns the appropriate auth encryption key id for this client.
+	// GetAuthEncryptionKeyID returns the registered encryption key id used for client assertions at this endpoint.
 	GetAuthEncryptionKeyID(client AuthenticationMethodClient) string
 
-	// GetAuthEncryptionAlg returns the appropriate auth encryption key algorithm for this client.
+	// GetAuthEncryptionAlg returns the registered encryption key algorithm used for client assertions at this endpoint.
 	GetAuthEncryptionAlg(client AuthenticationMethodClient) string
 
-	// GetAuthEncryptionEnc returns the appropriate auth encryption content encryption for this client.
+	// GetAuthEncryptionEnc returns the registered content encryption algorithm used for client assertions at this
+	// endpoint.
 	GetAuthEncryptionEnc(client AuthenticationMethodClient) string
 
-	// Name returns the appropriate name for this endpoint for logging purposes.
+	// Name returns the name of the endpoint this strategy represents, used when building error and log messages (for
+	// example 'token', 'introspection', or 'revocation').
 	Name() string
 
-	// AllowAuthMethodAny returns true if this endpoint client auth handler is allowed to be used for any method if not configured.
+	// AllowAuthMethodAny returns true if this endpoint permits any client authentication method when the client has not
+	// registered a specific method for the endpoint.
 	AllowAuthMethodAny() bool
+
+	// AllowMethodNone returns true if this endpoint permits clients to authenticate using the 'none' method.
+	// When false, a client using the 'none' method is rejected even if it is otherwise correctly configured.
+	AllowMethodNone() bool
 }
 
+// EndpointClientAuthJWTClient adapts an AuthenticationMethodClient and its EndpointClientAuthStrategy into a jwt.Client.
+// It is passed to the jwt.Strategy when decoding a client assertion (i.e. the 'private_key_jwt' or 'client_secret_jwt'
+// method) so the assertion is verified using the keys and algorithms configured for the endpoint the strategy
+// represents.
 type EndpointClientAuthJWTClient struct {
-	client  AuthenticationMethodClient
-	handler EndpointClientAuthHandler
+	client   AuthenticationMethodClient
+	strategy EndpointClientAuthStrategy
 }
 
+// GetID returns the underlying client's ID.
 func (c *EndpointClientAuthJWTClient) GetID() string {
 	return c.client.GetID()
 }
 
+// GetClientSecretPlainText returns the underlying client's plaintext secret, used to verify 'client_secret_jwt'
+// assertions. See jwt.BaseClient for the semantics of the return values.
 func (c *EndpointClientAuthJWTClient) GetClientSecretPlainText() (secret []byte, ok bool, err error) {
 	return c.client.GetClientSecretPlainText()
 }
 
+// GetJSONWebKeys returns the underlying client's registered JSON Web Key Set used to verify 'private_key_jwt'
+// assertions.
 func (c *EndpointClientAuthJWTClient) GetJSONWebKeys() (jwks *jose.JSONWebKeySet) {
 	return c.client.GetJSONWebKeys()
 }
 
+// GetJSONWebKeysURI returns the underlying client's registered JSON Web Key Set URI used to verify 'private_key_jwt'
+// assertions.
 func (c *EndpointClientAuthJWTClient) GetJSONWebKeysURI() (uri string) {
 	return c.client.GetJSONWebKeysURI()
 }
 
+// GetSigningKeyID returns an empty key id as the key is resolved from the client's JSON Web Key Set rather than a fixed
+// key id.
 func (c *EndpointClientAuthJWTClient) GetSigningKeyID() (kid string) {
 	return ""
 }
 
+// GetSigningAlg returns the signing algorithm configured for the endpoint, resolved via the strategy (for example the
+// client's 'token_endpoint_auth_signing_alg').
 func (c *EndpointClientAuthJWTClient) GetSigningAlg() (alg string) {
-	return c.handler.GetAuthSigningAlg(c.client)
+	return c.strategy.GetAuthSigningAlg(c.client)
 }
 
+// GetEncryptionKeyID returns an empty key id as client assertions are verified, not encrypted, by this client.
 func (c *EndpointClientAuthJWTClient) GetEncryptionKeyID() (kid string) {
 	return ""
 }
 
+// GetEncryptionAlg returns an empty algorithm as client assertions are verified, not encrypted, by this client.
 func (c *EndpointClientAuthJWTClient) GetEncryptionAlg() (alg string) {
 	return ""
 }
 
+// GetEncryptionEnc returns an empty content encryption algorithm as client assertions are verified, not encrypted, by
+// this client.
 func (c *EndpointClientAuthJWTClient) GetEncryptionEnc() (enc string) {
 	return ""
 }
 
+// IsClientSigned returns true as a client assertion is always signed by the client.
 func (c *EndpointClientAuthJWTClient) IsClientSigned() (is bool) {
 	return true
 }
 
-type TokenEndpointClientAuthHandler struct{}
+// TokenEndpointClientAuthStrategy is the EndpointClientAuthStrategy for the token endpoint. It resolves client
+// authentication configuration from the client's 'token_endpoint_auth_method' metadata and permits public clients to
+// authenticate using the 'none' method.
+type TokenEndpointClientAuthStrategy struct{}
 
-func (h *TokenEndpointClientAuthHandler) GetAuthMethod(client AuthenticationMethodClient) string {
+// GetAuthMethod returns the client's registered 'token_endpoint_auth_method'.
+func (s *TokenEndpointClientAuthStrategy) GetAuthMethod(client AuthenticationMethodClient) string {
 	return client.GetTokenEndpointAuthMethod()
 }
 
-func (h *TokenEndpointClientAuthHandler) GetAuthSigningKeyID(client AuthenticationMethodClient) string {
+// GetAuthSigningKeyID returns the signing key id used to verify client assertions at the token endpoint.
+func (s *TokenEndpointClientAuthStrategy) GetAuthSigningKeyID(client AuthenticationMethodClient) string {
 	return ""
 }
 
-func (h *TokenEndpointClientAuthHandler) GetAuthSigningAlg(client AuthenticationMethodClient) string {
+// GetAuthSigningAlg returns the client's registered 'token_endpoint_auth_signing_alg'.
+func (s *TokenEndpointClientAuthStrategy) GetAuthSigningAlg(client AuthenticationMethodClient) string {
 	return client.GetTokenEndpointAuthSigningAlg()
 }
 
-func (h *TokenEndpointClientAuthHandler) GetAuthEncryptionKeyID(client AuthenticationMethodClient) string {
+// GetAuthEncryptionKeyID returns the encryption key id used for client assertions at the token endpoint.
+func (s *TokenEndpointClientAuthStrategy) GetAuthEncryptionKeyID(client AuthenticationMethodClient) string {
 	return ""
 }
 
-func (h *TokenEndpointClientAuthHandler) GetAuthEncryptionAlg(client AuthenticationMethodClient) string {
+// GetAuthEncryptionAlg returns the encryption key algorithm used for client assertions at the token endpoint.
+func (s *TokenEndpointClientAuthStrategy) GetAuthEncryptionAlg(client AuthenticationMethodClient) string {
 	return ""
 }
 
-func (h *TokenEndpointClientAuthHandler) GetAuthEncryptionEnc(client AuthenticationMethodClient) string {
+// GetAuthEncryptionEnc returns the content encryption algorithm used for client assertions at the token endpoint.
+func (s *TokenEndpointClientAuthStrategy) GetAuthEncryptionEnc(client AuthenticationMethodClient) string {
 	return ""
 }
 
-func (h *TokenEndpointClientAuthHandler) Name() string {
+// Name returns 'token', the name of the endpoint this strategy represents.
+func (s *TokenEndpointClientAuthStrategy) Name() string {
 	return "token"
 }
 
-func (h *TokenEndpointClientAuthHandler) AllowAuthMethodAny() bool {
+// AllowAuthMethodAny returns false as the token endpoint requires a client to use its registered authentication method.
+func (s *TokenEndpointClientAuthStrategy) AllowAuthMethodAny() bool {
 	return false
 }
 
-type IntrospectionEndpointClientAuthHandler struct{}
-
-func (h *IntrospectionEndpointClientAuthHandler) GetAuthMethod(client AuthenticationMethodClient) string {
-	return client.GetIntrospectionEndpointAuthMethod()
-}
-
-func (h *IntrospectionEndpointClientAuthHandler) GetAuthSigningKeyID(client AuthenticationMethodClient) string {
-	return ""
-}
-
-func (h *IntrospectionEndpointClientAuthHandler) GetAuthSigningAlg(client AuthenticationMethodClient) string {
-	return client.GetIntrospectionEndpointAuthSigningAlg()
-}
-
-func (h *IntrospectionEndpointClientAuthHandler) GetAuthEncryptionKeyID(client AuthenticationMethodClient) string {
-	return ""
-}
-
-func (h *IntrospectionEndpointClientAuthHandler) GetAuthEncryptionAlg(client AuthenticationMethodClient) string {
-	return ""
-}
-
-func (h *IntrospectionEndpointClientAuthHandler) GetAuthEncryptionEnc(client AuthenticationMethodClient) string {
-	return ""
-}
-
-func (h *IntrospectionEndpointClientAuthHandler) Name() string {
-	return "introspection"
-}
-
-func (h *IntrospectionEndpointClientAuthHandler) AllowAuthMethodAny() bool {
+// AllowPublicClients returns true as the token endpoint permits public clients to authenticate using the 'none' method.
+func (s *TokenEndpointClientAuthStrategy) AllowMethodNone() bool {
 	return true
 }
 
-type RevocationEndpointClientAuthHandler struct{}
+// IntrospectionEndpointClientAuthStrategy is the EndpointClientAuthStrategy for the introspection endpoint. It resolves
+// client authentication configuration from the client's 'introspection_endpoint_auth_method' metadata and does not
+// permit public clients to authenticate using the 'none' method.
+type IntrospectionEndpointClientAuthStrategy struct{}
 
-func (h *RevocationEndpointClientAuthHandler) GetAuthMethod(client AuthenticationMethodClient) string {
+// GetAuthMethod returns the client's registered 'introspection_endpoint_auth_method'.
+func (s *IntrospectionEndpointClientAuthStrategy) GetAuthMethod(client AuthenticationMethodClient) string {
+	return client.GetIntrospectionEndpointAuthMethod()
+}
+
+// GetAuthSigningKeyID returns the signing key id used to verify client assertions at the introspection endpoint.
+func (s *IntrospectionEndpointClientAuthStrategy) GetAuthSigningKeyID(client AuthenticationMethodClient) string {
+	return ""
+}
+
+// GetAuthSigningAlg returns the client's registered 'introspection_endpoint_auth_signing_alg'.
+func (s *IntrospectionEndpointClientAuthStrategy) GetAuthSigningAlg(client AuthenticationMethodClient) string {
+	return client.GetIntrospectionEndpointAuthSigningAlg()
+}
+
+// GetAuthEncryptionKeyID returns the encryption key id used for client assertions at the introspection endpoint.
+func (s *IntrospectionEndpointClientAuthStrategy) GetAuthEncryptionKeyID(client AuthenticationMethodClient) string {
+	return ""
+}
+
+// GetAuthEncryptionAlg returns the encryption key algorithm used for client assertions at the introspection endpoint.
+func (s *IntrospectionEndpointClientAuthStrategy) GetAuthEncryptionAlg(client AuthenticationMethodClient) string {
+	return ""
+}
+
+// GetAuthEncryptionEnc returns the content encryption algorithm used for client assertions at the introspection
+// endpoint.
+func (s *IntrospectionEndpointClientAuthStrategy) GetAuthEncryptionEnc(client AuthenticationMethodClient) string {
+	return ""
+}
+
+// Name returns 'introspection', the name of the endpoint this strategy represents.
+func (s *IntrospectionEndpointClientAuthStrategy) Name() string {
+	return "introspection"
+}
+
+// AllowAuthMethodAny returns true as the introspection endpoint permits any authentication method when the client has
+// not registered a specific 'introspection_endpoint_auth_method'.
+func (s *IntrospectionEndpointClientAuthStrategy) AllowAuthMethodAny() bool {
+	return true
+}
+
+// AllowPublicClients returns false as the introspection endpoint does not permit public clients to authenticate using
+// the 'none' method.
+func (s *IntrospectionEndpointClientAuthStrategy) AllowMethodNone() bool {
+	return false
+}
+
+// RevocationEndpointClientAuthStrategy is the EndpointClientAuthStrategy for the revocation endpoint. It resolves client
+// authentication configuration from the client's 'revocation_endpoint_auth_method' metadata and permits public clients
+// to authenticate using the 'none' method.
+type RevocationEndpointClientAuthStrategy struct{}
+
+// GetAuthMethod returns the client's registered 'revocation_endpoint_auth_method'.
+func (s *RevocationEndpointClientAuthStrategy) GetAuthMethod(client AuthenticationMethodClient) string {
 	return client.GetRevocationEndpointAuthMethod()
 }
 
-func (h *RevocationEndpointClientAuthHandler) GetAuthSigningKeyID(client AuthenticationMethodClient) string {
+// GetAuthSigningKeyID returns the signing key id used to verify client assertions at the revocation endpoint.
+func (s *RevocationEndpointClientAuthStrategy) GetAuthSigningKeyID(client AuthenticationMethodClient) string {
 	return ""
 }
 
-func (h *RevocationEndpointClientAuthHandler) GetAuthSigningAlg(client AuthenticationMethodClient) string {
+// GetAuthSigningAlg returns the client's registered 'revocation_endpoint_auth_signing_alg'.
+func (s *RevocationEndpointClientAuthStrategy) GetAuthSigningAlg(client AuthenticationMethodClient) string {
 	return client.GetRevocationEndpointAuthSigningAlg()
 }
 
-func (h *RevocationEndpointClientAuthHandler) GetAuthEncryptionKeyID(client AuthenticationMethodClient) string {
+// GetAuthEncryptionKeyID returns the encryption key id used for client assertions at the revocation endpoint.
+func (s *RevocationEndpointClientAuthStrategy) GetAuthEncryptionKeyID(client AuthenticationMethodClient) string {
 	return ""
 }
 
-func (h *RevocationEndpointClientAuthHandler) GetAuthEncryptionAlg(client AuthenticationMethodClient) string {
+// GetAuthEncryptionAlg returns the encryption key algorithm used for client assertions at the revocation endpoint.
+func (s *RevocationEndpointClientAuthStrategy) GetAuthEncryptionAlg(client AuthenticationMethodClient) string {
 	return ""
 }
 
-func (h *RevocationEndpointClientAuthHandler) GetAuthEncryptionEnc(client AuthenticationMethodClient) string {
+// GetAuthEncryptionEnc returns the content encryption algorithm used for client assertions at the revocation endpoint.
+func (s *RevocationEndpointClientAuthStrategy) GetAuthEncryptionEnc(client AuthenticationMethodClient) string {
 	return ""
 }
 
-func (h *RevocationEndpointClientAuthHandler) Name() string {
+// Name returns 'revocation', the name of the endpoint this strategy represents.
+func (s *RevocationEndpointClientAuthStrategy) Name() string {
 	return "revocation"
 }
 
-func (h *RevocationEndpointClientAuthHandler) AllowAuthMethodAny() bool {
+// AllowAuthMethodAny returns true as the revocation endpoint permits any authentication method when the client has not
+// registered a specific 'revocation_endpoint_auth_method'.
+func (s *RevocationEndpointClientAuthStrategy) AllowAuthMethodAny() bool {
+	return true
+}
+
+// AllowPublicClients returns true as the revocation endpoint permits public clients to authenticate using the 'none'
+// method.
+func (s *RevocationEndpointClientAuthStrategy) AllowMethodNone() bool {
 	return true
 }
 

--- a/client_authentication_strategy.go
+++ b/client_authentication_strategy.go
@@ -30,7 +30,7 @@ type DefaultClientAuthenticationStrategy struct {
 	}
 }
 
-func (s *DefaultClientAuthenticationStrategy) AuthenticateClient(ctx context.Context, r *http.Request, form url.Values, handler EndpointClientAuthHandler) (client Client, method string, err error) {
+func (s *DefaultClientAuthenticationStrategy) AuthenticateClient(ctx context.Context, r *http.Request, form url.Values, strategy EndpointClientAuthStrategy) (client Client, method string, err error) {
 	var (
 		id, secret string
 
@@ -52,7 +52,7 @@ func (s *DefaultClientAuthenticationStrategy) AuthenticateClient(ctx context.Con
 	var assertion *ClientAssertion
 
 	if hasAssertion {
-		if assertion, err = NewClientAssertion(ctx, s.Config.GetJWTStrategy(ctx), s.Store, assertionValue, assertionType, handler); err != nil {
+		if assertion, err = NewClientAssertion(ctx, s.Config.GetJWTStrategy(ctx), s.Store, assertionValue, assertionType, strategy); err != nil {
 			return nil, "", err
 		}
 	}
@@ -68,10 +68,10 @@ func (s *DefaultClientAuthenticationStrategy) AuthenticateClient(ctx context.Con
 
 	hasNone := !hasPost && !hasBasic && assertion == nil && len(id) != 0
 
-	return s.authenticate(ctx, id, secret, assertion, hasBasic, hasPost, hasNone, handler)
+	return s.authenticate(ctx, id, secret, assertion, hasBasic, hasPost, hasNone, strategy)
 }
 
-func (s *DefaultClientAuthenticationStrategy) authenticate(ctx context.Context, id, secret string, assertion *ClientAssertion, hasBasic, hasPost, hasNone bool, handler EndpointClientAuthHandler) (client Client, method string, err error) {
+func (s *DefaultClientAuthenticationStrategy) authenticate(ctx context.Context, id, secret string, assertion *ClientAssertion, hasBasic, hasPost, hasNone bool, strategy EndpointClientAuthStrategy) (client Client, method string, err error) {
 	var methods []string
 
 	if hasBasic {
@@ -117,16 +117,16 @@ func (s *DefaultClientAuthenticationStrategy) authenticate(ctx context.Context, 
 			break
 		}
 
-		return nil, "", errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebugf("Client Authentication failed with more than one known authentication method included in the request which is not permitted. The registered client with id '%s' and the authorization server policy does not permit this malformed request. The `%s_endpoint_auth_method` methods determined to be used were '%s'.", client.GetID(), handler.Name(), strings.Join(methods, "', '")))
+		return nil, "", errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebugf("Client Authentication failed with more than one known authentication method included in the request which is not permitted. The registered client with id '%s' and the authorization server policy does not permit this malformed request. The `%s_endpoint_auth_method` methods determined to be used were '%s'.", client.GetID(), strategy.Name(), strings.Join(methods, "', '")))
 	}
 
 	switch {
 	case assertion != nil:
-		method, err = s.doAuthenticateAssertionJWTBearer(ctx, client, assertion, handler)
+		method, err = s.doAuthenticateAssertionJWTBearer(ctx, client, assertion, strategy)
 	case hasBasic, hasPost:
-		method, err = s.doAuthenticateClientSecret(ctx, client, secret, hasBasic, hasPost, handler)
+		method, err = s.doAuthenticateClientSecret(ctx, client, secret, hasBasic, hasPost, strategy)
 	default:
-		method, err = s.doAuthenticateNone(ctx, client, handler)
+		method, err = s.doAuthenticateNone(ctx, client, strategy)
 	}
 
 	if err != nil {
@@ -137,7 +137,7 @@ func (s *DefaultClientAuthenticationStrategy) authenticate(ctx context.Context, 
 }
 
 // NewClientAssertion converts a raw assertion string into a *ClientAssertion.
-func NewClientAssertion(ctx context.Context, strategy jwt.Strategy, store ClientManager, assertion, assertionType string, handler EndpointClientAuthHandler) (a *ClientAssertion, err error) {
+func NewClientAssertion(ctx context.Context, strategyJWT jwt.Strategy, store ClientManager, assertion, assertionType string, strategy EndpointClientAuthStrategy) (a *ClientAssertion, err error) {
 	var (
 		token *jwt.Token
 
@@ -154,7 +154,7 @@ func NewClientAssertion(ctx context.Context, strategy jwt.Strategy, store Client
 		return &ClientAssertion{Assertion: assertion, Type: assertionType}, errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebugf("Unknown client_assertion_type '%s'.", assertionType))
 	}
 
-	if token, err = strategy.Decode(ctx, assertion, jwt.WithAllowUnverified(), jwt.WithSigAlgorithm(jwt.SignatureAlgorithmsNone...)); err != nil {
+	if token, err = strategyJWT.Decode(ctx, assertion, jwt.WithAllowUnverified(), jwt.WithSigAlgorithm(jwt.SignatureAlgorithmsNone...)); err != nil {
 		return &ClientAssertion{Assertion: assertion, Type: assertionType}, resolveJWTErrorToRFCError(err)
 	}
 
@@ -193,21 +193,25 @@ type ClientAssertion struct {
 	Client                Client
 }
 
-func (s *DefaultClientAuthenticationStrategy) doAuthenticateNone(_ context.Context, client Client, handler EndpointClientAuthHandler) (method string, err error) {
+func (s *DefaultClientAuthenticationStrategy) doAuthenticateNone(_ context.Context, client Client, strategy EndpointClientAuthStrategy) (method string, err error) {
 	if c, ok := client.(AuthenticationMethodClient); ok {
-		if method = handler.GetAuthMethod(c); method != consts.ClientAuthMethodNone {
-			return "", errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebugf("The registered client with id '%s' is configured to only support '%s_endpoint_auth_method' method '%s', but the method '%s' was determined to be used. Either the Authorization Server client registration will need to have the '%s_endpoint_auth_method' updated to '%s' or the Relying Party will need to be configured to use '%s'.", client.GetID(), handler.Name(), method, consts.ClientAuthMethodNone, handler.Name(), consts.ClientAuthMethodNone, method))
+		if method = strategy.GetAuthMethod(c); method != consts.ClientAuthMethodNone {
+			return "", errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebugf("The registered client with id '%s' is configured to only support '%s_endpoint_auth_method' method '%s', but the method '%s' was determined to be used. Either the Authorization Server client registration will need to have the '%s_endpoint_auth_method' updated to '%s' or the Relying Party will need to be configured to use '%s'.", client.GetID(), strategy.Name(), method, consts.ClientAuthMethodNone, strategy.Name(), consts.ClientAuthMethodNone, method))
 		}
 	}
 
 	if !client.IsPublic() {
-		return "", errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebugf("The '%s_endpoint_auth_method' method 'none' was determined to be used, but the registered client with id '%s' is configured with a confidential client type but only client registrations with a public client type can use this '%s_endpoint_auth_method'.", handler.Name(), client.GetID(), handler.Name()))
+		return "", errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebugf("The '%s_endpoint_auth_method' method 'none' was determined to be used, but the registered client with id '%s' is configured with a confidential client type but only client registrations with a public client type can use this '%s_endpoint_auth_method'.", strategy.Name(), client.GetID(), strategy.Name()))
+	}
+
+	if !strategy.AllowMethodNone() {
+		return "", errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebugf("The '%s_endpoint_auth_method' method 'none' was determined to be used, but the %s endpoint does not permit clients to authenticate using this method.", strategy.Name(), strategy.Name()))
 	}
 
 	return consts.ClientAuthMethodNone, nil
 }
 
-func (s *DefaultClientAuthenticationStrategy) doAuthenticateClientSecret(ctx context.Context, client Client, rawSecret string, hasBasic, hasPost bool, handler EndpointClientAuthHandler) (method string, err error) {
+func (s *DefaultClientAuthenticationStrategy) doAuthenticateClientSecret(ctx context.Context, client Client, rawSecret string, hasBasic, hasPost bool, strategy EndpointClientAuthStrategy) (method string, err error) {
 	method = consts.ClientAuthMethodClientSecretBasic
 
 	if !hasBasic && hasPost {
@@ -215,14 +219,14 @@ func (s *DefaultClientAuthenticationStrategy) doAuthenticateClientSecret(ctx con
 	}
 
 	if c, ok := client.(AuthenticationMethodClient); ok {
-		switch cmethod := handler.GetAuthMethod(c); {
-		case cmethod == "" && handler.AllowAuthMethodAny():
+		switch cmethod := strategy.GetAuthMethod(c); {
+		case cmethod == "" && strategy.AllowAuthMethodAny():
 			break
 		case cmethod != method:
 			return "", errorsx.WithStack(
 				ErrInvalidClient.
 					WithHint(hintClientCredentialsInvalid).
-					WithDebugf("The request was determined to be using '%s_endpoint_auth_method' method '%s', however the registered client with id '%s' is configured to only support '%s_endpoint_auth_method' method '%s'. Either the Authorization Server client registration will need to have the '%s_endpoint_auth_method' updated to '%s' or the Relying Party will need to be configured to use '%s'.", handler.Name(), method, client.GetID(), handler.Name(), cmethod, handler.Name(), method, cmethod))
+					WithDebugf("The request was determined to be using '%s_endpoint_auth_method' method '%s', however the registered client with id '%s' is configured to only support '%s_endpoint_auth_method' method '%s'. Either the Authorization Server client registration will need to have the '%s_endpoint_auth_method' updated to '%s' or the Relying Party will need to be configured to use '%s'.", strategy.Name(), method, client.GetID(), strategy.Name(), cmethod, strategy.Name(), method, cmethod))
 		}
 	}
 
@@ -233,14 +237,14 @@ func (s *DefaultClientAuthenticationStrategy) doAuthenticateClientSecret(ctx con
 		return "", errorsx.WithStack(
 			ErrInvalidClient.
 				WithHint(hintClientCredentialsInvalid).
-				WithDebugf("The request was determined to be using '%s_endpoint_auth_method' method '%s', however the registered client with id '%s' has no 'client_secret' which is required to process this method.", handler.Name(), method, client.GetID()),
+				WithDebugf("The request was determined to be using '%s_endpoint_auth_method' method '%s', however the registered client with id '%s' has no 'client_secret' which is required to process this method.", strategy.Name(), method, client.GetID()),
 		)
 	default:
 		return "", errorsx.WithStack(ErrInvalidClient.WithWrap(err).WithDebugError(err))
 	}
 }
 
-func (s *DefaultClientAuthenticationStrategy) doAuthenticateAssertionJWTBearer(ctx context.Context, client Client, assertion *ClientAssertion, handler EndpointClientAuthHandler) (method string, err error) {
+func (s *DefaultClientAuthenticationStrategy) doAuthenticateAssertionJWTBearer(ctx context.Context, client Client, assertion *ClientAssertion, strategy EndpointClientAuthStrategy) (method string, err error) {
 	var (
 		token *jwt.Token
 		c     AuthenticationMethodClient
@@ -251,7 +255,7 @@ func (s *DefaultClientAuthenticationStrategy) doAuthenticateAssertionJWTBearer(c
 		return "", errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebug("The registered client does not support OAuth 2.0 JWT Profile Client Authentication RFC7523 or OpenID Connect 1.0 specific authentication methods."))
 	}
 
-	if method, _, _, token, err = s.doAuthenticateAssertionParseAssertionJWTBearer(ctx, c, assertion, handler); err != nil {
+	if method, _, _, token, err = s.doAuthenticateAssertionParseAssertionJWTBearer(ctx, c, assertion, strategy); err != nil {
 		return "", err
 	}
 
@@ -276,14 +280,14 @@ func (s *DefaultClientAuthenticationStrategy) doAuthenticateAssertionJWTBearer(c
 	case claims.JTI == "":
 		return "", errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebug("The client assertion had invalid claims. Claim 'jti' from 'client_assertion' must be set but is not."))
 	default:
-		switch cmethod := handler.GetAuthMethod(c); {
-		case cmethod == "" && handler.AllowAuthMethodAny():
+		switch cmethod := strategy.GetAuthMethod(c); {
+		case cmethod == "" && strategy.AllowAuthMethodAny():
 			break
 		case cmethod != method:
 			return "", errorsx.WithStack(
 				ErrInvalidClient.
 					WithHint(hintClientCredentialsInvalid).
-					WithDebugf("The request was determined to be using '%s_endpoint_auth_method' method '%s', however the registered client with id '%s' is configured to only support '%s_endpoint_auth_method' method '%s'. Either the Authorization Server client registration will need to have the '%s_endpoint_auth_method' updated to '%s' or the Relying Party will need to be configured to use '%s'.", handler.Name(), method, client.GetID(), handler.Name(), cmethod, handler.Name(), method, cmethod))
+					WithDebugf("The request was determined to be using '%s_endpoint_auth_method' method '%s', however the registered client with id '%s' is configured to only support '%s_endpoint_auth_method' method '%s'. Either the Authorization Server client registration will need to have the '%s_endpoint_auth_method' updated to '%s' or the Relying Party will need to be configured to use '%s'.", strategy.Name(), method, client.GetID(), strategy.Name(), cmethod, strategy.Name(), method, cmethod))
 		}
 
 		if !assertion.Parsed {
@@ -302,15 +306,15 @@ func (s *DefaultClientAuthenticationStrategy) doAuthenticateAssertionJWTBearer(c
 	}
 }
 
-func (s *DefaultClientAuthenticationStrategy) doAuthenticateAssertionParseAssertionJWTBearer(ctx context.Context, client AuthenticationMethodClient, assertion *ClientAssertion, handler EndpointClientAuthHandler) (method, kid, alg string, token *jwt.Token, err error) {
+func (s *DefaultClientAuthenticationStrategy) doAuthenticateAssertionParseAssertionJWTBearer(ctx context.Context, client AuthenticationMethodClient, assertion *ClientAssertion, strategy EndpointClientAuthStrategy) (method, kid, alg string, token *jwt.Token, err error) {
 	audience := s.Config.GetAllowedJWTAssertionAudiences(ctx)
 
 	if len(audience) == 0 {
 		return "", "", "", nil, errorsx.WithStack(ErrInvalidClient.WithHint(hintClientCredentialsInvalid).WithDebug("The authorization server does not support OAuth 2.0 JWT Profile Client Authentication RFC7523 or OpenID Connect 1.0 specific authentication methods as it could not determine any safe value for it's audience but it's required to validate the RFC7523 client assertions."))
 	}
 
-	if token, err = s.Config.GetJWTStrategy(ctx).Decode(ctx, assertion.Assertion, jwt.WithClient(&EndpointClientAuthJWTClient{client: client, handler: handler}), jwt.WithSigAlgorithm(jwt.SignatureAlgorithmsNone...)); err != nil {
-		return "", "", "", nil, errorsx.WithStack(fmtClientAssertionDecodeError(token, client, handler, audience, err))
+	if token, err = s.Config.GetJWTStrategy(ctx).Decode(ctx, assertion.Assertion, jwt.WithClient(&EndpointClientAuthJWTClient{client: client, strategy: strategy}), jwt.WithSigAlgorithm(jwt.SignatureAlgorithmsNone...)); err != nil {
+		return "", "", "", nil, errorsx.WithStack(fmtClientAssertionDecodeError(token, client, strategy, audience, err))
 	}
 
 	optsClaims := []jwt.ClaimValidationOption{
@@ -320,7 +324,7 @@ func (s *DefaultClientAuthenticationStrategy) doAuthenticateAssertionParseAssert
 	}
 
 	if err = token.Claims.Valid(optsClaims...); err != nil {
-		return "", "", "", nil, errorsx.WithStack(fmtClientAssertionDecodeError(token, client, handler, audience, err))
+		return "", "", "", nil, errorsx.WithStack(fmtClientAssertionDecodeError(token, client, strategy, audience, err))
 	}
 
 	var (
@@ -343,15 +347,15 @@ func (s *DefaultClientAuthenticationStrategy) doAuthenticateAssertionParseAssert
 	optsHeader := []jwt.HeaderValidationOption{
 		jwt.ValidateTypes(types...),
 		jwt.ValidateAllowEmptyType(allowEmptyType),
-		jwt.ValidateKeyID(handler.GetAuthSigningKeyID(client)),
-		jwt.ValidateAlgorithm(handler.GetAuthSigningAlg(client)),
-		jwt.ValidateEncryptionKeyID(handler.GetAuthEncryptionKeyID(client)),
-		jwt.ValidateKeyAlgorithm(handler.GetAuthEncryptionAlg(client)),
-		jwt.ValidateContentEncryption(handler.GetAuthEncryptionEnc(client)),
+		jwt.ValidateKeyID(strategy.GetAuthSigningKeyID(client)),
+		jwt.ValidateAlgorithm(strategy.GetAuthSigningAlg(client)),
+		jwt.ValidateEncryptionKeyID(strategy.GetAuthEncryptionKeyID(client)),
+		jwt.ValidateKeyAlgorithm(strategy.GetAuthEncryptionAlg(client)),
+		jwt.ValidateContentEncryption(strategy.GetAuthEncryptionEnc(client)),
 	}
 
 	if err = token.Valid(optsHeader...); err != nil {
-		return "", "", "", nil, errorsx.WithStack(fmtClientAssertionDecodeError(token, client, handler, audience, err))
+		return "", "", "", nil, errorsx.WithStack(fmtClientAssertionDecodeError(token, client, strategy, audience, err))
 	}
 
 	if raw, ok := token.Header[consts.JSONWebTokenHeaderKeyIdentifier]; ok {
@@ -409,15 +413,15 @@ func resolveJWTErrorToRFCError(err error) (rfc error) {
 }
 
 //nolint:gocyclo
-func fmtClientAssertionDecodeError(token *jwt.Token, client AuthenticationMethodClient, handler EndpointClientAuthHandler, audience []string, inner error) (outer *RFC6749Error) {
+func fmtClientAssertionDecodeError(token *jwt.Token, client AuthenticationMethodClient, strategy EndpointClientAuthStrategy, audience []string, inner error) (outer *RFC6749Error) {
 	outer = ErrInvalidClient.WithWrap(inner).WithHint(hintClientCredentialsInvalid)
 
 	if errJWTValidation := new(jwt.ValidationError); errors.As(inner, &errJWTValidation) {
 		switch {
 		case errJWTValidation.Has(jwt.ValidationErrorHeaderKeyIDInvalid):
-			return outer.WithDebugf("OAuth 2.0 client with id '%s' expects client assertions to be signed with the 'kid' header value '%s' due to the client registration 'request_object_signing_key_id' value but the client assertion was signed with the 'kid' header value '%s'.", client.GetID(), handler.GetAuthSigningKeyID(client), token.KeyID)
+			return outer.WithDebugf("OAuth 2.0 client with id '%s' expects client assertions to be signed with the 'kid' header value '%s' due to the client registration 'request_object_signing_key_id' value but the client assertion was signed with the 'kid' header value '%s'.", client.GetID(), strategy.GetAuthSigningKeyID(client), token.KeyID)
 		case errJWTValidation.Has(jwt.ValidationErrorHeaderAlgorithmInvalid):
-			return outer.WithDebugf("OAuth 2.0 client with id '%s' expects client assertions to be signed with the 'alg' header value '%s' due to the client registration 'request_object_signing_alg' value but the client assertion was signed with the 'alg' header value '%s'.", client.GetID(), handler.GetAuthSigningAlg(client), token.SignatureAlgorithm)
+			return outer.WithDebugf("OAuth 2.0 client with id '%s' expects client assertions to be signed with the 'alg' header value '%s' due to the client registration 'request_object_signing_alg' value but the client assertion was signed with the 'alg' header value '%s'.", client.GetID(), strategy.GetAuthSigningAlg(client), token.SignatureAlgorithm)
 		case errJWTValidation.Has(jwt.ValidationErrorHeaderTypeInvalid):
 			return outer.WithDebugf("OAuth 2.0 client with id '%s' expects client assertions to be signed with the 'typ' header value '%s' or '%s' but the client assertion was signed with the 'typ' header value '%s'.", client.GetID(), jwt.JSONWebTokenTypeClientAuthentication, jwt.JSONWebTokenTypeJWT, fmtHeaderValue(token.Header, jwt.JSONWebTokenHeaderType))
 		case errJWTValidation.Has(jwt.ValidationErrorHeaderEncryptionTypeInvalid):
@@ -427,11 +431,11 @@ func fmtClientAssertionDecodeError(token *jwt.Token, client AuthenticationMethod
 		case errJWTValidation.Has(jwt.ValidationErrorHeaderContentTypeInvalid):
 			return outer.WithDebugf("OAuth 2.0 client with id '%s' expects client assertions to be encrypted with the 'cty' header value '%s' or '%s' but the client assertion was encrypted with the 'cty' header value '%s'.", client.GetID(), jwt.JSONWebTokenTypeClientAuthentication, jwt.JSONWebTokenTypeJWT, fmtHeaderValue(token.HeaderJWE, jwt.JSONWebTokenHeaderContentType))
 		case errJWTValidation.Has(jwt.ValidationErrorHeaderEncryptionKeyIDInvalid):
-			return outer.WithDebugf("OAuth 2.0 client with id '%s' expects client assertions to be encrypted with the 'kid' header value '%s' due to the client registration 'request_object_encryption_key_id' value but the client assertion was encrypted with the 'kid' header value '%s'.", client.GetID(), handler.GetAuthEncryptionKeyID(client), token.EncryptionKeyID)
+			return outer.WithDebugf("OAuth 2.0 client with id '%s' expects client assertions to be encrypted with the 'kid' header value '%s' due to the client registration 'request_object_encryption_key_id' value but the client assertion was encrypted with the 'kid' header value '%s'.", client.GetID(), strategy.GetAuthEncryptionKeyID(client), token.EncryptionKeyID)
 		case errJWTValidation.Has(jwt.ValidationErrorHeaderKeyAlgorithmInvalid):
-			return outer.WithDebugf("OAuth 2.0 client with id '%s' expects client assertions to be encrypted with the 'alg' header value '%s' due to the client registration 'request_object_encryption_alg' value but the client assertion was encrypted with the 'alg' header value '%s'.", client.GetID(), handler.GetAuthEncryptionAlg(client), token.KeyAlgorithm)
+			return outer.WithDebugf("OAuth 2.0 client with id '%s' expects client assertions to be encrypted with the 'alg' header value '%s' due to the client registration 'request_object_encryption_alg' value but the client assertion was encrypted with the 'alg' header value '%s'.", client.GetID(), strategy.GetAuthEncryptionAlg(client), token.KeyAlgorithm)
 		case errJWTValidation.Has(jwt.ValidationErrorHeaderContentEncryptionInvalid):
-			return outer.WithDebugf("OAuth 2.0 client with id '%s' expects client assertions to be encrypted with the 'enc' header value '%s' due to the client registration 'request_object_encryption_enc' value but the client assertion was encrypted with the 'enc' header value '%s'.", client.GetID(), handler.GetAuthEncryptionEnc(client), token.ContentEncryption)
+			return outer.WithDebugf("OAuth 2.0 client with id '%s' expects client assertions to be encrypted with the 'enc' header value '%s' due to the client registration 'request_object_encryption_enc' value but the client assertion was encrypted with the 'enc' header value '%s'.", client.GetID(), strategy.GetAuthEncryptionEnc(client), token.ContentEncryption)
 		case errJWTValidation.Has(jwt.ValidationErrorMalformedNotCompactSerialized):
 			return outer.WithDebugf("OAuth 2.0 client with id '%s' provided a client assertion that was malformed. The client assertion does not appear to be a JWE or JWS compact serialized JWT.", client.GetID())
 		case errJWTValidation.Has(jwt.ValidationErrorMalformed):

--- a/client_authentication_test.go
+++ b/client_authentication_test.go
@@ -76,6 +76,7 @@ func TestAuthenticateClient(t *testing.T) {
 	testCases := []struct {
 		name          string
 		client        func(ts *httptest.Server) Client
+		strategy      EndpointClientAuthStrategy
 		assertionType string
 		assertion     string
 		r             *http.Request
@@ -126,6 +127,26 @@ func TestAuthenticateClient(t *testing.T) {
 			},
 			form: url.Values{},
 			r:    &http.Request{Header: clientBasicAuthHeader("foo", "")},
+		},
+		{
+			name:     "ShouldPassBecauseRevocationEndpointPermitsPublicClients",
+			strategy: &RevocationEndpointClientAuthStrategy{},
+			client: func(ts *httptest.Server) Client {
+				return &DefaultJARClient{DefaultClient: &DefaultClient{ID: "foo", Public: true}, RevocationEndpointAuthMethod: "none"}
+			},
+			form: url.Values{consts.FormParameterClientID: {"foo"}},
+			r:    new(http.Request),
+		},
+		{
+			name:     "ShouldFailBecauseIntrospectionEndpointForbidsPublicClients",
+			strategy: &IntrospectionEndpointClientAuthStrategy{},
+			client: func(ts *httptest.Server) Client {
+				return &DefaultJARClient{DefaultClient: &DefaultClient{ID: "foo", Public: true}, IntrospectionEndpointAuthMethod: "none"}
+			},
+			form:      url.Values{consts.FormParameterClientID: {"foo"}},
+			r:         new(http.Request),
+			err:       "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The required credentials were not found, used an unknown method, could not be parsed, were otherwise malformed, or were otherwise incorrect. The 'introspection_endpoint_auth_method' method 'none' was determined to be used, but the introspection endpoint does not permit clients to authenticate using this method.",
+			expectErr: ErrInvalidClient,
 		},
 		{
 			name: "ShouldFailBecauseClientRequiresBasicAuthAndClientSecretIsEmptyInBasicAuthHeader",
@@ -958,7 +979,12 @@ func TestAuthenticateClient(t *testing.T) {
 			store.Clients[client.GetID()] = client
 			provider.Store = store
 
-			actual, _, err := provider.AuthenticateClient(context.Background(), tc.r, tc.form)
+			strategy := tc.strategy
+			if strategy == nil {
+				strategy = config.GetTokenEndpointClientAuthStrategy(context.Background())
+			}
+
+			actual, _, err := provider.AuthenticateClientWithAuthHandler(context.Background(), tc.r, tc.form, strategy)
 
 			if len(tc.err) == 0 && tc.expectErr == nil && tc.errRegexp == nil {
 				require.NoError(t, ErrorToDebugRFC6749Error(err))

--- a/config.go
+++ b/config.go
@@ -356,8 +356,12 @@ type RFC9628DeviceAuthorizeConfigProvider interface {
 	// GetRFC8628CodeLifespan returns the device and user code lifespan.
 	GetRFC8628CodeLifespan(ctx context.Context) (lifespan time.Duration)
 
+	// GetRFC8628UserVerificationURL returns the end-user verification URL returned to the device as the
+	// 'verification_uri' where the user enters their user code to authorize the device.
 	GetRFC8628UserVerificationURL(ctx context.Context) (url string)
 
+	// GetRFC8628TokenPollingInterval returns the minimum interval the device should wait between polling the token
+	// endpoint, returned to the device as the 'interval' value.
 	GetRFC8628TokenPollingInterval(ctx context.Context) (interval time.Duration)
 }
 
@@ -375,14 +379,21 @@ type RFC8628UserAuthorizeEndpointHandlersProvider interface {
 
 // RFC8693ConfigProvider is the configuration provider for RFC8693 Token Exchange.
 type RFC8693ConfigProvider interface {
+	// GetRFC8693TokenTypes returns the supported token types for Token Exchange keyed by their token type identifier
+	// (i.e. the 'subject_token_type', 'actor_token_type', and 'requested_token_type' URN values).
 	GetRFC8693TokenTypes(ctx context.Context) (types map[string]RFC8693TokenType)
 
+	// GetDefaultRFC8693RequestedTokenType returns the token type identifier used as the 'requested_token_type' when the
+	// Token Exchange request does not explicitly specify one.
 	GetDefaultRFC8693RequestedTokenType(ctx context.Context) (tokenType string)
 
+	// GetScopeStrategy returns the scope strategy used to validate scopes during Token Exchange.
 	GetScopeStrategy(ctx context.Context) (strategy ScopeStrategy)
 
+	// GetAudienceStrategy returns the audience strategy used to validate audiences during Token Exchange.
 	GetAudienceStrategy(ctx context.Context) (strategy AudienceStrategy)
 
+	// GetResourceStrategy returns the RFC 8707 resource indicator strategy used during Token Exchange.
 	GetResourceStrategy(ctx context.Context) (strategy ResourceStrategy)
 }
 
@@ -397,7 +408,7 @@ type UseLegacyErrorFormatProvider interface {
 }
 
 // PushedAuthorizeRequestConfigProvider is the configuration provider for pushed
-// authorization request.
+// authorization requests.
 type PushedAuthorizeRequestConfigProvider interface {
 	// GetPushedAuthorizeRequestURIPrefix is the request URI prefix. This is
 	// usually 'urn:ietf:params:oauth:request_uri:'.
@@ -412,6 +423,35 @@ type PushedAuthorizeRequestConfigProvider interface {
 	GetRequirePushedAuthorizationRequests(ctx context.Context) (enforce bool)
 }
 
+// AuthorizeErrorFieldResponseStrategyProvider returns the provider for the strategy used to write authorization
+// endpoint errors that cannot be delivered via a response_mode handler.
 type AuthorizeErrorFieldResponseStrategyProvider interface {
+	// GetAuthorizeErrorFieldResponseStrategy returns the AuthorizeErrorFieldResponseStrategy used to write authorization
+	// endpoint errors directly to the response writer when no response_mode handler matches, such as when the user
+	// cannot be safely redirected back to the client.
 	GetAuthorizeErrorFieldResponseStrategy(ctx context.Context) (strategy AuthorizeErrorFieldResponseStrategy)
+}
+
+// TokenEndpointClientAuthStrategyProvider returns the provider for the client authentication strategy used at the token
+// endpoint.
+type TokenEndpointClientAuthStrategyProvider interface {
+	// GetTokenEndpointClientAuthStrategy returns the EndpointClientAuthStrategy used to authenticate clients at the
+	// token endpoint. This endpoint permits public clients to authenticate using the 'none' method.
+	GetTokenEndpointClientAuthStrategy(ctx context.Context) (strategy EndpointClientAuthStrategy)
+}
+
+// IntrospectionEndpointClientAuthStrategyProvider returns the provider for the client authentication strategy used at
+// the introspection endpoint.
+type IntrospectionEndpointClientAuthStrategyProvider interface {
+	// GetIntrospectionEndpointClientAuthStrategy returns the EndpointClientAuthStrategy used to authenticate clients at
+	// the introspection endpoint. This endpoint does not permit public clients to authenticate using the 'none' method.
+	GetIntrospectionEndpointClientAuthStrategy(ctx context.Context) (strategy EndpointClientAuthStrategy)
+}
+
+// RevocationEndpointClientAuthStrategyProvider returns the provider for the client authentication strategy used at the
+// revocation endpoint.
+type RevocationEndpointClientAuthStrategyProvider interface {
+	// GetRevocationEndpointClientAuthStrategy returns the EndpointClientAuthStrategy used to authenticate clients at the
+	// revocation endpoint. This endpoint permits public clients to authenticate using the 'none' method.
+	GetRevocationEndpointClientAuthStrategy(ctx context.Context) (strategy EndpointClientAuthStrategy)
 }

--- a/config_default.go
+++ b/config_default.go
@@ -659,6 +659,18 @@ func (c *Config) GetAuthorizeErrorFieldResponseStrategy(ctx context.Context) (st
 	return c.AuthorizeErrorFieldResponseStrategy
 }
 
+func (c *Config) GetTokenEndpointClientAuthStrategy(ctx context.Context) (strategy EndpointClientAuthStrategy) {
+	return &TokenEndpointClientAuthStrategy{}
+}
+
+func (c *Config) GetIntrospectionEndpointClientAuthStrategy(ctx context.Context) (strategy EndpointClientAuthStrategy) {
+	return &IntrospectionEndpointClientAuthStrategy{}
+}
+
+func (c *Config) GetRevocationEndpointClientAuthStrategy(ctx context.Context) (strategy EndpointClientAuthStrategy) {
+	return &RevocationEndpointClientAuthStrategy{}
+}
+
 var (
 	_ AuthorizeCodeLifespanProvider                   = (*Config)(nil)
 	_ RefreshTokenLifespanProvider                    = (*Config)(nil)
@@ -711,4 +723,7 @@ var (
 	_ IntrospectionIssuerProvider                     = (*Config)(nil)
 	_ IntrospectionJWTResponseStrategyProvider        = (*Config)(nil)
 	_ AuthorizeErrorFieldResponseStrategyProvider     = (*Config)(nil)
+	_ TokenEndpointClientAuthStrategyProvider         = (*Config)(nil)
+	_ IntrospectionEndpointClientAuthStrategyProvider = (*Config)(nil)
+	_ RevocationEndpointClientAuthStrategyProvider    = (*Config)(nil)
 )

--- a/config_default.go
+++ b/config_default.go
@@ -146,6 +146,18 @@ type Config struct {
 	// ClientAuthenticationStrategy indicates the Strategy to authenticate client requests
 	ClientAuthenticationStrategy ClientAuthenticationStrategy
 
+	// TokenEndpointClientAuthStrategy indicates the EndpointClientAuthStrategy used to authenticate clients at the token
+	// endpoint. Defaults to a TokenEndpointClientAuthStrategy.
+	TokenEndpointClientAuthStrategy EndpointClientAuthStrategy
+
+	// IntrospectionEndpointClientAuthStrategy indicates the EndpointClientAuthStrategy used to authenticate clients at
+	// the introspection endpoint. Defaults to an IntrospectionEndpointClientAuthStrategy.
+	IntrospectionEndpointClientAuthStrategy EndpointClientAuthStrategy
+
+	// RevocationEndpointClientAuthStrategy indicates the EndpointClientAuthStrategy used to authenticate clients at the
+	// revocation endpoint. Defaults to a RevocationEndpointClientAuthStrategy.
+	RevocationEndpointClientAuthStrategy EndpointClientAuthStrategy
+
 	// AuthorizeErrorFieldResponseStrategy handles authorize error responses when the user can't be redirected in a
 	// normal way for example when the redirect uri is invalid or for any other reason, just writing the fields in some
 	// way to the response. By default this happens as a JSON document but this may also be a redirect to a internal
@@ -660,15 +672,27 @@ func (c *Config) GetAuthorizeErrorFieldResponseStrategy(ctx context.Context) (st
 }
 
 func (c *Config) GetTokenEndpointClientAuthStrategy(ctx context.Context) (strategy EndpointClientAuthStrategy) {
-	return &TokenEndpointClientAuthStrategy{}
+	if c.TokenEndpointClientAuthStrategy == nil {
+		c.TokenEndpointClientAuthStrategy = &TokenEndpointClientAuthStrategy{}
+	}
+
+	return c.TokenEndpointClientAuthStrategy
 }
 
 func (c *Config) GetIntrospectionEndpointClientAuthStrategy(ctx context.Context) (strategy EndpointClientAuthStrategy) {
-	return &IntrospectionEndpointClientAuthStrategy{}
+	if c.IntrospectionEndpointClientAuthStrategy == nil {
+		c.IntrospectionEndpointClientAuthStrategy = &IntrospectionEndpointClientAuthStrategy{}
+	}
+
+	return c.IntrospectionEndpointClientAuthStrategy
 }
 
 func (c *Config) GetRevocationEndpointClientAuthStrategy(ctx context.Context) (strategy EndpointClientAuthStrategy) {
-	return &RevocationEndpointClientAuthStrategy{}
+	if c.RevocationEndpointClientAuthStrategy == nil {
+		c.RevocationEndpointClientAuthStrategy = &RevocationEndpointClientAuthStrategy{}
+	}
+
+	return c.RevocationEndpointClientAuthStrategy
 }
 
 var (

--- a/fosite.go
+++ b/fosite.go
@@ -202,6 +202,9 @@ type Configurator interface {
 	AuthorizeErrorFieldResponseStrategyProvider
 	UseLegacyErrorFormatProvider
 	ResourceStrategyProvider
+	TokenEndpointClientAuthStrategyProvider
+	RevocationEndpointClientAuthStrategyProvider
+	IntrospectionEndpointClientAuthStrategyProvider
 }
 
 // New returns a Fosite Provider backed by the given Storage and Configurator. For most consumers the compose package

--- a/handler/rfc8693/session.go
+++ b/handler/rfc8693/session.go
@@ -10,21 +10,30 @@ import (
 	"authelia.com/provider/oauth2/token/jwt"
 )
 
-// Session is required to support token exchange
+// Session is implemented by sessions that support RFC 8693 OAuth 2.0 Token Exchange. It exposes the subject and actor
+// tokens involved in the exchange and the claims derived from them.
 type Session interface {
 	// SetSubject sets the session's subject.
 	SetSubject(subject string)
 
+	// SetActorToken stores the claims of the actor token, i.e. the token representing the party acting on behalf of
+	// the subject in a delegation flow.
 	SetActorToken(token map[string]any)
 
+	// GetActorToken returns the previously stored actor token claims, or nil if none were set.
 	GetActorToken() map[string]any
 
+	// SetSubjectToken stores the claims of the subject token, i.e. the token representing the party on whose behalf
+	// the request is being made.
 	SetSubjectToken(token map[string]any)
 
+	// GetSubjectToken returns the previously stored subject token claims, or nil if none were set.
 	GetSubjectToken() map[string]any
 
+	// SetClaimActor records the RFC 8693 §4.1 'act' claim describing the actor in a delegation flow.
 	SetClaimActor(act map[string]any)
 
+	// AccessTokenClaimsMap returns the claims to include in the exchanged access token.
 	AccessTokenClaimsMap() map[string]any
 }
 

--- a/introspect.go
+++ b/introspect.go
@@ -29,6 +29,7 @@ func AccessTokenFromRequest(r *http.Request) string {
 
 	auth := r.Header.Get(consts.HeaderAuthorization)
 	split := strings.SplitN(auth, " ", 2)
+
 	if len(split) != 2 || !strings.EqualFold(split[0], BearerAccessToken) {
 		// Nothing in Authorization header, try access_token
 		// Empty string returned if there's no such parameter

--- a/introspection_request_handler.go
+++ b/introspection_request_handler.go
@@ -152,7 +152,7 @@ func (f *Fosite) handleNewIntrospectionRequestClientAuthentication(ctx context.C
 		}
 
 		client = ar.GetClient()
-	} else if client, _, err = f.AuthenticateClientWithAuthHandler(ctx, r, r.PostForm, &IntrospectionEndpointClientAuthHandler{}); err != nil {
+	} else if client, _, err = f.AuthenticateClientWithAuthHandler(ctx, r, r.PostForm, f.Config.GetIntrospectionEndpointClientAuthStrategy(ctx)); err != nil {
 		return nil, errorsx.WithStack(ErrRequestUnauthorized.WithHint("The request either did not include a known client authentication method, or contained invalid authentication details.").WithWrap(err).WithDebugError(err))
 	}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,7 +136,6 @@ packages:
 
   license-checker@25.0.1:
     resolution: {integrity: sha512-mET5AIwl7MR2IAKYYoVBBpV0OnkKQ1xGj2IMMeEFIs42QAkEVjRtFZGWmQ28WeU7MP779iAgOaOy93Mn44mn6g==}
-    hasBin: true
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -146,14 +145,12 @@ packages:
 
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
-    hasBin: true
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   nopt@4.0.3:
     resolution: {integrity: sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==}
-    hasBin: true
 
   normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
@@ -198,7 +195,6 @@ packages:
   prettier@3.9.4:
     resolution: {integrity: sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==}
     engines: {node: '>=14'}
-    hasBin: true
 
   read-installed@4.0.3:
     resolution: {integrity: sha512-O03wg/IYuV/VtnK2h/KXEt9VIbMUFbk3ERG0Iu4FhLZw0EP0T9znqrYDGn6ncbEsXUFaUjiVAWXHzxwt3lhRPQ==}
@@ -215,16 +211,13 @@ packages:
   resolve@1.22.10:
     resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
     engines: {node: '>= 0.4'}
-    hasBin: true
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
-    hasBin: true
 
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
-    hasBin: true
 
   slide@1.1.6:
     resolution: {integrity: sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==}
@@ -235,7 +228,6 @@ packages:
   sort-package-json@3.6.0:
     resolution: {integrity: sha512-fyJsPLhWvY7u2KsKPZn1PixbXp+1m7V8NWqU8CvgFRbMEX41Ffw1kD8n0CfJiGoaSfoAvbrqRRl/DcHO8omQOQ==}
     engines: {node: '>=20'}
-    hasBin: true
 
   spdx-compare@1.0.0:
     resolution: {integrity: sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==}

--- a/revoke_handler.go
+++ b/revoke_handler.go
@@ -43,7 +43,7 @@ func (f *Fosite) NewRevocationRequest(ctx context.Context, r *http.Request) erro
 		return errorsx.WithStack(ErrInvalidRequest.WithHint("The POST body can not be empty."))
 	}
 
-	client, _, err := f.AuthenticateClientWithAuthHandler(ctx, r, r.PostForm, &RevocationEndpointClientAuthHandler{})
+	client, _, err := f.AuthenticateClientWithAuthHandler(ctx, r, r.PostForm, f.Config.GetRevocationEndpointClientAuthStrategy(ctx))
 	if err != nil {
 		return err
 	}

--- a/session.go
+++ b/session.go
@@ -33,14 +33,22 @@ type Session interface {
 	Clone() Session
 }
 
-// DefaultSession is a default implementation of the session interface.
+// DefaultSession is a default implementation of the Session interface.
 type DefaultSession struct {
+	// ExpiresAt maps each token type to its expiration time.
 	ExpiresAt map[TokenType]time.Time `json:"expires_at"`
-	Username  string                  `json:"username"`
-	Subject   string                  `json:"subject"`
-	Extra     map[string]any          `json:"extra"`
+
+	// Username is the subject's username. It is optional and only used during token introspection.
+	Username string `json:"username"`
+
+	// Subject is the subject's identifier. It is optional and only used during token introspection.
+	Subject string `json:"subject"`
+
+	// Extra holds arbitrary additional claims associated with the session.
+	Extra map[string]any `json:"extra"`
 }
 
+// SetExpiresAt sets the expiration time of the token identified by key.
 func (s *DefaultSession) SetExpiresAt(key TokenType, exp time.Time) {
 	if s.ExpiresAt == nil {
 		s.ExpiresAt = make(map[TokenType]time.Time)
@@ -48,6 +56,7 @@ func (s *DefaultSession) SetExpiresAt(key TokenType, exp time.Time) {
 	s.ExpiresAt[key] = exp
 }
 
+// GetExpiresAt returns the expiration time of the token identified by key, or the zero time if it is not set.
 func (s *DefaultSession) GetExpiresAt(key TokenType) time.Time {
 	if s.ExpiresAt == nil {
 		s.ExpiresAt = make(map[TokenType]time.Time)
@@ -56,6 +65,7 @@ func (s *DefaultSession) GetExpiresAt(key TokenType) time.Time {
 	return s.ExpiresAt[key]
 }
 
+// GetUsername returns the username, or an empty string if it is not set.
 func (s *DefaultSession) GetUsername() string {
 	if s == nil {
 		return ""
@@ -63,10 +73,12 @@ func (s *DefaultSession) GetUsername() string {
 	return s.Username
 }
 
+// SetSubject sets the subject's identifier.
 func (s *DefaultSession) SetSubject(subject string) {
 	s.Subject = subject
 }
 
+// GetSubject returns the subject, or an empty string if it is not set.
 func (s *DefaultSession) GetSubject() string {
 	if s == nil {
 		return ""
@@ -75,6 +87,7 @@ func (s *DefaultSession) GetSubject() string {
 	return s.Subject
 }
 
+// Clone returns a deep copy of the session, or nil if the receiver is nil.
 func (s *DefaultSession) Clone() Session {
 	if s == nil {
 		return nil


### PR DESCRIPTION
This allows changing of the client authentication strategy depending on the endpoint being used. While the strategy selected should be sufficient for most implementers there are situations where an implementer may want to adjust these.