### PR TITLE
feat(rfc9449): include additional spec details

### DIFF
--- a/access_write.go
+++ b/access_write.go
@@ -37,8 +37,15 @@ func (f *Fosite) WriteAccessResponse(ctx context.Context, rw http.ResponseWriter
 	_, _ = rw.Write(data)
 }
 
+// writeDPoPNonceOnSuccess supplies the client with a fresh nonce to carry into its next DPoP proof, sparing it the
+// 'use_dpop_nonce' round trip it would otherwise need to obtain one.
+//
+// That is only of use when nonces are required. Issuing one otherwise persists a record per token issued, each held
+// for the nonce lifespan, which no proof will ever be checked against because ValidateDPoPProof only inspects the
+// 'nonce' claim when a nonce is required. It also keeps the server's behaviour aligned with RFC 9449 Section 4.3 step
+// 10, which conditions validating the claim on the server having provided a nonce in the first place.
 func (f *Fosite) writeDPoPNonceOnSuccess(ctx context.Context, rw http.ResponseWriter, request AccessRequester) {
-	if !f.Config.GetDPoPEnabled(ctx) {
+	if !f.Config.GetDPoPEnabled(ctx) || !f.Config.GetDPoPNonceRequired(ctx) {
 		return
 	}
 

--- a/access_write_test.go
+++ b/access_write_test.go
@@ -141,7 +141,7 @@ func TestWriteAccessResponseRotatesDPoPNonce(t *testing.T) {
 	store := storage.NewMemoryStore()
 	strategy := rfc9449.NewDefaultStrategy(&Config{DPoPEnabled: true}, store)
 
-	provider := &Fosite{Config: &Config{DPoPEnabled: true, DPoPStrategy: strategy}}
+	provider := &Fosite{Config: &Config{DPoPEnabled: true, DPoPNonceRequired: true, DPoPStrategy: strategy}}
 
 	session := &DefaultSession{}
 	session.SetDPoPJWKThumbprint("some-thumbprint")
@@ -165,7 +165,7 @@ func TestWriteAccessResponseDoesNotRotateDPoPNonceWhenSessionNotBound(t *testing
 	store := storage.NewMemoryStore()
 	strategy := rfc9449.NewDefaultStrategy(&Config{DPoPEnabled: true}, store)
 
-	provider := &Fosite{Config: &Config{DPoPEnabled: true, DPoPStrategy: strategy}}
+	provider := &Fosite{Config: &Config{DPoPEnabled: true, DPoPNonceRequired: true, DPoPStrategy: strategy}}
 
 	requester := mock.NewMockAccessRequester(ctrl)
 	requester.EXPECT().GetSession().AnyTimes().Return(&DefaultSession{})
@@ -186,7 +186,7 @@ func TestWriteAccessResponseDoesNotRotateDPoPNonceWhenDisabled(t *testing.T) {
 	store := storage.NewMemoryStore()
 	strategy := rfc9449.NewDefaultStrategy(&Config{DPoPEnabled: true}, store)
 
-	provider := &Fosite{Config: &Config{DPoPEnabled: false, DPoPStrategy: strategy}}
+	provider := &Fosite{Config: &Config{DPoPEnabled: false, DPoPNonceRequired: true, DPoPStrategy: strategy}}
 
 	session := &DefaultSession{}
 	session.SetDPoPJWKThumbprint("some-thumbprint")
@@ -201,4 +201,29 @@ func TestWriteAccessResponseDoesNotRotateDPoPNonceWhenDisabled(t *testing.T) {
 	provider.WriteAccessResponse(t.Context(), rw, requester, responder)
 
 	assert.Empty(t, rw.Header().Get(consts.HeaderDPoPNonce))
+}
+
+func TestWriteAccessResponseDoesNotRotateDPoPNonceWhenNotRequired(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	store := storage.NewMemoryStore()
+	strategy := rfc9449.NewDefaultStrategy(&Config{DPoPEnabled: true}, store)
+
+	provider := &Fosite{Config: &Config{DPoPEnabled: true, DPoPNonceRequired: false, DPoPStrategy: strategy}}
+
+	session := &DefaultSession{}
+	session.SetDPoPJWKThumbprint("some-thumbprint")
+
+	requester := mock.NewMockAccessRequester(ctrl)
+	requester.EXPECT().GetSession().AnyTimes().Return(session)
+
+	responder := mock.NewMockAccessResponder(ctrl)
+	responder.EXPECT().ToMap().Return(map[string]any{})
+
+	rw := httptest.NewRecorder()
+	provider.WriteAccessResponse(t.Context(), rw, requester, responder)
+
+	assert.Empty(t, rw.Header().Get(consts.HeaderDPoPNonce))
+	assert.Empty(t, store.DPoPNonces, "a nonce was persisted for a client that will never be asked for one")
 }

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -84,6 +84,8 @@ func ComposeAllEnabled(config *oauth2.Config, storage any, key any) oauth2.Provi
 			OpenIDConnectTokenStrategy: NewOpenIDConnectStrategy(keyGetter, strategy, config),
 			Strategy:                   strategy,
 		},
+		DPoPAuthorizeFactory,
+
 		OAuth2AuthorizeExplicitFactory,
 		OAuth2AuthorizeImplicitFactory,
 		OAuth2AuthorizeNoneFactory,

--- a/compose/compose_rfc9449.go
+++ b/compose/compose_rfc9449.go
@@ -9,7 +9,23 @@ import (
 	"authelia.com/provider/oauth2/handler/rfc9449"
 )
 
-// DPoPFactory creates the RFC 9449 DPoP handler and, when necessary, the default DPoP strategy.
+// DPoPAuthorizeFactory creates the RFC 9449 DPoP authorize endpoint handler, which records the 'dpop_jkt' parameter on
+// the session.
+//
+// It MUST be ordered ahead of every factory whose handler issues an authorization code, because those handlers persist
+// the session as they run and would otherwise store it without the binding. DPoPFactory carries the opposite
+// constraint and must be ordered last, so the two are deliberately separate factories.
+func DPoPAuthorizeFactory(config oauth2.Configurator, storage any, strategy any) any {
+	return &rfc9449.AuthorizeHandler{
+		Config: config.(*oauth2.Config),
+	}
+}
+
+// DPoPFactory creates the RFC 9449 DPoP token endpoint handler and, when necessary, the default DPoP strategy.
+//
+// It MUST be ordered after every factory whose handler restores a session at the token endpoint, so that the binding
+// recorded by DPoPAuthorizeFactory's handler is present on the session by the time the proof is checked against it,
+// and so that the DPoP token type is not overwritten by the grant handler that populates the response.
 func DPoPFactory(config oauth2.Configurator, storage any, strategy any) any {
 	c := config.(*oauth2.Config)
 

--- a/compose/compose_rfc9449_par_test.go
+++ b/compose/compose_rfc9449_par_test.go
@@ -1,0 +1,338 @@
+// SPDX-FileCopyrightText: 2026 Authelia
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package compose
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"authelia.com/provider/oauth2"
+	"authelia.com/provider/oauth2/internal/consts"
+	"authelia.com/provider/oauth2/storage"
+	"authelia.com/provider/oauth2/token/jwt"
+)
+
+const (
+	parEndpoint    = "https://as.example.com/par"
+	parRedirectURI = "https://rp.example.com/cb"
+	parClientID    = "par-client"
+	parSecret      = "par-client-secret"
+)
+
+func newPARProvider(t *testing.T, nonceRequired bool) (oauth2.Provider, *storage.MemoryStore, *oauth2.Config) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	store := storage.NewMemoryStore()
+
+	config := &oauth2.Config{
+		DPoPEnabled:       true,
+		DPoPNonceRequired: nonceRequired,
+		GlobalSecret:      []byte("some-cool-secret-that-is-32bytes"),
+	}
+
+	provider := ComposeAllEnabled(config, store, key)
+
+	store.Clients[parClientID] = &oauth2.DefaultClient{
+		ID:            parClientID,
+		ClientSecret:  oauth2.NewPlainTextClientSecret(parSecret),
+		RedirectURIs:  []string{parRedirectURI},
+		ResponseTypes: []string{consts.ResponseTypeAuthorizationCodeFlow},
+		GrantTypes:    []string{consts.GrantTypeAuthorizationCode},
+		Scopes:        []string{"foo"},
+	}
+
+	return provider, store, config
+}
+
+func newPARProofKey(t *testing.T) *jose.JSONWebKey {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	return &jose.JSONWebKey{Key: key, Algorithm: string(jose.ES256)}
+}
+
+func signPARProof(t *testing.T, key *jose.JSONWebKey, jti, htu string, claims map[string]any) string {
+	t.Helper()
+
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.SignatureAlgorithm(key.Algorithm), Key: key},
+		(&jose.SignerOptions{EmbedJWK: true}).WithType(jose.ContentType(jwt.JSONWebTokenTypeDPoP)),
+	)
+	require.NoError(t, err)
+
+	all := map[string]any{
+		consts.ClaimJWTID:      jti,
+		consts.ClaimHTTPMethod: http.MethodPost,
+		consts.ClaimHTTPURI:    htu,
+		consts.ClaimIssuedAt:   time.Now().Unix(),
+	}
+
+	maps.Copy(all, claims)
+
+	raw, err := josejwt.Signed(signer).Claims(all).Serialize()
+	require.NoError(t, err)
+
+	return raw
+}
+
+func thumbprintOf(t *testing.T, key *jose.JSONWebKey) string {
+	t.Helper()
+
+	pub := key.Public()
+
+	jkt, err := jwt.ThumbprintJWK(&pub)
+	require.NoError(t, err)
+
+	return jkt
+}
+
+func newPARRequest(form url.Values, proofs ...string) *http.Request {
+	form.Set(consts.FormParameterClientID, parClientID)
+	form.Set(consts.FormParameterClientSecret, parSecret)
+
+	r := httptest.NewRequest(http.MethodPost, parEndpoint, strings.NewReader(form.Encode()))
+	r.Header.Set(consts.HeaderContentType, consts.ContentTypeApplicationURLEncodedForm)
+
+	for _, proof := range proofs {
+		r.Header.Add(consts.HeaderDPoP, proof)
+	}
+
+	return r
+}
+
+func defaultPARForm() url.Values {
+	return url.Values{
+		consts.FormParameterResponseType: []string{consts.ResponseTypeAuthorizationCodeFlow},
+		consts.FormParameterRedirectURI:  []string{parRedirectURI},
+		consts.FormParameterScope:        []string{"foo"},
+		consts.FormParameterState:        []string{"abcdefghijklmnop"},
+	}
+}
+
+func TestPARDPoPProofIsTreatedAsDPoPJKT(t *testing.T) {
+	provider, store, _ := newPARProvider(t, false)
+
+	key := newPARProofKey(t)
+	jkt := thumbprintOf(t, key)
+
+	r := newPARRequest(defaultPARForm(), signPARProof(t, key, "par-1", parEndpoint, nil))
+
+	ctx := context.Background()
+
+	requester, err := provider.NewPushedAuthorizeRequest(ctx, r)
+	require.NoError(t, err)
+
+	assert.Equal(t, jkt, requester.GetRequestForm().Get(consts.FormParameterDPoPJKT),
+		"the proof thumbprint was not recorded as 'dpop_jkt' on the pushed request")
+
+	responder, err := provider.NewPushedAuthorizeResponse(ctx, requester, &oauth2.DefaultSession{Subject: "peter"})
+	require.NoError(t, err)
+
+	requestURI := responder.GetRequestURI()
+	require.NotEmpty(t, requestURI)
+
+	authForm := url.Values{
+		consts.FormParameterClientID:   []string{parClientID},
+		consts.FormParameterRequestURI: []string{requestURI},
+	}
+
+	ar := httptest.NewRequest(http.MethodGet, "https://as.example.com/authorize?"+authForm.Encode(), nil)
+
+	authRequester, err := provider.NewAuthorizeRequest(ctx, ar)
+	require.NoError(t, err)
+
+	assert.Equal(t, jkt, authRequester.GetRequestForm().Get(consts.FormParameterDPoPJKT),
+		"the binding did not survive the pushed authorization request round trip")
+
+	session := &oauth2.DefaultSession{Subject: "peter"}
+
+	_, err = provider.NewAuthorizeResponse(ctx, authRequester, session)
+	require.NoError(t, err)
+
+	assert.Equal(t, jkt, session.GetDPoPJWKThumbprint())
+
+	require.Len(t, store.AuthorizeCodes, 1)
+
+	for _, code := range store.AuthorizeCodes {
+		bound, ok := code.Requester.GetSession().(oauth2.DPoPBoundSession)
+		require.True(t, ok)
+		assert.Equal(t, jkt, bound.GetDPoPJWKThumbprint())
+	}
+}
+
+func TestPARDPoPProofAndDPoPJKT(t *testing.T) {
+	t.Run("ShouldAcceptMatching", func(t *testing.T) {
+		provider, _, _ := newPARProvider(t, false)
+
+		key := newPARProofKey(t)
+		jkt := thumbprintOf(t, key)
+
+		form := defaultPARForm()
+		form.Set(consts.FormParameterDPoPJKT, jkt)
+
+		r := newPARRequest(form, signPARProof(t, key, "par-match", parEndpoint, nil))
+
+		requester, err := provider.NewPushedAuthorizeRequest(context.Background(), r)
+		require.NoError(t, err)
+
+		assert.Equal(t, jkt, requester.GetRequestForm().Get(consts.FormParameterDPoPJKT))
+	})
+
+	t.Run("ShouldRejectMismatched", func(t *testing.T) {
+		provider, _, _ := newPARProvider(t, false)
+
+		key := newPARProofKey(t)
+
+		form := defaultPARForm()
+		form.Set(consts.FormParameterDPoPJKT, thumbprintOf(t, newPARProofKey(t)))
+
+		r := newPARRequest(form, signPARProof(t, key, "par-mismatch", parEndpoint, nil))
+
+		_, err := provider.NewPushedAuthorizeRequest(context.Background(), r)
+		require.Error(t, err)
+
+		rfc := oauth2.ErrorToRFC6749Error(err)
+
+		assert.Equal(t, "invalid_request", rfc.ErrorField)
+		assert.Contains(t, rfc.HintField, "'dpop_jkt' parameter does not match the thumbprint")
+	})
+}
+
+func TestPARDPoPProofRejections(t *testing.T) {
+	testCases := []struct {
+		name   string
+		proofs func(t *testing.T, key *jose.JSONWebKey) []string
+		err    string
+		hint   string
+	}{
+		{
+			name: "ShouldRejectMultipleProofs",
+			proofs: func(t *testing.T, key *jose.JSONWebKey) []string {
+				proof := signPARProof(t, key, "par-multi", parEndpoint, nil)
+
+				return []string{proof, proof}
+			},
+			err:  "invalid_dpop_proof",
+			hint: "more than one DPoP proof",
+		},
+		{
+			name: "ShouldRejectProofBoundToAnotherEndpoint",
+			proofs: func(t *testing.T, key *jose.JSONWebKey) []string {
+				return []string{signPARProof(t, key, "par-htu", "https://as.example.com/token", nil)}
+			},
+			err:  "invalid_dpop_proof",
+			hint: "'htu' claim",
+		},
+		{
+			name: "ShouldRejectMalformedProof",
+			proofs: func(t *testing.T, key *jose.JSONWebKey) []string {
+				return []string{"not-a-jwt"}
+			},
+			err:  "invalid_dpop_proof",
+			hint: "could not be parsed",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			provider, _, _ := newPARProvider(t, false)
+
+			r := newPARRequest(defaultPARForm(), tc.proofs(t, newPARProofKey(t))...)
+
+			_, err := provider.NewPushedAuthorizeRequest(context.Background(), r)
+			require.Error(t, err)
+
+			rfc := oauth2.ErrorToRFC6749Error(err)
+
+			assert.Equal(t, tc.err, rfc.ErrorField)
+			assert.Contains(t, rfc.HintField, tc.hint)
+		})
+	}
+}
+
+func TestPARWithoutDPoPProofIsUnaffected(t *testing.T) {
+	t.Run("ShouldPassThroughBareDPoPJKT", func(t *testing.T) {
+		provider, _, _ := newPARProvider(t, false)
+
+		form := defaultPARForm()
+		form.Set(consts.FormParameterDPoPJKT, "kM1FTfCFVzO9tGKBVBEAWCVoWZ2WcOK1EbSPxNjQfSw")
+
+		requester, err := provider.NewPushedAuthorizeRequest(context.Background(), newPARRequest(form))
+		require.NoError(t, err)
+
+		assert.Equal(t, "kM1FTfCFVzO9tGKBVBEAWCVoWZ2WcOK1EbSPxNjQfSw", requester.GetRequestForm().Get(consts.FormParameterDPoPJKT))
+	})
+
+	t.Run("ShouldRejectMalformedBareDPoPJKT", func(t *testing.T) {
+		provider, _, _ := newPARProvider(t, false)
+
+		form := defaultPARForm()
+		form.Set(consts.FormParameterDPoPJKT, "not-a-thumbprint")
+
+		_, err := provider.NewPushedAuthorizeRequest(context.Background(), newPARRequest(form))
+		require.Error(t, err)
+
+		rfc := oauth2.ErrorToRFC6749Error(err)
+
+		assert.Equal(t, "invalid_request", rfc.ErrorField)
+		assert.Contains(t, rfc.HintField, "'dpop_jkt' parameter must be the base64url encoded SHA-256 JWK Thumbprint")
+	})
+
+	t.Run("ShouldAcceptNoDPoPAtAll", func(t *testing.T) {
+		provider, _, _ := newPARProvider(t, false)
+
+		requester, err := provider.NewPushedAuthorizeRequest(context.Background(), newPARRequest(defaultPARForm()))
+		require.NoError(t, err)
+
+		assert.Empty(t, requester.GetRequestForm().Get(consts.FormParameterDPoPJKT))
+	})
+}
+
+func TestPARDPoPNonceChallenge(t *testing.T) {
+	provider, _, config := newPARProvider(t, true)
+
+	key := newPARProofKey(t)
+
+	ctx := context.Background()
+
+	_, err := provider.NewPushedAuthorizeRequest(ctx, newPARRequest(defaultPARForm(), signPARProof(t, key, "par-nonce-1", parEndpoint, nil)))
+	require.Error(t, err)
+
+	assert.Equal(t, "use_dpop_nonce", oauth2.ErrorToRFC6749Error(err).ErrorField)
+
+	rw := httptest.NewRecorder()
+	provider.WritePushedAuthorizeError(ctx, rw, nil, err)
+
+	nonce := rw.Header().Get(consts.HeaderDPoPNonce)
+	require.NotEmpty(t, nonce, "the PAR error response carried no DPoP-Nonce challenge")
+
+	require.NotNil(t, config.GetDPoPStrategy(ctx))
+
+	requester, err := provider.NewPushedAuthorizeRequest(ctx, newPARRequest(defaultPARForm(),
+		signPARProof(t, key, "par-nonce-2", parEndpoint, map[string]any{consts.ClaimNonce: nonce})))
+	require.NoError(t, err)
+
+	assert.Equal(t, thumbprintOf(t, key), requester.GetRequestForm().Get(consts.FormParameterDPoPJKT))
+}

--- a/compose/compose_rfc9449_refresh_test.go
+++ b/compose/compose_rfc9449_refresh_test.go
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: 2026 Authelia
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package compose
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"authelia.com/provider/oauth2"
+	"authelia.com/provider/oauth2/internal/consts"
+	"authelia.com/provider/oauth2/storage"
+)
+
+const (
+	rtTokenEndpoint = "https://as.example.com/token"
+	rtClientID      = "refresh-client"
+	rtSecret        = "refresh-client-secret"
+	rtRedirectURI   = "https://rp.example.com/cb"
+)
+
+func newRefreshProvider(t *testing.T) (oauth2.Provider, *storage.MemoryStore) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	store := storage.NewMemoryStore()
+	config := &oauth2.Config{DPoPEnabled: true, GlobalSecret: []byte("some-cool-secret-that-is-32bytes")}
+
+	provider := ComposeAllEnabled(config, store, key)
+
+	store.Clients[rtClientID] = &oauth2.DefaultClient{
+		ID:            rtClientID,
+		ClientSecret:  oauth2.NewPlainTextClientSecret(rtSecret),
+		RedirectURIs:  []string{rtRedirectURI},
+		ResponseTypes: []string{consts.ResponseTypeAuthorizationCodeFlow},
+		GrantTypes:    []string{consts.GrantTypeAuthorizationCode, consts.GrantTypeRefreshToken},
+		Scopes:        []string{consts.ScopeOffline},
+	}
+
+	return provider, store
+}
+
+func tokenRequest(t *testing.T, provider oauth2.Provider, form url.Values, proof string) (oauth2.AccessResponder, error) {
+	t.Helper()
+
+	form.Set(consts.FormParameterClientID, rtClientID)
+	form.Set(consts.FormParameterClientSecret, rtSecret)
+
+	r := httptest.NewRequest(http.MethodPost, rtTokenEndpoint, strings.NewReader(form.Encode()))
+	r.Header.Set(consts.HeaderContentType, consts.ContentTypeApplicationURLEncodedForm)
+
+	if proof != "" {
+		r.Header.Set(consts.HeaderDPoP, proof)
+	}
+
+	requester, err := provider.NewAccessRequest(context.Background(), r, &oauth2.DefaultSession{})
+	if err != nil {
+		return nil, err
+	}
+
+	return provider.NewAccessResponse(context.Background(), requester)
+}
+
+func TestDPoPIsEnforcedOnRefreshTokenRequests(t *testing.T) {
+	provider, _ := newRefreshProvider(t)
+
+	key := newPARProofKey(t)
+	jkt := thumbprintOf(t, key)
+
+	code := authorizeForCode(t, provider, jkt)
+
+	response, err := tokenRequest(t, provider, url.Values{
+		consts.FormParameterGrantType:         []string{consts.GrantTypeAuthorizationCode},
+		consts.FormParameterAuthorizationCode: []string{code},
+		consts.FormParameterRedirectURI:       []string{rtRedirectURI},
+	}, signPARProof(t, key, "rt-1", rtTokenEndpoint, nil))
+	require.NoError(t, err)
+
+	assert.Equal(t, oauth2.DPoPAccessToken, response.GetTokenType(), "the issued access token was not of type DPoP")
+
+	refreshToken, _ := response.ToMap()[consts.AccessResponseRefreshToken].(string)
+	require.NotEmpty(t, refreshToken, "no refresh token was issued")
+
+	t.Run("ShouldRejectRefreshWithoutAProof", func(t *testing.T) {
+		_, err := tokenRequest(t, provider, url.Values{
+			consts.FormParameterGrantType:    []string{consts.GrantTypeRefreshToken},
+			consts.FormParameterRefreshToken: []string{refreshToken},
+		}, "")
+
+		require.Error(t, err)
+		assert.Equal(t, "invalid_dpop_proof", oauth2.ErrorToRFC6749Error(err).ErrorField)
+	})
+
+	t.Run("ShouldRejectRefreshWithAnotherKey", func(t *testing.T) {
+		_, err := tokenRequest(t, provider, url.Values{
+			consts.FormParameterGrantType:    []string{consts.GrantTypeRefreshToken},
+			consts.FormParameterRefreshToken: []string{refreshToken},
+		}, signPARProof(t, newPARProofKey(t), "rt-other", rtTokenEndpoint, nil))
+
+		require.Error(t, err)
+		assert.Equal(t, "invalid_dpop_proof", oauth2.ErrorToRFC6749Error(err).ErrorField)
+	})
+
+	t.Run("ShouldAcceptRefreshWithTheBoundKeyAndStayBound", func(t *testing.T) {
+		response, err := tokenRequest(t, provider, url.Values{
+			consts.FormParameterGrantType:    []string{consts.GrantTypeRefreshToken},
+			consts.FormParameterRefreshToken: []string{refreshToken},
+		}, signPARProof(t, key, "rt-2", rtTokenEndpoint, nil))
+
+		require.NoError(t, err)
+
+		assert.Equal(t, oauth2.DPoPAccessToken, response.GetTokenType())
+
+		rotated, _ := response.ToMap()[consts.AccessResponseRefreshToken].(string)
+		require.NotEmpty(t, rotated)
+
+		_, err = tokenRequest(t, provider, url.Values{
+			consts.FormParameterGrantType:    []string{consts.GrantTypeRefreshToken},
+			consts.FormParameterRefreshToken: []string{rotated},
+		}, "")
+
+		require.Error(t, err)
+		assert.Equal(t, "invalid_dpop_proof", oauth2.ErrorToRFC6749Error(err).ErrorField)
+	})
+}
+
+func authorizeForCode(t *testing.T, provider oauth2.Provider, jkt string) string {
+	t.Helper()
+
+	form := url.Values{
+		consts.FormParameterClientID:     []string{rtClientID},
+		consts.FormParameterResponseType: []string{consts.ResponseTypeAuthorizationCodeFlow},
+		consts.FormParameterRedirectURI:  []string{rtRedirectURI},
+		consts.FormParameterScope:        []string{consts.ScopeOffline},
+		consts.FormParameterState:        []string{"abcdefghijklmnop"},
+		consts.FormParameterDPoPJKT:      []string{jkt},
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "https://as.example.com/authorize?"+form.Encode(), nil)
+
+	requester, err := provider.NewAuthorizeRequest(context.Background(), r)
+	require.NoError(t, err)
+
+	requester.GrantScope(consts.ScopeOffline)
+
+	responder, err := provider.NewAuthorizeResponse(context.Background(), requester, &oauth2.DefaultSession{Subject: "peter"})
+	require.NoError(t, err)
+
+	code := responder.GetParameters().Get(consts.FormParameterAuthorizationCode)
+	require.NotEmpty(t, code)
+
+	return code
+}
+
+func TestTokenEndpointDPoPNonceRoundTrip(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	store := storage.NewMemoryStore()
+	config := &oauth2.Config{DPoPEnabled: true, DPoPNonceRequired: true, GlobalSecret: []byte("some-cool-secret-that-is-32bytes")}
+
+	provider := ComposeAllEnabled(config, store, key)
+
+	store.Clients[rtClientID] = &oauth2.DefaultClient{
+		ID:            rtClientID,
+		ClientSecret:  oauth2.NewPlainTextClientSecret(rtSecret),
+		RedirectURIs:  []string{rtRedirectURI},
+		ResponseTypes: []string{consts.ResponseTypeAuthorizationCodeFlow},
+		GrantTypes:    []string{consts.GrantTypeAuthorizationCode, consts.GrantTypeRefreshToken},
+		Scopes:        []string{consts.ScopeOffline},
+	}
+
+	proofKey := newPARProofKey(t)
+	code := authorizeForCode(t, provider, thumbprintOf(t, proofKey))
+
+	ctx := context.Background()
+
+	form := func() url.Values {
+		return url.Values{
+			consts.FormParameterGrantType:         []string{consts.GrantTypeAuthorizationCode},
+			consts.FormParameterAuthorizationCode: []string{code},
+			consts.FormParameterRedirectURI:       []string{rtRedirectURI},
+		}
+	}
+
+	_, err = tokenRequest(t, provider, form(), signPARProof(t, proofKey, "nonce-1", rtTokenEndpoint, nil))
+	require.Error(t, err)
+
+	assert.Equal(t, "use_dpop_nonce", oauth2.ErrorToRFC6749Error(err).ErrorField)
+
+	rw := httptest.NewRecorder()
+	provider.WriteAccessError(ctx, rw, nil, err)
+
+	nonce := rw.Header().Get(consts.HeaderDPoPNonce)
+	require.NotEmpty(t, nonce, "the challenge carried no DPoP-Nonce for the client to retry with")
+
+	response, err := tokenRequest(t, provider, form(),
+		signPARProof(t, proofKey, "nonce-2", rtTokenEndpoint, map[string]any{consts.ClaimNonce: nonce}))
+	require.NoError(t, err)
+
+	assert.Equal(t, oauth2.DPoPAccessToken, response.GetTokenType())
+
+	rw = httptest.NewRecorder()
+
+	requester := oauth2.NewAccessRequest(&oauth2.DefaultSession{})
+	requester.Session.(*oauth2.DefaultSession).SetDPoPJWKThumbprint(thumbprintOf(t, proofKey))
+
+	provider.WriteAccessResponse(ctx, rw, requester, response)
+
+	assert.NotEmpty(t, rw.Header().Get(consts.HeaderDPoPNonce), "no rotated nonce was supplied on success")
+}

--- a/compose/compose_rfc9449_test.go
+++ b/compose/compose_rfc9449_test.go
@@ -5,13 +5,28 @@
 package compose
 
 import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/go-jose/go-jose/v4"
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"authelia.com/provider/oauth2"
+	oauth2handler "authelia.com/provider/oauth2/handler/oauth2"
+	"authelia.com/provider/oauth2/handler/openid"
 	"authelia.com/provider/oauth2/handler/rfc9449"
+	"authelia.com/provider/oauth2/internal/consts"
 	"authelia.com/provider/oauth2/storage"
 )
 
@@ -25,7 +40,47 @@ func TestDPoPFactory(t *testing.T) {
 	assert.NotNil(t, config.DPoPStrategy)
 
 	var _ oauth2.TokenEndpointHandler = h.(*rfc9449.Handler)
-	var _ oauth2.AuthorizeEndpointHandler = h.(*rfc9449.Handler)
+}
+
+func TestDPoPAuthorizeFactory(t *testing.T) {
+	config := &oauth2.Config{DPoPEnabled: true}
+	store := storage.NewMemoryStore()
+
+	h := DPoPAuthorizeFactory(config, store, nil)
+
+	require.IsType(t, &rfc9449.AuthorizeHandler{}, h)
+
+	var _ oauth2.AuthorizeEndpointHandler = h.(*rfc9449.AuthorizeHandler)
+}
+
+func TestDPoPAuthorizeFactoryPrecedesCodeIssuingFactories(t *testing.T) {
+	config := &oauth2.Config{DPoPEnabled: true, GlobalSecret: []byte("some-cool-secret-that-is-32bytes")}
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	ComposeAllEnabled(config, storage.NewMemoryStore(), key)
+
+	handlers := config.GetAuthorizeEndpointHandlers(context.Background())
+
+	var dpop = -1
+
+	for i, h := range handlers {
+		if _, ok := h.(*rfc9449.AuthorizeHandler); ok {
+			dpop = i
+
+			break
+		}
+	}
+
+	require.NotEqual(t, -1, dpop, "the DPoP authorize handler is not registered by ComposeAllEnabled")
+
+	for i, h := range handlers {
+		switch h.(type) {
+		case *oauth2handler.AuthorizeExplicitGrantHandler, *openid.OpenIDConnectExplicitHandler, *openid.OpenIDConnectHybridHandler:
+			assert.Greater(t, i, dpop, "the code issuing handler %T at index %d runs before the DPoP authorize handler at index %d", h, i, dpop)
+		}
+	}
 }
 
 func TestDPoPFactoryPanicsWithoutUsableStrategy(t *testing.T) {
@@ -36,4 +91,109 @@ func TestDPoPFactoryPanicsWithoutUsableStrategy(t *testing.T) {
 	})
 
 	assert.Nil(t, config.DPoPStrategy)
+}
+
+// snapshotStore records the DPoP binding present on the session at the moment the authorization code session is handed
+// to storage. The bundled MemoryStore retains the session pointer, so a mutation made after this point is still
+// observable through it; a store which serializes the session on write, as any real one does, would not see it.
+type snapshotStore struct {
+	*storage.MemoryStore
+
+	jkt       string
+	persisted bool
+}
+
+func (s *snapshotStore) CreateAuthorizeCodeSession(ctx context.Context, code string, req oauth2.Requester) error {
+	s.persisted = true
+
+	if session, ok := req.GetSession().(oauth2.DPoPBoundSession); ok {
+		s.jkt = session.GetDPoPJWKThumbprint()
+	}
+
+	return s.MemoryStore.CreateAuthorizeCodeSession(ctx, code, req)
+}
+
+func TestDPoPJKTIsBoundBeforeTheAuthorizationCodeSessionIsPersisted(t *testing.T) {
+	const jkt = "kM1FTfCFVzO9tGKBVBEAWCVoWZ2WcOK1EbSPxNjQfSw"
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	store := &snapshotStore{MemoryStore: storage.NewMemoryStore()}
+	config := &oauth2.Config{DPoPEnabled: true, GlobalSecret: []byte("some-cool-secret-that-is-32bytes")}
+
+	provider := ComposeAllEnabled(config, store, key)
+
+	client := &oauth2.DefaultClient{
+		ID:            "test-client",
+		RedirectURIs:  []string{"https://rp.example.com/cb"},
+		ResponseTypes: []string{consts.ResponseTypeAuthorizationCodeFlow},
+		GrantTypes:    []string{consts.GrantTypeAuthorizationCode},
+		Scopes:        []string{"foo"},
+	}
+
+	store.Clients[client.ID] = client
+
+	request := oauth2.NewAuthorizeRequest()
+	request.Client = client
+	request.Form = url.Values{
+		consts.FormParameterDPoPJKT:     []string{jkt},
+		consts.FormParameterRedirectURI: []string{"https://rp.example.com/cb"},
+	}
+	request.ResponseTypes = oauth2.Arguments{consts.ResponseTypeAuthorizationCodeFlow}
+	request.RedirectURI, _ = url.Parse("https://rp.example.com/cb")
+	request.State = "abcdefghijklmnop"
+	request.GrantScope("foo")
+
+	session := &oauth2.DefaultSession{Subject: "peter"}
+
+	_, err = provider.NewAuthorizeResponse(context.Background(), request, session)
+	require.NoError(t, err)
+
+	require.True(t, store.persisted, "the authorization code session was never persisted")
+
+	assert.Equal(t, jkt, store.jkt)
+}
+
+func TestUnknownGrantTypeIsNotSatisfiedByTheDPoPHandler(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	store := storage.NewMemoryStore()
+	config := &oauth2.Config{DPoPEnabled: true, GlobalSecret: []byte("some-cool-secret-that-is-32bytes")}
+
+	provider := ComposeAllEnabled(config, store, key)
+
+	proofKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.ES256, Key: &jose.JSONWebKey{Key: proofKey, Algorithm: string(jose.ES256)}},
+		(&jose.SignerOptions{EmbedJWK: true}).WithType(jose.ContentType(consts.JSONWebTokenTypeDPoP)),
+	)
+	require.NoError(t, err)
+
+	proof, err := josejwt.Signed(signer).Claims(map[string]any{
+		consts.ClaimJWTID:      "unknown-grant-poc",
+		consts.ClaimHTTPMethod: http.MethodPost,
+		consts.ClaimHTTPURI:    "https://as.example.com/token",
+		consts.ClaimIssuedAt:   time.Now().Unix(),
+	}).Serialize()
+	require.NoError(t, err)
+
+	form := url.Values{consts.FormParameterGrantType: []string{"urn:example:not-a-real-grant"}}
+
+	r := httptest.NewRequest(http.MethodPost, "https://as.example.com/token", strings.NewReader(form.Encode()))
+	r.Header.Set(consts.HeaderContentType, consts.ContentTypeApplicationURLEncodedForm)
+	r.Header.Set(consts.HeaderDPoP, proof)
+
+	_, err = provider.NewAccessRequest(context.Background(), r, &oauth2.DefaultSession{})
+	require.Error(t, err)
+
+	rfc := oauth2.ErrorToRFC6749Error(err)
+
+	assert.Equal(t, http.StatusBadRequest, rfc.CodeField)
+	assert.Equal(t, "invalid_request", rfc.ErrorField)
+
+	assert.Empty(t, store.DPoPProofJTIs, "an unauthenticated caller wrote a replay marker to the store")
 }

--- a/dpop.go
+++ b/dpop.go
@@ -6,8 +6,64 @@ package oauth2
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"net/http"
 	"time"
+
+	"authelia.com/provider/oauth2/internal/consts"
 )
+
+// DPoPJWKThumbprintLength is the length of a well-formed 'dpop_jkt' value, being the number of characters a 32 byte
+// SHA-256 digest occupies when base64url encoded without padding.
+const DPoPJWKThumbprintLength = 43
+
+// IsValidDPoPJWKThumbprint reports whether jkt is a well-formed RFC 9449 Section 10.1 'dpop_jkt' value, which that
+// section defines as the RFC 7638 JWK Thumbprint of the proof-of-possession public key computed with SHA-256, the same
+// value used for 'jkt' in the 'cnf' claim. Only the encoding can be checked, as the thumbprint of a key the client has
+// not yet presented cannot be recomputed.
+//
+// The client supplies this value directly, so it is validated before being recorded against a grant. An unchecked
+// value is stored verbatim for the lifetime of the authorization code and can be of any length, and while a malformed
+// one only ever fails to match a proof, there is no reason to carry it that far.
+func IsValidDPoPJWKThumbprint(jkt string) bool {
+	if len(jkt) != DPoPJWKThumbprintLength {
+		return false
+	}
+
+	// Decoding covers the base64url alphabet as well as the length, as no other input of this length decodes to a
+	// SHA-256 sized digest.
+	decoded, err := base64.RawURLEncoding.DecodeString(jkt)
+
+	return err == nil && len(decoded) == sha256.Size
+}
+
+// RequestURL reconstructs the RFC 9449 target URI ('htu') from the request, discarding query and fragment. When the
+// request did not arrive over TLS directly it falls back to the X-Forwarded-Proto header to determine the scheme;
+// deployments MUST therefore ensure that header is set (and any client-supplied value stripped) by a trusted edge
+// proxy, otherwise a client could influence the reconstructed htu scheme.
+//
+// The path is taken in its escaped form. The decoded (*url.URL).Path would silently turn a percent-encoded delimiter
+// in the request target into a real one, so a request to '/token%3Fx=1' would reconstruct as '/token?x=1' and compare
+// equal to a proof bound to '/token' once the query is discarded.
+func RequestURL(r *http.Request) string {
+	scheme := consts.SchemeHTTPS
+
+	if r.TLS == nil {
+		if proto := r.Header.Get(consts.HeaderXForwardedProto); proto != "" {
+			scheme = proto
+		} else {
+			scheme = consts.SchemeHTTP
+		}
+	}
+
+	host := r.Host
+	if host == "" {
+		host = r.URL.Host
+	}
+
+	return scheme + "://" + host + r.URL.EscapedPath()
+}
 
 // DPoPProof is the validated result of a RFC 9449 DPoP proof JWT.
 type DPoPProof struct {

--- a/dpop_thumbprint_test.go
+++ b/dpop_thumbprint_test.go
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 Authelia
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package oauth2_test
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "authelia.com/provider/oauth2"
+)
+
+func TestIsValidDPoPJWKThumbprint(t *testing.T) {
+	sum := sha256.Sum256([]byte("some key material"))
+	valid := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	testCases := []struct {
+		name     string
+		have     string
+		expected bool
+	}{
+		{"ShouldAcceptASHA256Thumbprint", valid, true},
+		{"ShouldAcceptAKnownGoodValue", "kM1FTfCFVzO9tGKBVBEAWCVoWZ2WcOK1EbSPxNjQfSw", true},
+		{"ShouldRejectEmpty", "", false},
+		{"ShouldRejectShort", "kM1FTfCFVzO9tGKBVBEAWCVoWZ2WcOK1EbSPxNjQfS", false},
+		{"ShouldRejectLong", "kM1FTfCFVzO9tGKBVBEAWCVoWZ2WcOK1EbSPxNjQfSww", false},
+		{"ShouldRejectOverlong", strings.Repeat("A", 4096), false},
+		{"ShouldRejectStandardBase64Plus", "kM1FTfCFVzO9tGKBVBEAWCVoWZ2WcOK1EbSPxNjQfS+", false},
+		{"ShouldRejectStandardBase64Slash", "kM1FTfCFVzO9tGKBVBEAWCVoWZ2WcOK1EbSPxNjQfS/", false},
+		{"ShouldRejectPadding", "kM1FTfCFVzO9tGKBVBEAWCVoWZ2WcOK1EbSPxNjQfS=", false},
+		{"ShouldRejectNonAlphabet", "kM1FTfCFVzO9tGKBVBEAWCVoWZ2WcOK1EbSPxNjQfS!", false},
+		{"ShouldRejectSHA512Thumbprint", base64.RawURLEncoding.EncodeToString(make([]byte, 64)), false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, IsValidDPoPJWKThumbprint(tc.have))
+		})
+	}
+}
+
+func TestThumbprintJWKProducesAValidDPoPJKT(t *testing.T) {
+	sum := sha256.Sum256([]byte("a key"))
+
+	assert.Len(t, base64.RawURLEncoding.EncodeToString(sum[:]), DPoPJWKThumbprintLength)
+	assert.True(t, IsValidDPoPJWKThumbprint(base64.RawURLEncoding.EncodeToString(sum[:])))
+}

--- a/handler/oauth2/flow_resource_owner_test.go
+++ b/handler/oauth2/flow_resource_owner_test.go
@@ -295,6 +295,8 @@ func (s *nonResourceOwnerSession) GetExpiresAt(key oauth2.TokenType) time.Time {
 	return s.expiresAt[key]
 }
 
-func (s *nonResourceOwnerSession) GetUsername() string   { return "" }
-func (s *nonResourceOwnerSession) GetSubject() string    { return "" }
+func (s *nonResourceOwnerSession) GetUsername() string { return "" }
+
+func (s *nonResourceOwnerSession) GetSubject() string { return "" }
+
 func (s *nonResourceOwnerSession) Clone() oauth2.Session { return &nonResourceOwnerSession{} }

--- a/handler/rfc9449/handler.go
+++ b/handler/rfc9449/handler.go
@@ -9,46 +9,17 @@ import (
 	"net/http"
 
 	"authelia.com/provider/oauth2"
-	"authelia.com/provider/oauth2/internal/consts"
 	"authelia.com/provider/oauth2/x/errorsx"
 )
 
-// Handler implements RFC 9449 DPoP at the token and authorize endpoints.
+// Handler implements RFC 9449 DPoP at the token endpoint. The authorize endpoint is handled by AuthorizeHandler, which
+// MUST be registered ahead of the handlers that issue an authorization code; see its documentation for why.
 type Handler struct {
 	Config interface {
 		oauth2.DPoPConfigProvider
+		oauth2.TokenEndpointHandlersProvider
 	}
 	Strategy oauth2.DPoPStrategy
-}
-
-// HandleAuthorizeEndpointRequest records the 'dpop_jkt' authorize-request parameter onto the session so the
-// authorization code becomes bound to the client's DPoP proof-of-possession key. The bound thumbprint is later
-// enforced by HandleTokenEndpointRequest against the DPoP proof presented at the token endpoint.
-func (h *Handler) HandleAuthorizeEndpointRequest(ctx context.Context, request oauth2.AuthorizeRequester, response oauth2.AuthorizeResponder) (err error) {
-	if !h.Config.GetDPoPEnabled(ctx) {
-		return nil
-	}
-
-	jkt := request.GetRequestForm().Get(consts.FormParameterDPoPJKT)
-	if jkt == "" {
-		return nil
-	}
-
-	// Only record the binding for flows that issue an authorization code; an implicit-only flow never presents a
-	// code at the token endpoint, so it would never pass through HandleTokenEndpointRequest's proof check and would
-	// otherwise end up with an unenforceable cnf.jkt on its (directly issued) token.
-	if !request.GetResponseTypes().Has(consts.ResponseTypeAuthorizationCodeFlow) {
-		return nil
-	}
-
-	session, ok := request.GetSession().(oauth2.DPoPBoundSession)
-	if !ok {
-		return errorsx.WithStack(oauth2.ErrServerError.WithHint("The session does not support DPoP binding."))
-	}
-
-	session.SetDPoPJWKThumbprint(jkt)
-
-	return nil
 }
 
 func (h *Handler) HandleTokenEndpointRequest(ctx context.Context, request oauth2.AccessRequester) (err error) {
@@ -98,7 +69,11 @@ func (h *Handler) HandleTokenEndpointRequest(ctx context.Context, request oauth2
 
 	session.SetDPoPJWKThumbprint(proof.Thumbprint)
 
-	return nil
+	// DPoP augments a grant, it never satisfies one. Returning nil here would mark the access request as handled in
+	// oauth2.(*Fosite).NewAccessRequest, which combined with CanSkipClientAuth would let an unauthenticated caller
+	// pass off a 'grant_type' no grant handler implements as a valid request. The binding recorded above is retained
+	// because it was written to the session, not to the return value.
+	return errorsx.WithStack(oauth2.ErrUnknownRequest)
 }
 
 func (h *Handler) PopulateTokenEndpointResponse(ctx context.Context, request oauth2.AccessRequester, response oauth2.AccessResponder) (err error) {
@@ -124,9 +99,27 @@ func (h *Handler) CanSkipClientAuth(ctx context.Context, request oauth2.AccessRe
 }
 
 func (h *Handler) CanHandleTokenEndpointRequest(ctx context.Context, request oauth2.AccessRequester) bool {
-	// DPoP augments all token-endpoint grants rather than owning one, but must not participate at all when disabled,
-	// otherwise a nil HandleTokenEndpointRequest return would mask an unknown/bogus grant type as "found".
-	return h.Config.GetDPoPEnabled(ctx)
+	if !h.Config.GetDPoPEnabled(ctx) {
+		return false
+	}
+
+	// DPoP augments all token-endpoint grants rather than owning one, so it participates only when some grant handler
+	// will actually process the request. Without this, a caller presenting any self-signed proof alongside a
+	// 'grant_type' nothing implements would reach ValidateDPoPProof, and since CanSkipClientAuth waives client
+	// authentication for this handler, that caller need not be authenticated at all. Validating the proof records a
+	// replay marker, so it would hand an anonymous caller a write into the replay store on every request.
+	for _, handler := range h.Config.GetTokenEndpointHandlers(ctx) {
+		// Skip every DPoP handler, not just this instance, so a duplicate registration cannot recurse.
+		if _, ok := handler.(*Handler); ok {
+			continue
+		}
+
+		if handler.CanHandleTokenEndpointRequest(ctx, request) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (h *Handler) required(ctx context.Context, request oauth2.AccessRequester) bool {
@@ -142,6 +135,5 @@ func (h *Handler) required(ctx context.Context, request oauth2.AccessRequester) 
 }
 
 var (
-	_ oauth2.TokenEndpointHandler     = (*Handler)(nil)
-	_ oauth2.AuthorizeEndpointHandler = (*Handler)(nil)
+	_ oauth2.TokenEndpointHandler = (*Handler)(nil)
 )

--- a/handler/rfc9449/handler_authorize.go
+++ b/handler/rfc9449/handler_authorize.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 Authelia
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rfc9449
+
+import (
+	"context"
+
+	"authelia.com/provider/oauth2"
+	"authelia.com/provider/oauth2/internal/consts"
+	"authelia.com/provider/oauth2/x/errorsx"
+)
+
+// AuthorizeHandler implements the RFC 9449 Section 10.1 'dpop_jkt' authorize-request parameter.
+//
+// It is a distinct handler from Handler because the two have opposite ordering requirements. The binding is carried on
+// the session, and the handlers that issue an authorization code persist a copy of that session as they run, so this
+// handler MUST be registered ahead of every handler that calls CreateAuthorizeCodeSession (the OAuth 2.0 explicit
+// grant and the OpenID Connect explicit/hybrid flows). Registering it after them leaves the thumbprint absent from the
+// persisted session and silently disables the authorization code injection protection this parameter exists to
+// provide. Handler, in contrast, must run after the grant handlers at the token endpoint so that the session it reads
+// the binding back from has already been restored from storage.
+type AuthorizeHandler struct {
+	Config interface {
+		oauth2.DPoPConfigProvider
+	}
+}
+
+// HandleAuthorizeEndpointRequest records the 'dpop_jkt' authorize-request parameter onto the session so the
+// authorization code becomes bound to the client's DPoP proof-of-possession key. The bound thumbprint is later
+// enforced by Handler.HandleTokenEndpointRequest against the DPoP proof presented at the token endpoint.
+func (h *AuthorizeHandler) HandleAuthorizeEndpointRequest(ctx context.Context, request oauth2.AuthorizeRequester, response oauth2.AuthorizeResponder) (err error) {
+	if !h.Config.GetDPoPEnabled(ctx) {
+		return nil
+	}
+
+	jkt := request.GetRequestForm().Get(consts.FormParameterDPoPJKT)
+	if jkt == "" {
+		return nil
+	}
+
+	// Checked before the response type gates below, as a malformed parameter is malformed whether or not this flow
+	// goes on to use it.
+	if !oauth2.IsValidDPoPJWKThumbprint(jkt) {
+		return errorsx.WithStack(oauth2.ErrInvalidRequest.WithHintf("The 'dpop_jkt' parameter must be the base64url encoded SHA-256 JWK Thumbprint of the DPoP proof-of-possession public key, which is %d characters long.", oauth2.DPoPJWKThumbprintLength))
+	}
+
+	types := request.GetResponseTypes()
+
+	// Only record the binding for flows that issue an authorization code; an implicit-only flow never presents a
+	// code at the token endpoint, so it would never pass through Handler.HandleTokenEndpointRequest's proof check and
+	// would otherwise end up with an unenforceable cnf.jkt on its (directly issued) token.
+	if !types.Has(consts.ResponseTypeAuthorizationCodeFlow) {
+		return nil
+	}
+
+	// A hybrid flow that also issues an access token straight from the authorization endpoint is skipped for the same
+	// reason. The binding lives on the session shared by every authorize handler, so it cannot be applied to the code
+	// alone: the directly issued access token would pick up a cnf.jkt that no proof was ever checked against, while
+	// still being advertised as 'token_type=bearer' in the authorization response. RFC 9449 Section 7.1 requires a
+	// DPoP bound access token to be presented under the DPoP scheme, so a conforming client would present that token
+	// as a bearer token and the resource server would be obliged to reject it.
+	if types.Has(consts.ResponseTypeImplicitFlowToken) {
+		return nil
+	}
+
+	session, ok := request.GetSession().(oauth2.DPoPBoundSession)
+	if !ok {
+		return errorsx.WithStack(oauth2.ErrServerError.WithHint("The session does not support DPoP binding."))
+	}
+
+	session.SetDPoPJWKThumbprint(jkt)
+
+	return nil
+}
+
+var (
+	_ oauth2.AuthorizeEndpointHandler = (*AuthorizeHandler)(nil)
+)

--- a/handler/rfc9449/handler_test.go
+++ b/handler/rfc9449/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,7 +34,8 @@ func TestHandlerBindsProof(t *testing.T) {
 	request.Client = &oauth2.DefaultClient{}
 
 	ctx := ctxWithDPoP(http.MethodPost, "https://as.example.com/token", raw)
-	require.NoError(t, h.HandleTokenEndpointRequest(ctx, request))
+
+	assert.ErrorIs(t, h.HandleTokenEndpointRequest(ctx, request), oauth2.ErrUnknownRequest)
 	assert.NotEmpty(t, session.GetDPoPJWKThumbprint())
 }
 
@@ -74,6 +76,10 @@ func TestHandlerRequiredButMissing(t *testing.T) {
 	assert.ErrorIs(t, err, oauth2.ErrInvalidDPoPProof)
 }
 
+// testAuthorizeJKT is a well-formed 'dpop_jkt', being 43 characters of base64url which decode to a SHA-256 sized
+// digest. The parameter is validated, so a placeholder will not do.
+const testAuthorizeJKT = "kM1FTfCFVzO9tGKBVBEAWCVoWZ2WcOK1EbSPxNjQfSw"
+
 func TestHandlerAuthorize(t *testing.T) {
 	testCases := []struct {
 		name          string
@@ -88,15 +94,15 @@ func TestHandlerAuthorize(t *testing.T) {
 			name:          "RecordsDPoPJKT",
 			enabled:       true,
 			session:       &oauth2.DefaultSession{},
-			jkt:           "authz-jkt",
+			jkt:           testAuthorizeJKT,
 			responseTypes: oauth2.Arguments{consts.ResponseTypeAuthorizationCodeFlow},
-			wantJKT:       "authz-jkt",
+			wantJKT:       testAuthorizeJKT,
 		},
 		{
 			name:    "DisabledLeavesSessionUnchanged",
 			enabled: false,
 			session: &oauth2.DefaultSession{},
-			jkt:     "authz-jkt",
+			jkt:     testAuthorizeJKT,
 		},
 		{
 			name:    "NoDPoPJKTLeavesSessionUnchanged",
@@ -107,23 +113,73 @@ func TestHandlerAuthorize(t *testing.T) {
 			name:          "RecordsDPoPJKTOnlyForCodeFlow",
 			enabled:       true,
 			session:       &oauth2.DefaultSession{},
-			jkt:           "authz-jkt",
+			jkt:           testAuthorizeJKT,
 			responseTypes: oauth2.Arguments{consts.ResponseTypeImplicitFlowToken},
+		},
+		{
+			name:          "RecordsDPoPJKTForCodeIDTokenHybridFlow",
+			enabled:       true,
+			session:       &oauth2.DefaultSession{},
+			jkt:           testAuthorizeJKT,
+			responseTypes: oauth2.Arguments{consts.ResponseTypeAuthorizationCodeFlow, consts.ResponseTypeImplicitFlowIDToken},
+			wantJKT:       testAuthorizeJKT,
+		},
+		{
+			name:          "SkipsHybridFlowIssuingAnAccessTokenDirectly",
+			enabled:       true,
+			session:       &oauth2.DefaultSession{},
+			jkt:           testAuthorizeJKT,
+			responseTypes: oauth2.Arguments{consts.ResponseTypeAuthorizationCodeFlow, consts.ResponseTypeImplicitFlowToken},
 		},
 		{
 			name:          "NonDPoPSessionReturnsServerError",
 			enabled:       true,
 			session:       nonDPoPSession{},
-			jkt:           "authz-jkt",
+			jkt:           testAuthorizeJKT,
 			responseTypes: oauth2.Arguments{consts.ResponseTypeAuthorizationCodeFlow},
 			wantErr:       oauth2.ErrServerError,
+		},
+		{
+			name:          "RejectsMalformedDPoPJKT",
+			enabled:       true,
+			session:       &oauth2.DefaultSession{},
+			jkt:           "not-a-thumbprint",
+			responseTypes: oauth2.Arguments{consts.ResponseTypeAuthorizationCodeFlow},
+			wantErr:       oauth2.ErrInvalidRequest,
+		},
+		{
+			name:          "RejectsOverlongDPoPJKT",
+			enabled:       true,
+			session:       &oauth2.DefaultSession{},
+			jkt:           strings.Repeat("A", 4096),
+			responseTypes: oauth2.Arguments{consts.ResponseTypeAuthorizationCodeFlow},
+			wantErr:       oauth2.ErrInvalidRequest,
+		},
+		{
+			name:          "RejectsDPoPJKTOutsideTheBase64URLAlphabet",
+			enabled:       true,
+			session:       &oauth2.DefaultSession{},
+			jkt:           "kM1FTfCFVzO9tGKBVBEAWCVoWZ2WcOK1EbSPxNjQfS+",
+			responseTypes: oauth2.Arguments{consts.ResponseTypeAuthorizationCodeFlow},
+			wantErr:       oauth2.ErrInvalidRequest,
+		},
+		{
+			// A malformed value is rejected even for a flow whose binding would be skipped anyway.
+			name:          "RejectsMalformedDPoPJKTForSkippedFlow",
+			enabled:       true,
+			session:       &oauth2.DefaultSession{},
+			jkt:           "not-a-thumbprint",
+			responseTypes: oauth2.Arguments{consts.ResponseTypeImplicitFlowToken},
+			wantErr:       oauth2.ErrInvalidRequest,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			h, _, cfg := newTestHandler(false)
+			_, _, cfg := newTestHandler(false)
 			cfg.enabled = tc.enabled
+
+			h := &AuthorizeHandler{Config: cfg}
 
 			ar := oauth2.NewAuthorizeRequest()
 			ar.Client = &oauth2.DefaultClient{}
@@ -182,6 +238,19 @@ func TestHandlerCanHandleTokenEndpointRequestGatedByEnabled(t *testing.T) {
 	assert.False(t, h.CanHandleTokenEndpointRequest(context.Background(), request))
 }
 
+func TestHandlerCanHandleTokenEndpointRequestGatedByAGrantHandler(t *testing.T) {
+	h, _, cfg := newTestHandler(false)
+	request := oauth2.NewAccessRequest(&oauth2.DefaultSession{})
+
+	assert.True(t, h.CanHandleTokenEndpointRequest(context.Background(), request))
+
+	cfg.handlers = oauth2.TokenEndpointHandlers{&stubGrantHandler{handles: false}}
+	assert.False(t, h.CanHandleTokenEndpointRequest(context.Background(), request))
+
+	cfg.handlers = oauth2.TokenEndpointHandlers{h, &Handler{Config: cfg, Strategy: cfg.strategy}}
+	assert.False(t, h.CanHandleTokenEndpointRequest(context.Background(), request))
+}
+
 func TestHandlerReturnsUnknownRequestWhenUnbound(t *testing.T) {
 	h, _, _ := newTestHandler(false)
 
@@ -221,7 +290,7 @@ func TestDPoPEndToEndBindingAndRefresh(t *testing.T) {
 	})
 	ctx1 := ctxWithDPoP(http.MethodPost, "https://as.example.com/token", raw1)
 
-	require.NoError(t, h.HandleTokenEndpointRequest(ctx1, request))
+	require.ErrorIs(t, h.HandleTokenEndpointRequest(ctx1, request), oauth2.ErrUnknownRequest)
 	jkt := session.GetDPoPJWKThumbprint()
 	require.NotEmpty(t, jkt)
 
@@ -235,7 +304,7 @@ func TestDPoPEndToEndBindingAndRefresh(t *testing.T) {
 	})
 	ctx2 := ctxWithDPoP(http.MethodPost, "https://as.example.com/token", raw2)
 
-	require.NoError(t, h.HandleTokenEndpointRequest(ctx2, refreshRequest))
+	require.ErrorIs(t, h.HandleTokenEndpointRequest(ctx2, refreshRequest), oauth2.ErrUnknownRequest)
 	assert.Equal(t, jkt, refreshSession.GetDPoPJWKThumbprint())
 
 	otherKey := newTestProofKey(t)
@@ -257,12 +326,40 @@ type testHandlerConfig struct {
 	testStrategyConfig
 	enabled, enforce, nonceRequired bool
 	strategy                        oauth2.DPoPStrategy
+	handlers                        oauth2.TokenEndpointHandlers
 }
 
-func (c *testHandlerConfig) GetDPoPEnabled(context.Context) bool                 { return c.enabled }
-func (c *testHandlerConfig) GetDPoPEnforce(context.Context) bool                 { return c.enforce }
-func (c *testHandlerConfig) GetDPoPNonceRequired(context.Context) bool           { return c.nonceRequired }
+func (c *testHandlerConfig) GetTokenEndpointHandlers(context.Context) oauth2.TokenEndpointHandlers {
+	return c.handlers
+}
+
+func (c *testHandlerConfig) GetDPoPEnabled(context.Context) bool { return c.enabled }
+
+func (c *testHandlerConfig) GetDPoPEnforce(context.Context) bool { return c.enforce }
+
+func (c *testHandlerConfig) GetDPoPNonceRequired(context.Context) bool { return c.nonceRequired }
+
 func (c *testHandlerConfig) GetDPoPStrategy(context.Context) oauth2.DPoPStrategy { return c.strategy }
+
+type stubGrantHandler struct {
+	handles bool
+}
+
+func (s *stubGrantHandler) HandleTokenEndpointRequest(ctx context.Context, request oauth2.AccessRequester) error {
+	return nil
+}
+
+func (s *stubGrantHandler) PopulateTokenEndpointResponse(ctx context.Context, request oauth2.AccessRequester, response oauth2.AccessResponder) error {
+	return nil
+}
+
+func (s *stubGrantHandler) CanSkipClientAuth(ctx context.Context, request oauth2.AccessRequester) bool {
+	return false
+}
+
+func (s *stubGrantHandler) CanHandleTokenEndpointRequest(ctx context.Context, request oauth2.AccessRequester) bool {
+	return s.handles
+}
 
 func newTestHandler(enforce bool) (*Handler, *storage.MemoryStore, *testHandlerConfig) {
 	store := storage.NewMemoryStore()
@@ -270,6 +367,7 @@ func newTestHandler(enforce bool) (*Handler, *storage.MemoryStore, *testHandlerC
 		testStrategyConfig: testStrategyConfig{algs: []string{"ES256"}, skew: time.Minute, nonceExp: time.Minute},
 		enabled:            true,
 		enforce:            enforce,
+		handlers:           oauth2.TokenEndpointHandlers{&stubGrantHandler{handles: true}},
 	}
 	strategy := NewDefaultStrategy(cfg, store)
 	cfg.strategy = strategy
@@ -293,11 +391,14 @@ func ctxWithDPoP(method, rawURL, proof string) context.Context {
 	return context.WithValue(context.Background(), oauth2.RequestContextKey, r)
 }
 
-// nonDPoPSession implements only oauth2.Session, not oauth2.DPoPBoundSession.
 type nonDPoPSession struct{}
 
 func (nonDPoPSession) SetExpiresAt(oauth2.TokenType, time.Time) {}
-func (nonDPoPSession) GetExpiresAt(oauth2.TokenType) time.Time  { return time.Time{} }
-func (nonDPoPSession) GetUsername() string                      { return "" }
-func (nonDPoPSession) GetSubject() string                       { return "" }
-func (nonDPoPSession) Clone() oauth2.Session                    { return nonDPoPSession{} }
+
+func (nonDPoPSession) GetExpiresAt(oauth2.TokenType) time.Time { return time.Time{} }
+
+func (nonDPoPSession) GetUsername() string { return "" }
+
+func (nonDPoPSession) GetSubject() string { return "" }
+
+func (nonDPoPSession) Clone() oauth2.Session { return nonDPoPSession{} }

--- a/handler/rfc9449/proof.go
+++ b/handler/rfc9449/proof.go
@@ -5,6 +5,7 @@
 package rfc9449
 
 import (
+	"crypto/rsa"
 	"encoding/json"
 	"time"
 
@@ -15,6 +16,18 @@ import (
 	"authelia.com/provider/oauth2/token/jwt"
 	"authelia.com/provider/oauth2/x/errorsx"
 )
+
+// JTIMaxLength is the longest accepted 'jti' claim. RFC 9449 Section 11.1 recommends rejecting proofs carrying an
+// unnecessarily large 'jti' (or storing only a hash of it) so that a client cannot exhaust the memory of the replay
+// store, which retains every accepted value for the proof's 'iat' acceptance window. Section 4.2 only asks for at
+// least 96 bits of pseudorandom data or a version 4 UUID, both of which are far shorter than this bound.
+const JTIMaxLength = 255
+
+// RSAMinimumKeySize is the smallest accepted modulus for an RSA DPoP proof key. RFC 7518 Sections 3.3 and 3.5 require
+// a key of at least 2048 bits for the RS* and PS* algorithms, and nothing in the JOSE layer enforces it: a signature
+// from a weak key verifies perfectly well, so without this check a token could be bound to a key that offers no real
+// proof of possession. The client chooses this key freely, so the check costs a conforming client nothing.
+const RSAMinimumKeySize = 2048
 
 // ParseProof parses a compact DPoP proof JWT, validates its structural requirements (typ, alg, embedded public jwk,
 // signature, and required claims), and returns the validated proof. Request-contextual checks (htm/htu/iat/nonce and
@@ -46,6 +59,11 @@ func ParseProof(proof string, algorithms []jose.SignatureAlgorithm) (parsed *oau
 		return nil, errorsx.WithStack(oauth2.ErrInvalidDPoPProof.WithHint("The DPoP proof must contain a valid public 'jwk' header."))
 	}
 
+	// Checked before the signature is verified, as there is no reason to do the work for a key that will be rejected.
+	if err = validateProofKeyStrength(jwk); err != nil {
+		return nil, err
+	}
+
 	var payload []byte
 
 	if payload, err = jws.Verify(jwk); err != nil {
@@ -61,6 +79,10 @@ func ParseProof(proof string, algorithms []jose.SignatureAlgorithm) (parsed *oau
 
 	if parsed.ID, _ = claims[consts.ClaimJWTID].(string); parsed.ID == "" {
 		return nil, errorsx.WithStack(oauth2.ErrInvalidDPoPProof.WithHint("The DPoP proof is missing the required 'jti' claim."))
+	}
+
+	if len(parsed.ID) > JTIMaxLength {
+		return nil, errorsx.WithStack(oauth2.ErrInvalidDPoPProof.WithHintf("The DPoP proof 'jti' claim must not be longer than %d characters.", JTIMaxLength))
 	}
 
 	if parsed.Method, _ = claims[consts.ClaimHTTPMethod].(string); parsed.Method == "" {
@@ -85,6 +107,22 @@ func ParseProof(proof string, algorithms []jose.SignatureAlgorithm) (parsed *oau
 	}
 
 	return parsed, nil
+}
+
+// validateProofKeyStrength rejects a proof key too weak for the proof-of-possession binding to be meaningful.
+//
+// Only RSA needs checking. The elliptic curve and Ed25519 key types the JOSE layer will accept as a public key all
+// carry a fixed, adequate strength: go-jose parses an 'EC' JWK only for P-256, P-384 and P-521, and its ECDSA verifier
+// derives the expected signature size from the algorithm rather than the key, so a curve weaker than the declared
+// algorithm cannot be smuggled in.
+func validateProofKeyStrength(jwk *jose.JSONWebKey) (err error) {
+	if key, ok := jwk.Key.(*rsa.PublicKey); ok {
+		if bits := key.N.BitLen(); bits < RSAMinimumKeySize {
+			return errorsx.WithStack(oauth2.ErrInvalidDPoPProof.WithHintf("The DPoP proof 'jwk' header contains a %d bit RSA key but keys of at least %d bits are required.", bits, RSAMinimumKeySize))
+		}
+	}
+
+	return nil
 }
 
 func toFloat(v any) (f float64, ok bool) {

--- a/handler/rfc9449/proof_test.go
+++ b/handler/rfc9449/proof_test.go
@@ -6,8 +6,10 @@ package rfc9449
 
 import (
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"encoding/base64"
 	"net/http"
 	"strings"
@@ -80,6 +82,26 @@ func TestParseProof(t *testing.T) {
 			wantErr: oauth2.ErrInvalidDPoPProof,
 		},
 		{
+			name: "RejectsOversizedJTI",
+			raw: func(t *testing.T, key *jose.JSONWebKey) string {
+				return signProof(t, key, ijwt.JSONWebTokenTypeDPoP, map[string]any{
+					ijwt.ClaimJWTID: strings.Repeat("j", JTIMaxLength+1), ijwt.ClaimHTTPMethod: http.MethodPost, ijwt.ClaimHTTPURI: "https://as/token", ijwt.ClaimIssuedAt: 1,
+				})
+			},
+			wantErr: oauth2.ErrInvalidDPoPProof,
+		},
+		{
+			name: "AcceptsMaximumLengthJTI",
+			raw: func(t *testing.T, key *jose.JSONWebKey) string {
+				return signProof(t, key, ijwt.JSONWebTokenTypeDPoP, map[string]any{
+					ijwt.ClaimJWTID: strings.Repeat("j", JTIMaxLength), ijwt.ClaimHTTPMethod: http.MethodPost, ijwt.ClaimHTTPURI: "https://as/token", ijwt.ClaimIssuedAt: 1,
+				})
+			},
+			check: func(t *testing.T, proof *oauth2.DPoPProof) {
+				assert.Len(t, proof.ID, JTIMaxLength)
+			},
+		},
+		{
 			name: "RejectsDisallowedAlg",
 			raw: func(t *testing.T, key *jose.JSONWebKey) string {
 				return signProof(t, key, ijwt.JSONWebTokenTypeDPoP, map[string]any{ijwt.ClaimJWTID: "x", ijwt.ClaimHTTPMethod: http.MethodPost, ijwt.ClaimHTTPURI: "https://as/token", ijwt.ClaimIssuedAt: 1})
@@ -150,4 +172,75 @@ func signProof(t *testing.T, key *jose.JSONWebKey, typ string, claims map[string
 	require.NoError(t, err)
 
 	return raw
+}
+
+func TestParseProofRSAKeySize(t *testing.T) {
+	testCases := []struct {
+		name    string
+		bits    int
+		wantErr bool
+	}{
+		{"ShouldRejectBelowTheMinimum", 1024, true},
+		{"ShouldAcceptTheMinimum", RSAMinimumKeySize, false},
+		{"ShouldAcceptAboveTheMinimum", 3072, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			priv, err := rsa.GenerateKey(rand.Reader, tc.bits)
+			require.NoError(t, err)
+
+			key := &jose.JSONWebKey{Key: priv, Algorithm: string(jose.RS256), KeyID: "rsa"}
+
+			raw := signProof(t, key, ijwt.JSONWebTokenTypeDPoP, map[string]any{
+				ijwt.ClaimJWTID:      "rsa-1",
+				ijwt.ClaimHTTPMethod: http.MethodPost,
+				ijwt.ClaimHTTPURI:    "https://as.example.com/token",
+				ijwt.ClaimIssuedAt:   1000,
+			})
+
+			proof, err := ParseProof(raw, []jose.SignatureAlgorithm{jose.RS256})
+
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, oauth2.ErrInvalidDPoPProof)
+				assert.Contains(t, oauth2.ErrorToRFC6749Error(err).HintField, "RSA key but keys of at least")
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.NotEmpty(t, proof.Thumbprint)
+		})
+	}
+}
+
+func TestParseProofAcceptsEllipticAndEdDSAKeys(t *testing.T) {
+	t.Run("ES256", func(t *testing.T) {
+		priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+
+		key := &jose.JSONWebKey{Key: priv, Algorithm: string(jose.ES256)}
+
+		raw := signProof(t, key, ijwt.JSONWebTokenTypeDPoP, map[string]any{
+			ijwt.ClaimJWTID: "ec-1", ijwt.ClaimHTTPMethod: http.MethodPost, ijwt.ClaimHTTPURI: "https://as.example.com/token", ijwt.ClaimIssuedAt: 1000,
+		})
+
+		_, err = ParseProof(raw, []jose.SignatureAlgorithm{jose.ES256})
+		require.NoError(t, err)
+	})
+
+	t.Run("EdDSA", func(t *testing.T) {
+		_, priv, err := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, err)
+
+		key := &jose.JSONWebKey{Key: priv, Algorithm: string(jose.EdDSA)}
+
+		raw := signProof(t, key, ijwt.JSONWebTokenTypeDPoP, map[string]any{
+			ijwt.ClaimJWTID: "ed-1", ijwt.ClaimHTTPMethod: http.MethodPost, ijwt.ClaimHTTPURI: "https://as.example.com/token", ijwt.ClaimIssuedAt: 1000,
+		})
+
+		_, err = ParseProof(raw, []jose.SignatureAlgorithm{jose.EdDSA})
+		require.NoError(t, err)
+	})
 }

--- a/handler/rfc9449/storage.go
+++ b/handler/rfc9449/storage.go
@@ -9,12 +9,24 @@ import (
 	"time"
 )
 
-// DPoPReplayStorage provides replay protection for DPoP proof JWTs keyed by their 'jti' claim.
+// DPoPReplayStorage provides replay protection for DPoP proof JWTs keyed by their 'jti' claim within the context the
+// 'jti' is required to be unique in.
 type DPoPReplayStorage interface {
-	// CheckAndSetDPoPProofUsed atomically reports whether a proof 'jti' has already been used (and not yet expired)
-	// and, when it has not, records it as used until exp. The check and the store MUST happen within a single critical
-	// section so that concurrent requests presenting the same 'jti' cannot both observe it as unused.
-	CheckAndSetDPoPProofUsed(ctx context.Context, jti string, exp time.Time) (used bool, err error)
+	// CheckAndSetDPoPProofUsed atomically reports whether a proof has already been used (and not yet expired) and,
+	// when it has not, records it as used until exp. The check and the store MUST happen within a single critical
+	// section so that concurrent requests presenting the same proof cannot both observe it as unused.
+	//
+	// Implementations MUST key the record on all three of thumbprint (the RFC 7638 JWK Thumbprint of the proof's
+	// public key), htu (the normalized target URI) and jti, rather than on jti alone. RFC 9449 Section 4.2 only
+	// requires a 'jti' to be unique "in the same context", and Section 11.1 describes tracking it "in the context of
+	// the target URI", so a conforming client may reuse a 'jti' at another endpoint; keying on jti alone would reject
+	// that as a replay and would additionally let one client emitting weak 'jti' values deny service to every other
+	// client that happens to pick the same value.
+	//
+	// The narrower key does not weaken replay protection. A replayed proof is presented verbatim, so it carries the
+	// same key and the same 'htu', and the strategy separately rejects any proof whose 'htu' does not match the
+	// request URI. A proof cannot be re-signed under a different key without the corresponding private key.
+	CheckAndSetDPoPProofUsed(ctx context.Context, thumbprint, htu, jti string, exp time.Time) (used bool, err error)
 }
 
 // DPoPNonceStorage persists server-provided DPoP nonces.

--- a/handler/rfc9449/strategy.go
+++ b/handler/rfc9449/strategy.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
-	"strings"
 	"time"
 
 	"github.com/go-jose/go-jose/v4"
@@ -39,7 +38,9 @@ func (s *DefaultStrategy) ValidateDPoPProof(ctx context.Context, method, request
 		return nil, err
 	}
 
-	if !strings.EqualFold(parsed.Method, method) {
+	// RFC 9449 4.3 step 8: the 'htm' claim must match the request method. The comparison is exact because RFC 9110
+	// Section 9.1 defines the method token as case-sensitive.
+	if parsed.Method != method {
 		return nil, errorsx.WithStack(oauth2.ErrInvalidDPoPProof.WithHintf("The DPoP proof 'htm' claim '%s' does not match the request method '%s'.", parsed.Method, method))
 	}
 
@@ -74,13 +75,15 @@ func (s *DefaultStrategy) ValidateDPoPProof(ctx context.Context, method, request
 		}
 	}
 
-	// Check-and-mark the proof 'jti' as used in a single atomic step so concurrent requests presenting the same proof
-	// cannot both pass the replay check. The marker is kept until the end of the proof's own 'iat' acceptance window
+	// Check-and-mark the proof as used in a single atomic step so concurrent requests presenting the same proof cannot
+	// both pass the replay check. The marker is kept until the end of the proof's own 'iat' acceptance window
 	// (iat+skew), not now+skew: a proof presented before its iat (client clock ahead, within skew) stays iat-acceptable
-	// until iat+skew, so expiring the marker at now+skew < iat+skew would reopen a replay window for the remainder.
+	// until iat+skew, so expiring the marker at now+skew < iat+skew would reopen a replay window for the remainder. It
+	// is recorded against the proof key and the normalized target URI rather than the 'jti' alone, as that is the
+	// context a 'jti' is required to be unique in, see DPoPReplayStorage.
 	var used bool
 
-	if used, err = s.Store.CheckAndSetDPoPProofUsed(ctx, parsed.ID, parsed.IssuedAt.Add(skew)); err != nil {
+	if used, err = s.Store.CheckAndSetDPoPProofUsed(ctx, parsed.Thumbprint, expected, parsed.ID, parsed.IssuedAt.Add(skew)); err != nil {
 		return nil, errorsx.WithStack(oauth2.ErrServerError.WithWrap(err).WithDebugError(err))
 	} else if used {
 		return nil, errorsx.WithStack(oauth2.ErrInvalidDPoPProof.WithHint("The DPoP proof has already been used."))

--- a/handler/rfc9449/strategy_test.go
+++ b/handler/rfc9449/strategy_test.go
@@ -2,7 +2,9 @@ package rfc9449
 
 import (
 	"context"
+	"crypto/tls"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -22,8 +24,10 @@ type testStrategyConfig struct {
 }
 
 func (c *testStrategyConfig) GetDPoPAllowedJWSAlgorithms(context.Context) []string { return c.algs }
-func (c *testStrategyConfig) GetDPoPClockSkew(context.Context) time.Duration       { return c.skew }
-func (c *testStrategyConfig) GetDPoPNonceLifespan(context.Context) time.Duration   { return c.nonceExp }
+
+func (c *testStrategyConfig) GetDPoPClockSkew(context.Context) time.Duration { return c.skew }
+
+func (c *testStrategyConfig) GetDPoPNonceLifespan(context.Context) time.Duration { return c.nonceExp }
 
 func newTestStrategy() (*DefaultStrategy, *storage.MemoryStore) {
 	store := storage.NewMemoryStore()
@@ -58,6 +62,39 @@ func TestStrategyValidateProofReplay(t *testing.T) {
 	assert.ErrorIs(t, err, oauth2.ErrInvalidDPoPProof)
 }
 
+func TestStrategyValidateProofReplayIsScopedToTheProofKey(t *testing.T) {
+	s, _ := newTestStrategy()
+
+	claims := map[string]any{
+		jwt.ClaimJWTID: "shared-1", jwt.ClaimHTTPMethod: http.MethodPost, jwt.ClaimHTTPURI: "https://as.example.com/token", jwt.ClaimIssuedAt: time.Now().Unix(),
+	}
+
+	_, err := s.ValidateDPoPProof(context.Background(), http.MethodPost, "https://as.example.com/token", signProof(t, newTestProofKey(t), jwt.JSONWebTokenTypeDPoP, claims), false)
+	require.NoError(t, err)
+
+	_, err = s.ValidateDPoPProof(context.Background(), http.MethodPost, "https://as.example.com/token", signProof(t, newTestProofKey(t), jwt.JSONWebTokenTypeDPoP, claims), false)
+	require.NoError(t, err)
+}
+
+func TestStrategyValidateProofReplayIsScopedToTheTargetURI(t *testing.T) {
+	s, _ := newTestStrategy()
+	key := newTestProofKey(t)
+
+	raw := signProof(t, key, jwt.JSONWebTokenTypeDPoP, map[string]any{
+		jwt.ClaimJWTID: "per-uri-1", jwt.ClaimHTTPMethod: http.MethodPost, jwt.ClaimHTTPURI: "https://as.example.com/token", jwt.ClaimIssuedAt: time.Now().Unix(),
+	})
+
+	_, err := s.ValidateDPoPProof(context.Background(), http.MethodPost, "https://as.example.com/token", raw, false)
+	require.NoError(t, err)
+
+	raw = signProof(t, key, jwt.JSONWebTokenTypeDPoP, map[string]any{
+		jwt.ClaimJWTID: "per-uri-1", jwt.ClaimHTTPMethod: http.MethodPost, jwt.ClaimHTTPURI: "https://as.example.com/introspect", jwt.ClaimIssuedAt: time.Now().Unix(),
+	})
+
+	_, err = s.ValidateDPoPProof(context.Background(), http.MethodPost, "https://as.example.com/introspect", raw, false)
+	require.NoError(t, err)
+}
+
 func TestStrategyReplayMarkerCoversFullIATWindow(t *testing.T) {
 	s, store := newTestStrategy()
 	key := newTestProofKey(t)
@@ -67,10 +104,10 @@ func TestStrategyReplayMarkerCoversFullIATWindow(t *testing.T) {
 		jwt.ClaimJWTID: "future-iat", jwt.ClaimHTTPMethod: http.MethodPost, jwt.ClaimHTTPURI: "https://as.example.com/token", jwt.ClaimIssuedAt: iat.Unix(),
 	})
 
-	_, err := s.ValidateDPoPProof(context.Background(), http.MethodPost, "https://as.example.com/token", raw, false)
+	proof, err := s.ValidateDPoPProof(context.Background(), http.MethodPost, "https://as.example.com/token", raw, false)
 	require.NoError(t, err)
 
-	exp, ok := store.DPoPProofJTIs["future-iat"]
+	exp, ok := store.DPoPProofJTIs[storage.DPoPProofMarker{Thumbprint: proof.Thumbprint, URL: "https://as.example.com/token", JTI: "future-iat"}]
 	require.True(t, ok, "expected the proof jti to be recorded as used")
 
 	wantMin := time.Unix(iat.Unix(), 0).Add(time.Minute)
@@ -117,11 +154,43 @@ func TestStrategyValidateProofRejects(t *testing.T) {
 			iat:    time.Now().Unix(),
 		},
 		{
+			name:   "MethodCaseMismatch",
+			method: http.MethodPost,
+			url:    "https://as.example.com/token",
+			htm:    "post",
+			htu:    "https://as.example.com/token",
+			iat:    time.Now().Unix(),
+		},
+		{
 			name:   "HTUMismatch",
 			method: http.MethodPost,
 			url:    "https://as.example.com/token",
 			htm:    http.MethodPost,
 			htu:    "https://as.example.com/other",
+			iat:    time.Now().Unix(),
+		},
+		{
+			name:   "HTUEncodedSlashNotConflated",
+			method: http.MethodPost,
+			url:    "https://as.example.com/a/b",
+			htm:    http.MethodPost,
+			htu:    "https://as.example.com/a%2Fb",
+			iat:    time.Now().Unix(),
+		},
+		{
+			name:   "HTURelative",
+			method: http.MethodPost,
+			url:    "https://as.example.com/token",
+			htm:    http.MethodPost,
+			htu:    "/token",
+			iat:    time.Now().Unix(),
+		},
+		{
+			name:   "HTUDotSegmentsResolveElsewhere",
+			method: http.MethodPost,
+			url:    "https://as.example.com/token",
+			htm:    http.MethodPost,
+			htu:    "https://as.example.com/token/../admin",
 			iat:    time.Now().Unix(),
 		},
 		{
@@ -167,6 +236,86 @@ func TestStrategyValidateProofAcceptsDefaultPortEquivalence(t *testing.T) {
 
 	_, err := s.ValidateDPoPProof(context.Background(), http.MethodPost, "https://as.example.com/token", raw, false)
 	assert.NoError(t, err)
+}
+
+func TestStrategyValidateProofAcceptsNormalizedEquivalence(t *testing.T) {
+	testCases := []struct {
+		name string
+		url  string
+		htu  string
+	}{
+		{
+			name: "UppercaseSchemeAndHost",
+			url:  "https://as.example.com/token",
+			htu:  "HTTPS://AS.EXAMPLE.COM/token",
+		},
+		{
+			name: "UnreservedPercentEncoding",
+			url:  "https://as.example.com/~token",
+			htu:  "https://as.example.com/%7Etoken",
+		},
+		{
+			name: "PercentEncodingCase",
+			url:  "https://as.example.com/a%2Fb",
+			htu:  "https://as.example.com/a%2fb",
+		},
+		{
+			name: "DotSegments",
+			url:  "https://as.example.com/token",
+			htu:  "https://as.example.com/admin/../token",
+		},
+		{
+			name: "EmptyPath",
+			url:  "https://as.example.com/",
+			htu:  "https://as.example.com",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, _ := newTestStrategy()
+
+			raw := signProof(t, newTestProofKey(t), jwt.JSONWebTokenTypeDPoP, map[string]any{
+				jwt.ClaimJWTID: tc.name, jwt.ClaimHTTPMethod: http.MethodPost, jwt.ClaimHTTPURI: tc.htu, jwt.ClaimIssuedAt: time.Now().Unix(),
+			})
+
+			_, err := s.ValidateDPoPProof(context.Background(), http.MethodPost, tc.url, raw, false)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestStrategyValidateProofAgainstReconstructedRequestURI(t *testing.T) {
+	newRequest := func(t *testing.T, target string) *http.Request {
+		u, err := url.Parse(target)
+		require.NoError(t, err)
+
+		return &http.Request{Method: http.MethodPost, Header: http.Header{}, URL: u, Host: "as.example.com", TLS: &tls.ConnectionState{}}
+	}
+
+	t.Run("Matches", func(t *testing.T) {
+		s, _ := newTestStrategy()
+		r := newRequest(t, "https://as.example.com/token")
+
+		raw := signProof(t, newTestProofKey(t), jwt.JSONWebTokenTypeDPoP, map[string]any{
+			jwt.ClaimJWTID: "req-1", jwt.ClaimHTTPMethod: http.MethodPost, jwt.ClaimHTTPURI: "https://as.example.com/token", jwt.ClaimIssuedAt: time.Now().Unix(),
+		})
+
+		_, err := s.ValidateDPoPProof(context.Background(), r.Method, requestURL(r), raw, false)
+		assert.NoError(t, err)
+	})
+
+	t.Run("RejectsEncodedDelimiterSmuggledIntoThePath", func(t *testing.T) {
+		s, _ := newTestStrategy()
+		r := newRequest(t, "https://as.example.com/token%3Fx=1")
+
+		raw := signProof(t, newTestProofKey(t), jwt.JSONWebTokenTypeDPoP, map[string]any{
+			jwt.ClaimJWTID: "req-2", jwt.ClaimHTTPMethod: http.MethodPost, jwt.ClaimHTTPURI: "https://as.example.com/token", jwt.ClaimIssuedAt: time.Now().Unix(),
+		})
+
+		_, err := s.ValidateDPoPProof(context.Background(), r.Method, requestURL(r), raw, false)
+		assert.ErrorIs(t, err, oauth2.ErrInvalidDPoPProof)
+	})
 }
 
 var _ = jose.ES256

--- a/handler/rfc9449/util.go
+++ b/handler/rfc9449/util.go
@@ -1,6 +1,8 @@
 package rfc9449
 
 import (
+	"bytes"
+	"errors"
 	"net/http"
 	"net/url"
 	"strings"
@@ -18,46 +20,158 @@ func singleDPoPHeader(r *http.Request) (header string, err error) {
 	return r.Header.Get(consts.HeaderDPoP), nil
 }
 
-// requestURL reconstructs the request target URI (htu) from the request, discarding query and fragment. When the
-// request did not arrive over TLS directly it falls back to the X-Forwarded-Proto header to determine the scheme;
-// deployments MUST therefore ensure that header is set (and any client-supplied value stripped) by a trusted edge
-// proxy, otherwise a client could influence the reconstructed htu scheme.
+// requestURL reconstructs the request target URI (htu) from the request. It lives in the core package so the pushed
+// authorization request endpoint, which is handled there, reconstructs the htu identically; see oauth2.RequestURL for
+// the scheme and path caveats.
 func requestURL(r *http.Request) string {
-	scheme := consts.SchemeHTTPS
-
-	if r.TLS == nil {
-		if proto := r.Header.Get(consts.HeaderXForwardedProto); proto != "" {
-			scheme = proto
-		} else {
-			scheme = consts.SchemeHTTP
-		}
-	}
-
-	host := r.Host
-	if host == "" {
-		host = r.URL.Host
-	}
-
-	return scheme + "://" + host + r.URL.Path
+	return oauth2.RequestURL(r)
 }
 
+// normalizeHTU prepares an absolute URI for the RFC 9449 4.3 'htu' comparison. RFC 9449 requires servers to apply
+// syntax-based normalization (RFC 3986 Section 6.2.2) and scheme-based normalization (RFC 3986 Section 6.2.3) before
+// comparing, and to compare ignoring the query and fragment parts.
 func normalizeHTU(raw string) (string, error) {
 	u, err := url.Parse(raw)
 	if err != nil {
 		return "", err
 	}
 
+	if u.Scheme == "" || u.Host == "" {
+		return "", errors.New("the URI is not absolute")
+	}
+
 	u.RawQuery = ""
 	u.Fragment = ""
+	u.RawFragment = ""
 	u.ForceQuery = false
+
+	// RFC 3986 6.2.2.1: the scheme and host are case-insensitive.
 	u.Scheme = strings.ToLower(u.Scheme)
 	host := strings.ToLower(u.Host)
 
+	// RFC 3986 6.2.3: an empty port and the scheme's default port are equivalent to no port at all.
 	if (u.Scheme == consts.SchemeHTTPS && strings.HasSuffix(host, ":443")) || (u.Scheme == consts.SchemeHTTP && strings.HasSuffix(host, ":80")) {
 		host = host[:strings.LastIndex(host, ":")]
 	}
 
 	u.Host = host
 
+	// RFC 3986 6.2.2.2 then 6.2.2.3, in that order: decoding the percent-encoded unreserved characters first is what
+	// makes an encoded dot-segment such as '/%2E%2E/' visible to the segment normalization that follows. Both operate
+	// on the escaped path so that an encoded delimiter (notably '%2F') is never conflated with a real one.
+	path := removeDotSegments(normalizePercentEncoding(u.EscapedPath()))
+
+	// RFC 3986 6.2.3: for http(s) an empty path is equivalent to '/'.
+	if path == "" {
+		path = "/"
+	}
+
+	if u.Path, err = url.PathUnescape(path); err != nil {
+		return "", err
+	}
+
+	u.RawPath = path
+
 	return u.String(), nil
+}
+
+const upperhex = "0123456789ABCDEF"
+
+// normalizePercentEncoding applies RFC 3986 Section 6.2.2.1 and 6.2.2.2 to an escaped path: the hexadecimal digits of
+// a percent-encoding triplet are upper-cased, and a triplet encoding an unreserved character is decoded to it.
+func normalizePercentEncoding(path string) string {
+	var b strings.Builder
+
+	b.Grow(len(path))
+
+	for i := 0; i < len(path); i++ {
+		if path[i] != '%' || i+2 >= len(path) || !ishex(path[i+1]) || !ishex(path[i+2]) {
+			b.WriteByte(path[i])
+
+			continue
+		}
+
+		c := unhex(path[i+1])<<4 | unhex(path[i+2])
+
+		if isunreserved(c) {
+			b.WriteByte(c)
+		} else {
+			b.WriteByte('%')
+			b.WriteByte(upperhex[c>>4])
+			b.WriteByte(upperhex[c&0xF])
+		}
+
+		i += 2
+	}
+
+	return b.String()
+}
+
+// removeDotSegments implements the RFC 3986 Section 5.2.4 algorithm used by the path segment normalization of Section
+// 6.2.2.3. Unlike path.Clean it preserves a trailing slash and empty segments, both of which are significant.
+func removeDotSegments(path string) string {
+	out := make([]byte, 0, len(path))
+
+	for len(path) > 0 {
+		switch {
+		case strings.HasPrefix(path, "../"):
+			path = path[3:]
+		case strings.HasPrefix(path, "./"):
+			path = path[2:]
+		case strings.HasPrefix(path, "/./"):
+			path = path[2:]
+		case path == "/.":
+			path = "/"
+		case strings.HasPrefix(path, "/../"):
+			path = path[3:]
+			out = removeLastSegment(out)
+		case path == "/..":
+			path = "/"
+			out = removeLastSegment(out)
+		case path == "." || path == "..":
+			path = ""
+		default:
+			i := 1
+			if !strings.HasPrefix(path, "/") {
+				i = 0
+			}
+
+			if j := strings.IndexByte(path[i:], '/'); j < 0 {
+				out, path = append(out, path...), ""
+			} else {
+				out, path = append(out, path[:i+j]...), path[i+j:]
+			}
+		}
+	}
+
+	return string(out)
+}
+
+func removeLastSegment(out []byte) []byte {
+	if i := bytes.LastIndexByte(out, '/'); i >= 0 {
+		return out[:i]
+	}
+
+	return out[:0]
+}
+
+func ishex(c byte) bool {
+	return ('0' <= c && c <= '9') || ('a' <= c && c <= 'f') || ('A' <= c && c <= 'F')
+}
+
+func unhex(c byte) byte {
+	switch {
+	case '0' <= c && c <= '9':
+		return c - '0'
+	case 'a' <= c && c <= 'f':
+		return c - 'a' + 10
+	default:
+		return c - 'A' + 10
+	}
+}
+
+// isunreserved reports whether c is an RFC 3986 Section 2.3 unreserved character, which is exactly the set that must
+// not remain percent-encoded in a normalized URI.
+func isunreserved(c byte) bool {
+	return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9') || c == '-' || c == '.' || c == '_' || c == '~'
 }

--- a/handler/rfc9449/util_test.go
+++ b/handler/rfc9449/util_test.go
@@ -118,6 +118,27 @@ func TestRequestURL(t *testing.T) {
 			rawURL: "https://as.example.com/token?access_token=secret",
 			want:   "https://as.example.com/token",
 		},
+		{
+			name:   "PreservesEncodedQueryDelimiter",
+			tls:    true,
+			host:   "as.example.com",
+			rawURL: "https://as.example.com/token%3Fx=1",
+			want:   "https://as.example.com/token%3Fx=1",
+		},
+		{
+			name:   "PreservesEncodedFragmentDelimiter",
+			tls:    true,
+			host:   "as.example.com",
+			rawURL: "https://as.example.com/token%23frag",
+			want:   "https://as.example.com/token%23frag",
+		},
+		{
+			name:   "PreservesEncodedSpace",
+			tls:    true,
+			host:   "as.example.com",
+			rawURL: "https://as.example.com/to%20ken",
+			want:   "https://as.example.com/to%20ken",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -188,8 +209,63 @@ func TestNormalizeHTU(t *testing.T) {
 			want: "https://as.example.com/token",
 		},
 		{
+			name: "RemovesParentDotSegments",
+			raw:  "https://as.example.com/token/../admin",
+			want: "https://as.example.com/admin",
+		},
+		{
+			name: "RemovesCurrentDotSegments",
+			raw:  "https://as.example.com/./token",
+			want: "https://as.example.com/token",
+		},
+		{
+			name: "RemovesPercentEncodedDotSegments",
+			raw:  "https://as.example.com/token/%2E%2E/admin",
+			want: "https://as.example.com/admin",
+		},
+		{
+			name: "PreservesEmptySegments",
+			raw:  "https://as.example.com/a//token",
+			want: "https://as.example.com/a//token",
+		},
+		{
+			name: "PreservesTrailingSlash",
+			raw:  "https://as.example.com/token/",
+			want: "https://as.example.com/token/",
+		},
+		{
+			name: "DecodesUnreservedPercentEncoding",
+			raw:  "https://as.example.com/%7Etoken",
+			want: "https://as.example.com/~token",
+		},
+		{
+			name: "UppercasesPercentEncoding",
+			raw:  "https://as.example.com/a%2fb",
+			want: "https://as.example.com/a%2Fb",
+		},
+		{
+			name: "PreservesEncodedSlash",
+			raw:  "https://as.example.com/a%2Fb",
+			want: "https://as.example.com/a%2Fb",
+		},
+		{
+			name: "AddsRootPathWhenEmpty",
+			raw:  "https://as.example.com",
+			want: "https://as.example.com/",
+		},
+		{
 			name:    "ParseError",
 			raw:     "http://[::1",
+			wantErr: true,
+		},
+		{
+			name:    "RejectsRelativeURI",
+			raw:     "/token",
+			wantErr: true,
+		},
+		{
+			name:    "RejectsMissingHost",
+			raw:     "https:///token",
 			wantErr: true,
 		},
 	}
@@ -204,6 +280,56 @@ func TestNormalizeHTU(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestRemoveDotSegments(t *testing.T) {
+	testCases := []struct {
+		path string
+		want string
+	}{
+		{path: "/a/b/c/./../../g", want: "/a/g"},
+		{path: "/a/b/c/../../../g", want: "/g"},
+		{path: "/../a", want: "/a"},
+		{path: "/a/..", want: "/"},
+		{path: "/a/../..", want: "/"},
+		{path: "/a/b/", want: "/a/b/"},
+		{path: "/a/b/.", want: "/a/b/"},
+		{path: "/a/b/..", want: "/a/"},
+		{path: "/", want: "/"},
+		{path: "//a", want: "//a"},
+		{path: "/a//", want: "/a//"},
+		{path: "/.", want: "/"},
+		{path: "/..", want: "/"},
+		{path: "", want: ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.path, func(t *testing.T) {
+			assert.Equal(t, tc.want, removeDotSegments(tc.path))
+		})
+	}
+}
+
+func TestNormalizePercentEncoding(t *testing.T) {
+	testCases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "Unchanged", path: "/token", want: "/token"},
+		{name: "DecodesUnreserved", path: "/%7E%61%2D%2E%5F", want: "/~a-._"},
+		{name: "UppercasesReserved", path: "/a%2fb%3fc", want: "/a%2Fb%3Fc"},
+		{name: "KeepsReservedEncoded", path: "/a%2Fb", want: "/a%2Fb"},
+		{name: "IgnoresTruncatedTriplet", path: "/a%2", want: "/a%2"},
+		{name: "IgnoresNonHexTriplet", path: "/a%zzb", want: "/a%zzb"},
+		{name: "Empty", path: "", want: ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, normalizePercentEncoding(tc.path))
 		})
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,7 +195,6 @@ packages:
   prettier@3.9.6:
     resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
     engines: {node: '>=14'}
-    hasBin: true
 
   read-installed@4.0.3:
     resolution: {integrity: sha512-O03wg/IYuV/VtnK2h/KXEt9VIbMUFbk3ERG0Iu4FhLZw0EP0T9znqrYDGn6ncbEsXUFaUjiVAWXHzxwt3lhRPQ==}

--- a/pushed_authorize_request_handler.go
+++ b/pushed_authorize_request_handler.go
@@ -73,5 +73,62 @@ func (f *Fosite) NewPushedAuthorizeRequest(ctx context.Context, r *http.Request)
 		return frequest, errorsx.WithStack(ErrInvalidRequest.WithHint("Query parameter 'redirect_uri' is required when performing an OpenID Connect flow."))
 	}
 
+	if err = f.handlePushedAuthorizeRequestDPoP(ctx, r, frequest); err != nil {
+		return frequest, err
+	}
+
 	return frequest, nil
+}
+
+// handlePushedAuthorizeRequestDPoP implements RFC 9449 Section 10.1 at the pushed authorization request endpoint. A
+// client may commit to a DPoP proof-of-possession key either by sending the 'dpop_jkt' parameter or by presenting a
+// DPoP proof, and when a proof is presented the authorization server MUST check it and MUST then behave as if its
+// public key thumbprint had been supplied via 'dpop_jkt'. It does so by writing the thumbprint into the pushed request
+// form, which Request.Merge copies onto the authorization request when the 'request_uri' is later redeemed, so the
+// binding reaches rfc9449.AuthorizeHandler by the same route as a directly supplied 'dpop_jkt'.
+//
+// This lives here rather than in a pushed authorize endpoint handler because the proof arrives in an HTTP header and
+// NewPushedAuthorizeResponse, where those handlers run, is not given the request.
+func (f *Fosite) handlePushedAuthorizeRequestDPoP(ctx context.Context, r *http.Request, request AuthorizeRequester) (err error) {
+	if !f.Config.GetDPoPEnabled(ctx) {
+		return nil
+	}
+
+	strategy := f.Config.GetDPoPStrategy(ctx)
+	if strategy == nil {
+		return nil
+	}
+
+	// Validated here as well as at the authorization endpoint so a malformed value is reported against the request
+	// that supplied it, rather than surfacing later as a redirect borne error against the redeemed 'request_uri'.
+	if jkt := request.GetRequestForm().Get(consts.FormParameterDPoPJKT); jkt != "" && !IsValidDPoPJWKThumbprint(jkt) {
+		return errorsx.WithStack(ErrInvalidRequest.WithHintf("The 'dpop_jkt' parameter must be the base64url encoded SHA-256 JWK Thumbprint of the DPoP proof-of-possession public key, which is %d characters long.", DPoPJWKThumbprintLength))
+	}
+
+	// RFC 9449 Section 4.3 step 1.
+	if len(r.Header.Values(consts.HeaderDPoP)) > 1 {
+		return errorsx.WithStack(ErrInvalidDPoPProof.WithHint("The request contains more than one DPoP proof but only one is allowed."))
+	}
+
+	proof := r.Header.Get(consts.HeaderDPoP)
+	if proof == "" {
+		// A bare 'dpop_jkt' without a proof is legitimate; it is carried through to the authorization request as sent.
+		return nil
+	}
+
+	var parsed *DPoPProof
+
+	if parsed, err = strategy.ValidateDPoPProof(ctx, r.Method, RequestURL(r), proof, f.Config.GetDPoPNonceRequired(ctx)); err != nil {
+		return err
+	}
+
+	// RFC 9449 Section 10.1: when both are supplied the request MUST be rejected unless they agree, otherwise the
+	// authorization code would be bound to a key the client did not prove possession of.
+	if jkt := request.GetRequestForm().Get(consts.FormParameterDPoPJKT); jkt != "" && jkt != parsed.Thumbprint {
+		return errorsx.WithStack(ErrInvalidRequest.WithHint("The 'dpop_jkt' parameter does not match the thumbprint of the public key in the DPoP proof."))
+	}
+
+	request.GetRequestForm().Set(consts.FormParameterDPoPJKT, parsed.Thumbprint)
+
+	return nil
 }

--- a/pushed_authorize_response_writer.go
+++ b/pushed_authorize_response_writer.go
@@ -74,6 +74,17 @@ func (f *Fosite) WritePushedAuthorizeError(ctx context.Context, rw http.Response
 	rw.Header().Set(consts.HeaderPragma, consts.PragmaNoCache)
 	rw.Header().Set(consts.HeaderContentType, consts.ContentTypeApplicationJSON)
 
+	// RFC 9449 Section 8: a nonce is demanded with the 'use_dpop_nonce' error, and the nonce to retry with is supplied
+	// in the DPoP-Nonce header. Without it a client that presented a proof to this endpoint while nonces are required
+	// has no way to learn the value it must include, so the request could never succeed.
+	if f.isErrUseDPoPNonce(ctx, err) {
+		if strategy := f.Config.GetDPoPStrategy(ctx); strategy != nil {
+			if nonce, nonceErr := strategy.NewDPoPNonce(ctx); nonceErr == nil {
+				rw.Header().Set(consts.HeaderDPoPNonce, nonce)
+			}
+		}
+	}
+
 	rfcerr := ErrorToRFC6749Error(err).WithLegacyFormat(f.Config.GetUseLegacyErrorFormat(ctx)).
 		WithExposeDebug(f.Config.GetSendDebugMessagesToClients(ctx)).WithLocalizer(f.Config.GetMessageCatalog(ctx), getLangFromRequester(request))
 

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -38,25 +38,32 @@ type PublicKeyScopes struct {
 	Scopes []string
 }
 
+// DPoPProofMarker identifies a used DPoP proof for replay detection. RFC 9449 requires a 'jti' to be unique only
+// within the context it is presented in, so the marker is the proof key thumbprint, the normalized target URI, and
+// the 'jti' together rather than the 'jti' alone. See rfc9449.DPoPReplayStorage.
+type DPoPProofMarker struct {
+	Thumbprint string
+	URL        string
+	JTI        string
+}
+
 type MemoryStore struct {
-	Clients         map[string]oauth2.Client
-	AuthorizeCodes  map[string]StoreAuthorizeCode
-	IDSessions      map[string]oauth2.Requester
-	AccessTokens    map[string]oauth2.Requester
-	RefreshTokens   map[string]StoreRefreshToken
-	DeviceCodes     map[string]oauth2.Requester
-	UserCodes       map[string]oauth2.Requester
-	PKCES           map[string]oauth2.Requester
-	Users           map[string]MemoryUserRelation
-	BlacklistedJTIs map[string]time.Time
-	// In-memory request ID to token signatures
+	Clients                map[string]oauth2.Client
+	AuthorizeCodes         map[string]StoreAuthorizeCode
+	IDSessions             map[string]oauth2.Requester
+	AccessTokens           map[string]oauth2.Requester
+	RefreshTokens          map[string]StoreRefreshToken
+	DeviceCodes            map[string]oauth2.Requester
+	UserCodes              map[string]oauth2.Requester
+	PKCES                  map[string]oauth2.Requester
+	Users                  map[string]MemoryUserRelation
+	BlacklistedJTIs        map[string]time.Time
 	AccessTokenRequestIDs  map[string]string
 	RefreshTokenRequestIDs map[string]string
-	// Public keys to check signature in auth grant jwt assertion.
-	IssuerPublicKeys map[string]IssuerPublicKeys
-	PARSessions      map[string]oauth2.AuthorizeRequester
-	DPoPProofJTIs    map[string]time.Time
-	DPoPNonces       map[string]time.Time
+	IssuerPublicKeys       map[string]IssuerPublicKeys
+	PARSessions            map[string]oauth2.AuthorizeRequester
+	DPoPProofJTIs          map[DPoPProofMarker]time.Time
+	DPoPNonces             map[string]time.Time
 
 	clientsMutex                sync.RWMutex
 	authorizeCodesMutex         sync.RWMutex
@@ -91,7 +98,7 @@ func NewMemoryStore() *MemoryStore {
 		BlacklistedJTIs:        make(map[string]time.Time),
 		IssuerPublicKeys:       make(map[string]IssuerPublicKeys),
 		PARSessions:            make(map[string]oauth2.AuthorizeRequester),
-		DPoPProofJTIs:          make(map[string]time.Time),
+		DPoPProofJTIs:          make(map[DPoPProofMarker]time.Time),
 		DPoPNonces:             make(map[string]time.Time),
 	}
 }
@@ -158,6 +165,8 @@ func NewExampleStore() *MemoryStore {
 		RefreshTokenRequestIDs: map[string]string{},
 		IssuerPublicKeys:       map[string]IssuerPublicKeys{},
 		PARSessions:            map[string]oauth2.AuthorizeRequester{},
+		DPoPProofJTIs:          map[DPoPProofMarker]time.Time{},
+		DPoPNonces:             map[string]time.Time{},
 	}
 }
 
@@ -617,15 +626,24 @@ func (s *MemoryStore) InvalidateDeviceCodeSession(_ context.Context, signature s
 	return nil
 }
 
-func (s *MemoryStore) CheckAndSetDPoPProofUsed(_ context.Context, jti string, exp time.Time) (bool, error) {
+func (s *MemoryStore) CheckAndSetDPoPProofUsed(_ context.Context, thumbprint, htu, jti string, exp time.Time) (bool, error) {
 	s.dpopProofJTIsMutex.Lock()
 	defer s.dpopProofJTIsMutex.Unlock()
 
-	if existing, ok := s.DPoPProofJTIs[jti]; ok && existing.After(time.Now()) {
+	marker := DPoPProofMarker{Thumbprint: thumbprint, URL: htu, JTI: jti}
+
+	if existing, ok := s.DPoPProofJTIs[marker]; ok && existing.After(time.Now()) {
 		return true, nil
 	}
 
-	s.DPoPProofJTIs[jti] = exp
+	// delete expired markers
+	for m, e := range s.DPoPProofJTIs {
+		if e.Before(time.Now()) {
+			delete(s.DPoPProofJTIs, m)
+		}
+	}
+
+	s.DPoPProofJTIs[marker] = exp
 
 	return false, nil
 }
@@ -633,6 +651,13 @@ func (s *MemoryStore) CheckAndSetDPoPProofUsed(_ context.Context, jti string, ex
 func (s *MemoryStore) CreateDPoPNonce(_ context.Context, nonce string, exp time.Time) error {
 	s.dpopNoncesMutex.Lock()
 	defer s.dpopNoncesMutex.Unlock()
+
+	// delete expired nonces
+	for n, e := range s.DPoPNonces {
+		if e.Before(time.Now()) {
+			delete(s.DPoPNonces, n)
+		}
+	}
 
 	s.DPoPNonces[nonce] = exp
 

--- a/storage/memory_test.go
+++ b/storage/memory_test.go
@@ -67,20 +67,31 @@ func TestMemoryStoreDPoP(t *testing.T) {
 	ctx := context.Background()
 	s := NewMemoryStore()
 
-	// First use of a jti reports unused and records it.
-	used, err := s.CheckAndSetDPoPProofUsed(ctx, "jti-1", time.Now().Add(time.Minute))
+	const htu, other = "https://as.example.com/token", "https://as.example.com/introspect"
+
+	used, err := s.CheckAndSetDPoPProofUsed(ctx, "jkt-1", htu, "jti-1", time.Now().Add(time.Minute))
 	require.NoError(t, err)
 	assert.False(t, used)
 
-	// A second use of the same, still-valid jti reports used.
-	used, err = s.CheckAndSetDPoPProofUsed(ctx, "jti-1", time.Now().Add(time.Minute))
+	used, err = s.CheckAndSetDPoPProofUsed(ctx, "jkt-1", htu, "jti-1", time.Now().Add(time.Minute))
 	require.NoError(t, err)
 	assert.True(t, used)
 
-	// A jti whose recorded marker has expired is treated as unused (and re-recorded).
-	_, err = s.CheckAndSetDPoPProofUsed(ctx, "jti-2", time.Now().Add(-time.Minute))
+	used, err = s.CheckAndSetDPoPProofUsed(ctx, "jkt-2", htu, "jti-1", time.Now().Add(time.Minute))
 	require.NoError(t, err)
-	used, err = s.CheckAndSetDPoPProofUsed(ctx, "jti-2", time.Now().Add(time.Minute))
+	assert.False(t, used)
+
+	used, err = s.CheckAndSetDPoPProofUsed(ctx, "jkt-2", htu, "jti-1", time.Now().Add(time.Minute))
+	require.NoError(t, err)
+	assert.True(t, used)
+
+	used, err = s.CheckAndSetDPoPProofUsed(ctx, "jkt-1", other, "jti-1", time.Now().Add(time.Minute))
+	require.NoError(t, err)
+	assert.False(t, used)
+
+	_, err = s.CheckAndSetDPoPProofUsed(ctx, "jkt-1", htu, "jti-2", time.Now().Add(-time.Minute))
+	require.NoError(t, err)
+	used, err = s.CheckAndSetDPoPProofUsed(ctx, "jkt-1", htu, "jti-2", time.Now().Add(time.Minute))
 	require.NoError(t, err)
 	assert.False(t, used)
 
@@ -90,6 +101,40 @@ func TestMemoryStoreDPoP(t *testing.T) {
 
 	require.NoError(t, s.CreateDPoPNonce(ctx, "n-1", time.Now().Add(time.Minute)))
 	valid, err = s.IsDPoPNonceValid(ctx, "n-1")
+	require.NoError(t, err)
+	assert.True(t, valid)
+}
+
+func TestMemoryStoreDPoPPrunesExpiredRecords(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+
+	require.NoError(t, s.CreateDPoPNonce(ctx, "expired", time.Now().Add(-time.Minute)))
+	require.NoError(t, s.CreateDPoPNonce(ctx, "live", time.Now().Add(time.Minute)))
+
+	assert.NotContains(t, s.DPoPNonces, "expired")
+	assert.Contains(t, s.DPoPNonces, "live")
+
+	_, err := s.CheckAndSetDPoPProofUsed(ctx, "jkt-1", "https://as.example.com/token", "expired", time.Now().Add(-time.Minute))
+	require.NoError(t, err)
+	_, err = s.CheckAndSetDPoPProofUsed(ctx, "jkt-1", "https://as.example.com/token", "live", time.Now().Add(time.Minute))
+	require.NoError(t, err)
+
+	assert.NotContains(t, s.DPoPProofJTIs, DPoPProofMarker{Thumbprint: "jkt-1", URL: "https://as.example.com/token", JTI: "expired"})
+	assert.Contains(t, s.DPoPProofJTIs, DPoPProofMarker{Thumbprint: "jkt-1", URL: "https://as.example.com/token", JTI: "live"})
+}
+
+func TestExampleStoreSupportsDPoP(t *testing.T) {
+	ctx := context.Background()
+	s := NewExampleStore()
+
+	used, err := s.CheckAndSetDPoPProofUsed(ctx, "jkt-1", "https://as.example.com/token", "jti-1", time.Now().Add(time.Minute))
+	require.NoError(t, err)
+	assert.False(t, used)
+
+	require.NoError(t, s.CreateDPoPNonce(ctx, "n-1", time.Now().Add(time.Minute)))
+
+	valid, err := s.IsDPoPNonceValid(ctx, "n-1")
 	require.NoError(t, err)
 	assert.True(t, valid)
 }


### PR DESCRIPTION
This includes additional details from the spec including the HTTP URI in the DPoP JTI key, the inclusion of it at the Pushed Authorization Endpoint, etc.