### PR TITLE
feat: back-channel logout

### DIFF
--- a/backchannel_logout_request.go
+++ b/backchannel_logout_request.go
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2026 Authelia
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package oauth2
+
+// BackChannelLogoutRequester is a request to deliver Logout Tokens to the Relying Parties participating in a
+// session.
+//
+// The caller supplies the clients: this library does not track which clients participated in a session.
+//
+// See: https://openid.net/specs/openid-connect-backchannel-1_0.html
+type BackChannelLogoutRequester interface {
+	// GetSubject returns the 'sub' claim for the Logout Token, empty if absent.
+	GetSubject() (subject string)
+
+	// GetSessionID returns the 'sid' claim for the Logout Token, empty if absent.
+	GetSessionID() (sid string)
+
+	// GetClients returns the clients to notify.
+	GetClients() (clients []Client)
+
+	// GetExtra returns additional claims to include in every Logout Token.
+	GetExtra() (extra map[string]any)
+}
+
+// NewBackChannelLogoutRequest returns a BackChannelLogoutRequest with its map fields initialized.
+//
+// A Logout Token must carry either a subject or a session identifier; supplying neither is an error at send
+// time.
+func NewBackChannelLogoutRequest(subject, sid string, clients []Client) (request *BackChannelLogoutRequest) {
+	return &BackChannelLogoutRequest{
+		Subject:   subject,
+		SessionID: sid,
+		Clients:   clients,
+		Extra:     map[string]any{},
+	}
+}
+
+// BackChannelLogoutRequest is an implementation of BackChannelLogoutRequester.
+type BackChannelLogoutRequest struct {
+	Subject   string
+	SessionID string
+	Clients   []Client
+	Extra     map[string]any
+}
+
+func (r *BackChannelLogoutRequest) GetSubject() (subject string) {
+	return r.Subject
+}
+
+func (r *BackChannelLogoutRequest) GetSessionID() (sid string) {
+	return r.SessionID
+}
+
+func (r *BackChannelLogoutRequest) GetClients() (clients []Client) {
+	return r.Clients
+}
+
+func (r *BackChannelLogoutRequest) GetExtra() (extra map[string]any) {
+	return r.Extra
+}
+
+// BackChannelLogoutResult is the outcome of delivering a Logout Token to a single Relying Party.
+//
+// A result is reported for every client supplied, in the order supplied, including clients that were skipped.
+type BackChannelLogoutResult struct {
+	// ClientID is the identifier of the client this result concerns.
+	ClientID string
+
+	// Skipped is true when the client was ineligible and no request was attempted.
+	Skipped bool
+
+	// Reason explains why the client was skipped. Empty when Skipped is false.
+	Reason string
+
+	// Status is the HTTP status code the Relying Party returned, zero when no response was received.
+	Status int
+
+	// Err is the signing or delivery failure for this client, nil on success.
+	Err error
+}
+
+// Success returns true when the Relying Party acknowledged the Logout Token.
+func (r BackChannelLogoutResult) Success() (ok bool) {
+	return !r.Skipped && r.Err == nil
+}
+
+// backChannelLogoutURI returns the client's back-channel logout URI, or the reason it is ineligible when it has
+// none registered or requires a session identifier that was not supplied.
+func backChannelLogoutURI(client Client, sid string) (uri string, reason string) {
+	c, ok := client.(BackChannelLogoutClient)
+	if !ok {
+		return "", "The OAuth 2.0 Client does not support OpenID Connect Back-Channel Logout."
+	}
+
+	if uri = c.GetBackChannelLogoutURI(); uri == "" {
+		return "", "The OAuth 2.0 Client does not have a registered 'backchannel_logout_uri'."
+	}
+
+	if c.GetBackChannelLogoutSessionRequired() && sid == "" {
+		return "", "The OAuth 2.0 Client requires the 'sid' claim but no session identifier was supplied."
+	}
+
+	return uri, ""
+}
+
+var (
+	_ BackChannelLogoutRequester = (*BackChannelLogoutRequest)(nil)
+)

--- a/backchannel_logout_request_handler.go
+++ b/backchannel_logout_request_handler.go
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: 2026 Authelia
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package oauth2
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/hashicorp/go-retryablehttp"
+
+	"authelia.com/provider/oauth2/internal/consts"
+	"authelia.com/provider/oauth2/x/errorsx"
+)
+
+// backChannelLogoutResponseBodyLimit bounds how much of a Relying Party's response body is drained. The body is
+// discarded, but draining it lets the connection be reused.
+const backChannelLogoutResponseBodyLimit = 1 << 16
+
+// SendBackChannelLogout delivers a Logout Token to each of the supplied clients, as per OpenID Connect
+// Back-Channel Logout 1.0.
+//
+// The caller supplies the clients: this library does not track which clients participated in a session, and
+// does not end any session. A result is returned for every client supplied, in the order supplied.
+//
+// Delivery is best effort. A Relying Party that is unreachable or that rejects the Logout Token is reported in
+// its own result and never fails the call, so one broken Relying Party cannot prevent the others being
+// notified. Only whole-operation failures are returned as err.
+//
+// Deliveries run concurrently, up to the configured concurrency limit. Each supplied Client and the requester's
+// Extra map are read concurrently from the delivery goroutines, and so must be safe for concurrent reads.
+//
+// See: https://openid.net/specs/openid-connect-backchannel-1_0.html
+func (f *Fosite) SendBackChannelLogout(ctx context.Context, requester BackChannelLogoutRequester) (results []BackChannelLogoutResult, err error) {
+	subject, sid := requester.GetSubject(), requester.GetSessionID()
+
+	// A Logout Token MUST contain either a 'sub' or a 'sid' claim, and MAY contain both.
+	if subject == "" && sid == "" {
+		return nil, errorsx.WithStack(ErrInvalidRequest.WithHint("A Logout Token must contain either the 'sub' or the 'sid' claim."))
+	}
+
+	clients := requester.GetClients()
+
+	// A session in which no client participates is an ordinary outcome, not an error.
+	if len(clients) == 0 {
+		return []BackChannelLogoutResult{}, nil
+	}
+
+	strategy := f.Config.GetBackChannelLogoutTokenStrategy(ctx)
+
+	if strategy == nil {
+		return nil, errorsx.WithStack(ErrServerError.WithDebug("Failed to send the Back-Channel Logout requests because the Back-Channel Logout token strategy is not configured."))
+	}
+
+	extra := requester.GetExtra()
+
+	concurrency := f.Config.GetBackChannelLogoutConcurrency(ctx)
+
+	if concurrency <= 0 {
+		concurrency = 1
+	}
+
+	results = make([]BackChannelLogoutResult, len(clients))
+
+	// Constructed once, outside the delivery loop, so every delivery shares a single underlying transport and
+	// connection pool. Constructing it per delivery (as GetHTTPClient's default of a nil Config.HTTPClient
+	// would otherwise force) would hand each Relying Party a brand-new retryablehttp client with no connection
+	// reuse at all.
+	client := backChannelLogoutHTTPClient(f.Config.GetHTTPClient(ctx))
+
+	var wg sync.WaitGroup
+
+	sem := make(chan struct{}, concurrency)
+
+	for i, c := range clients {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			sem <- struct{}{}
+
+			defer func() { <-sem }()
+
+			// Each goroutine writes its own index, so no synchronisation of results is required and the order
+			// always matches the order the clients were supplied in.
+			results[i] = f.sendBackChannelLogout(ctx, strategy, client, c, subject, sid, extra)
+		}()
+	}
+
+	wg.Wait()
+
+	return results, nil
+}
+
+// sendBackChannelLogout generates and delivers a single Logout Token, reporting every failure in the result
+// rather than returning it.
+func (f *Fosite) sendBackChannelLogout(ctx context.Context, strategy BackChannelLogoutTokenStrategy, httpClient *retryablehttp.Client, client Client, subject, sid string, extra map[string]any) (result BackChannelLogoutResult) {
+	result.ClientID = client.GetID()
+
+	uri, reason := backChannelLogoutURI(client, sid)
+
+	if reason != "" {
+		result.Skipped, result.Reason = true, reason
+
+		return result
+	}
+
+	var (
+		token string
+		err   error
+	)
+
+	// The audience names only this client, so each Relying Party receives a token with its own 'jti'.
+	if token, err = strategy.GenerateBackChannelLogoutToken(ctx, client, f.Config.GetBackChannelLogoutLifespan(ctx), subject, sid, []string{client.GetID()}, extra); err != nil {
+		result.Err = errorsx.WithStack(ErrServerError.WithHint("Failed to generate the Logout Token.").WithWrap(err).WithDebugError(err))
+
+		return result
+	}
+
+	result.Status, result.Err = postBackChannelLogout(ctx, httpClient, uri, token)
+
+	return result
+}
+
+// postBackChannelLogout performs the form encoded POST to a Relying Party's back-channel logout URI.
+func postBackChannelLogout(ctx context.Context, client *retryablehttp.Client, uri, token string) (status int, err error) {
+	body := url.Values{consts.FormParameterLogoutToken: []string{token}}
+
+	var request *retryablehttp.Request
+
+	if request, err = retryablehttp.NewRequestWithContext(ctx, http.MethodPost, uri, strings.NewReader(body.Encode())); err != nil {
+		return 0, errorsx.WithStack(ErrServerError.WithHint("Failed to create the Back-Channel Logout request.").WithWrap(err).WithDebugError(err))
+	}
+
+	request.Header.Set(consts.HeaderContentType, consts.ContentTypeApplicationURLEncodedForm)
+
+	var response *http.Response
+
+	if response, err = client.Do(request); err != nil {
+		return 0, errorsx.WithStack(ErrServerError.WithHint("Failed to perform the Back-Channel Logout request.").WithWrap(err).WithDebugError(err))
+	}
+
+	defer response.Body.Close()
+
+	// Drain a bounded amount of the body so the connection can be reused; the content is not used.
+	_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, backChannelLogoutResponseBodyLimit))
+
+	// The specification requires 200 on success and 400 on failure, and warns that some frameworks substitute
+	// 204 for 200 when the body is empty. Nothing else is sanctioned, so nothing else is treated as success.
+	switch response.StatusCode {
+	case http.StatusOK, http.StatusNoContent:
+		return response.StatusCode, nil
+	default:
+		return response.StatusCode, errorsx.WithStack(ErrServerError.WithHintf("The Relying Party responded with status code '%d', expected '200' or '204'.", response.StatusCode))
+	}
+}
+
+// backChannelLogoutHTTPClient returns a client configured like base, except that it always returns the final
+// response and error rather than discarding the response once retries are exhausted, and never follows
+// redirects.
+//
+// The default ErrorHandler closes the body and synthesizes a generic "giving up" error once retries run out,
+// even when a response was received (for example a Relying Party's default retry policy treats a 500 response
+// as retryable, but discards the 500 response itself when no more retries remain). Back-Channel Logout results
+// report the Relying Party's actual status code, so the response must be preserved. A fresh value is
+// constructed rather than mutating base's ErrorHandler, because base is shared across concurrent deliveries and
+// across calls to SendBackChannelLogout.
+//
+// The wrapped *http.Client is likewise a copy of base.HTTPClient, never base.HTTPClient itself, with
+// CheckRedirect overridden so that a 3xx response is returned as-is instead of being followed: a registered
+// Relying Party could otherwise use a 307 or 308 (which Go's client replays with the same method and body) to
+// forward the signed Logout Token to a host that never registered to receive it. Copying rather than mutating
+// base.HTTPClient in place means the integrator's own *http.Client, which may be shared and used elsewhere, is
+// never touched.
+func backChannelLogoutHTTPClient(base *retryablehttp.Client) (client *retryablehttp.Client) {
+	httpClient := &http.Client{}
+
+	if base.HTTPClient != nil {
+		copied := *base.HTTPClient
+		httpClient = &copied
+	}
+
+	httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	return &retryablehttp.Client{
+		HTTPClient:      httpClient,
+		Logger:          base.Logger,
+		RetryWaitMin:    base.RetryWaitMin,
+		RetryWaitMax:    base.RetryWaitMax,
+		RetryMax:        base.RetryMax,
+		RequestLogHook:  base.RequestLogHook,
+		ResponseLogHook: base.ResponseLogHook,
+		CheckRetry:      base.CheckRetry,
+		Backoff:         base.Backoff,
+		PrepareRetry:    base.PrepareRetry,
+		ErrorHandler:    retryablehttp.PassthroughErrorHandler,
+	}
+}

--- a/backchannel_logout_request_handler_test.go
+++ b/backchannel_logout_request_handler_test.go
@@ -1,0 +1,481 @@
+// SPDX-FileCopyrightText: 2026 Authelia
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package oauth2_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"authelia.com/provider/oauth2"
+	"authelia.com/provider/oauth2/handler/openid"
+	"authelia.com/provider/oauth2/internal/gen"
+	"authelia.com/provider/oauth2/storage"
+	"authelia.com/provider/oauth2/token/jwt"
+)
+
+func TestSendBackChannelLogout_RequiresSubjectOrSessionID(t *testing.T) {
+	f, _ := newBCLProvider(t)
+
+	client := bclClient("rp-1", "https://rp.example/logout", false)
+
+	_, err := f.SendBackChannelLogout(t.Context(), oauth2.NewBackChannelLogoutRequest("", "", []oauth2.Client{client}))
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, oauth2.ErrInvalidRequest)
+}
+
+func TestSendBackChannelLogout_RequiresStrategy(t *testing.T) {
+	f, config := newBCLProvider(t)
+
+	config.BackChannelLogoutTokenStrategy = nil
+
+	client := bclClient("rp-1", "https://rp.example/logout", false)
+
+	_, err := f.SendBackChannelLogout(t.Context(), oauth2.NewBackChannelLogoutRequest("alice", "", []oauth2.Client{client}))
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, oauth2.ErrServerError)
+}
+
+func TestSendBackChannelLogout_EmptyClientsIsNotAnError(t *testing.T) {
+	f, _ := newBCLProvider(t)
+
+	results, err := f.SendBackChannelLogout(t.Context(), oauth2.NewBackChannelLogoutRequest("alice", "", nil))
+
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestSendBackChannelLogout_DeliversAndAcceptsOKAndNoContent(t *testing.T) {
+	for name, status := range map[string]int{"OK": http.StatusOK, "NoContent": http.StatusNoContent} {
+		t.Run(name, func(t *testing.T) {
+			f, _ := newBCLProvider(t)
+
+			server, tokens := bclServer(t, status)
+
+			client := bclClient("rp-1", server.URL, false)
+
+			results, err := f.SendBackChannelLogout(t.Context(), oauth2.NewBackChannelLogoutRequest("alice", "session-1", []oauth2.Client{client}))
+
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+
+			assert.Equal(t, "rp-1", results[0].ClientID)
+			assert.True(t, results[0].Success())
+			assert.Equal(t, status, results[0].Status)
+			assert.NoError(t, results[0].Err)
+
+			require.Len(t, *tokens, 1)
+
+			header := decodeLogoutTokenHeader(t, (*tokens)[0])
+			assert.Equal(t, "logout+jwt", header["typ"])
+
+			claims := decodeLogoutToken(t, (*tokens)[0])
+
+			assert.Equal(t, "alice", claims["sub"])
+			assert.Equal(t, "session-1", claims["sid"])
+			assert.Equal(t, bclTestIssuer, claims["iss"])
+			assert.Equal(t, []any{"rp-1"}, claims["aud"])
+			assert.NotEmpty(t, claims["jti"])
+			assert.NotContains(t, claims, "nonce")
+
+			events, ok := claims["events"].(map[string]any)
+			require.True(t, ok)
+			assert.Contains(t, events, "http://schemas.openid.net/event/backchannel-logout")
+			assert.Empty(t, events["http://schemas.openid.net/event/backchannel-logout"])
+		})
+	}
+}
+
+func TestSendBackChannelLogout_ReportsNonSuccessStatus(t *testing.T) {
+	for name, status := range map[string]int{"BadRequest": http.StatusBadRequest, "ServerError": http.StatusInternalServerError, "Accepted": http.StatusAccepted} {
+		t.Run(name, func(t *testing.T) {
+			f, _ := newBCLProvider(t)
+
+			server, _ := bclServer(t, status)
+
+			client := bclClient("rp-1", server.URL, false)
+
+			results, err := f.SendBackChannelLogout(t.Context(), oauth2.NewBackChannelLogoutRequest("alice", "", []oauth2.Client{client}))
+
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+
+			assert.False(t, results[0].Success())
+			assert.Equal(t, status, results[0].Status)
+			assert.Error(t, results[0].Err)
+		})
+	}
+}
+
+func TestSendBackChannelLogout_ReportsUnreachableRelyingParty(t *testing.T) {
+	f, _ := newBCLProvider(t)
+
+	server, _ := bclServer(t, http.StatusOK)
+
+	uri := server.URL
+
+	server.Close()
+
+	client := bclClient("rp-1", uri, false)
+
+	results, err := f.SendBackChannelLogout(t.Context(), oauth2.NewBackChannelLogoutRequest("alice", "", []oauth2.Client{client}))
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.False(t, results[0].Success())
+	assert.Zero(t, results[0].Status)
+	assert.Error(t, results[0].Err)
+}
+
+func TestSendBackChannelLogout_SkipsIneligibleClients(t *testing.T) {
+	f, _ := newBCLProvider(t)
+
+	server, tokens := bclServer(t, http.StatusOK)
+
+	clients := []oauth2.Client{
+		bclClient("rp-eligible", server.URL, false),
+		bclClient("rp-no-uri", "", false),
+		bclClient("rp-needs-sid", server.URL, true),
+		&oauth2.DefaultClient{ID: "rp-not-a-bcl-client"},
+	}
+
+	results, err := f.SendBackChannelLogout(t.Context(), oauth2.NewBackChannelLogoutRequest("alice", "", clients))
+
+	require.NoError(t, err)
+	require.Len(t, results, 4)
+
+	assert.True(t, results[0].Success())
+	assert.False(t, results[0].Skipped)
+
+	for _, i := range []int{1, 2, 3} {
+		assert.True(t, results[i].Skipped, "index %d", i)
+		assert.NotEmpty(t, results[i].Reason, "index %d", i)
+		assert.Zero(t, results[i].Status, "index %d", i)
+		assert.False(t, results[i].Success(), "index %d", i)
+	}
+
+	assert.Equal(t, "rp-no-uri", results[1].ClientID)
+	assert.Contains(t, results[2].Reason, "sid")
+
+	assert.Len(t, *tokens, 1)
+}
+
+func TestSendBackChannelLogout_SessionRequiredSatisfiedBySessionID(t *testing.T) {
+	f, _ := newBCLProvider(t)
+
+	server, _ := bclServer(t, http.StatusOK)
+
+	client := bclClient("rp-1", server.URL, true)
+
+	results, err := f.SendBackChannelLogout(t.Context(), oauth2.NewBackChannelLogoutRequest("alice", "session-1", []oauth2.Client{client}))
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.True(t, results[0].Success())
+}
+
+func TestSendBackChannelLogout_MintsDistinctJTIPerClient(t *testing.T) {
+	f, _ := newBCLProvider(t)
+
+	server, tokens := bclServer(t, http.StatusOK)
+
+	clients := []oauth2.Client{
+		bclClient("rp-1", server.URL, false),
+		bclClient("rp-2", server.URL, false),
+	}
+
+	results, err := f.SendBackChannelLogout(t.Context(), oauth2.NewBackChannelLogoutRequest("alice", "", clients))
+
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	require.Len(t, *tokens, 2)
+
+	first, second := decodeLogoutToken(t, (*tokens)[0]), decodeLogoutToken(t, (*tokens)[1])
+
+	assert.NotEqual(t, first["jti"], second["jti"])
+
+	auds := []any{first["aud"], second["aud"]}
+
+	assert.Contains(t, auds, []any{"rp-1"})
+	assert.Contains(t, auds, []any{"rp-2"})
+}
+
+func TestSendBackChannelLogout_ResultsFollowInputOrder(t *testing.T) {
+	f, _ := newBCLProvider(t)
+
+	var counter int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt64(&counter, 1) == 1 {
+			time.Sleep(100 * time.Millisecond)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	t.Cleanup(server.Close)
+
+	clients := []oauth2.Client{
+		bclClient("rp-1", server.URL, false),
+		bclClient("rp-2", server.URL, false),
+		bclClient("rp-3", "", false),
+		bclClient("rp-4", server.URL, false),
+	}
+
+	results, err := f.SendBackChannelLogout(t.Context(), oauth2.NewBackChannelLogoutRequest("alice", "", clients))
+
+	require.NoError(t, err)
+	require.Len(t, results, 4)
+
+	for i, client := range clients {
+		assert.Equal(t, client.GetID(), results[i].ClientID, "index %d", i)
+	}
+
+	assert.True(t, results[2].Skipped)
+}
+
+func TestSendBackChannelLogout_RespectsConcurrencyLimit(t *testing.T) {
+	f, config := newBCLProvider(t)
+
+	config.BackChannelLogoutConcurrency = 2
+
+	var (
+		mu       sync.Mutex
+		current  int
+		observed int
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		current++
+
+		if current > observed {
+			observed = current
+		}
+		mu.Unlock()
+
+		time.Sleep(50 * time.Millisecond)
+
+		mu.Lock()
+		current--
+		mu.Unlock()
+
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	t.Cleanup(server.Close)
+
+	clients := make([]oauth2.Client, 0, 10)
+
+	for i := 0; i < 10; i++ {
+		clients = append(clients, bclClient("rp-"+strconv.Itoa(i), server.URL, false))
+	}
+
+	results, err := f.SendBackChannelLogout(t.Context(), oauth2.NewBackChannelLogoutRequest("alice", "", clients))
+
+	require.NoError(t, err)
+	require.Len(t, results, 10)
+
+	for i := range results {
+		assert.True(t, results[i].Success(), "index %d", i)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	assert.Equal(t, 2, observed)
+}
+
+func TestSendBackChannelLogout_HonoursContextCancellation(t *testing.T) {
+	f, _ := newBCLProvider(t)
+
+	release := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-release:
+		}
+	}))
+
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { close(release) })
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	client := bclClient("rp-1", server.URL, false)
+
+	results, err := f.SendBackChannelLogout(ctx, oauth2.NewBackChannelLogoutRequest("alice", "", []oauth2.Client{client}))
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.False(t, results[0].Success())
+	assert.Error(t, results[0].Err)
+}
+
+func TestSendBackChannelLogout_ReportsSigningFailure(t *testing.T) {
+	f, config := newBCLProvider(t)
+
+	config.BackChannelLogoutTokenStrategy = stubFailingBackChannelLogoutTokenStrategy{}
+
+	client := bclClient("rp-1", "https://rp.example/logout", false)
+
+	results, err := f.SendBackChannelLogout(t.Context(), oauth2.NewBackChannelLogoutRequest("alice", "", []oauth2.Client{client}))
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.Error(t, results[0].Err)
+	assert.Zero(t, results[0].Status)
+	assert.False(t, results[0].Skipped)
+	assert.False(t, results[0].Success())
+}
+
+func TestSendBackChannelLogout_DoesNotFollowRedirects(t *testing.T) {
+	f, _ := newBCLProvider(t)
+
+	var secondContacted int32
+
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&secondContacted, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(second.Close)
+
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, second.URL, http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(first.Close)
+
+	client := bclClient("rp-1", first.URL, false)
+
+	results, err := f.SendBackChannelLogout(t.Context(), oauth2.NewBackChannelLogoutRequest("alice", "", []oauth2.Client{client}))
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.False(t, results[0].Success())
+	assert.Equal(t, http.StatusTemporaryRedirect, results[0].Status)
+	assert.Error(t, results[0].Err)
+
+	assert.Zero(t, atomic.LoadInt32(&secondContacted), "the redirect target must never be contacted")
+}
+
+func TestRetryableHTTPClientFieldCount(t *testing.T) {
+	assert.Equal(t, 13, reflect.TypeOf(retryablehttp.Client{}).NumField(),
+		"retryablehttp.Client's field count changed: review backChannelLogoutHTTPClient in backchannel_logout_request_handler.go")
+}
+
+const bclTestIssuer = "https://op.example/"
+
+var bclTestKey = gen.MustRSAKey()
+
+type stubFailingBackChannelLogoutTokenStrategy struct{}
+
+func (stubFailingBackChannelLogoutTokenStrategy) GenerateBackChannelLogoutToken(ctx context.Context, client oauth2.Client, lifespan time.Duration, subject, sid string, audience []string, extra map[string]any) (token string, err error) {
+	return "", errors.New("signing failed")
+}
+
+func newBCLProvider(t *testing.T) (*oauth2.Fosite, *oauth2.Config) {
+	t.Helper()
+
+	config := &oauth2.Config{IDTokenIssuer: bclTestIssuer, MinParameterEntropy: 8}
+
+	jwtStrategy := &jwt.DefaultStrategy{Config: config, Issuer: jwt.NewDefaultIssuerRS256Unverified(bclTestKey)}
+
+	config.BackChannelLogoutTokenStrategy = &openid.DefaultStrategy{Strategy: jwtStrategy, Config: config}
+
+	client := retryablehttp.NewClient()
+	client.RetryMax = 0
+	client.Logger = nil
+
+	config.HTTPClient = client
+
+	return &oauth2.Fosite{Store: storage.NewMemoryStore(), Config: config}, config
+}
+
+func bclClient(id, uri string, sessionRequired bool) *oauth2.DefaultBackChannelLogoutClient {
+	return &oauth2.DefaultBackChannelLogoutClient{
+		DefaultClient:                    &oauth2.DefaultClient{ID: id},
+		BackChannelLogoutURI:             uri,
+		BackChannelLogoutSessionRequired: sessionRequired,
+	}
+}
+
+func bclServer(t *testing.T, status int) (server *httptest.Server, tokens *[]string) {
+	t.Helper()
+
+	var (
+		mu        sync.Mutex
+		collected []string
+	)
+
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+
+		require.NoError(t, r.ParseForm())
+
+		mu.Lock()
+		collected = append(collected, r.PostForm.Get("logout_token"))
+		mu.Unlock()
+
+		w.WriteHeader(status)
+	}))
+
+	t.Cleanup(server.Close)
+
+	return server, &collected
+}
+
+func decodeLogoutToken(t *testing.T, token string) map[string]any {
+	t.Helper()
+
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3)
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+
+	claims := map[string]any{}
+	require.NoError(t, json.Unmarshal(payload, &claims))
+
+	return claims
+}
+
+func decodeLogoutTokenHeader(t *testing.T, token string) map[string]any {
+	t.Helper()
+
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3)
+
+	header, err := base64.RawURLEncoding.DecodeString(parts[0])
+	require.NoError(t, err)
+
+	claims := map[string]any{}
+	require.NoError(t, json.Unmarshal(header, &claims))
+
+	return claims
+}

--- a/backchannel_logout_request_handler_test.go
+++ b/backchannel_logout_request_handler_test.go
@@ -303,7 +303,8 @@ func TestSendBackChannelLogout_RespectsConcurrencyLimit(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 
-	assert.Equal(t, 2, observed)
+	assert.Positive(t, observed)
+	assert.LessOrEqual(t, observed, 2)
 }
 
 func TestSendBackChannelLogout_HonoursContextCancellation(t *testing.T) {

--- a/backchannel_logout_request_test.go
+++ b/backchannel_logout_request_test.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 Authelia
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package oauth2_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"authelia.com/provider/oauth2"
+)
+
+func TestNewBackChannelLogoutRequest(t *testing.T) {
+	client := &oauth2.DefaultBackChannelLogoutClient{DefaultClient: &oauth2.DefaultClient{ID: "rp-1"}}
+
+	request := oauth2.NewBackChannelLogoutRequest("alice", "session-1", []oauth2.Client{client})
+
+	assert.Equal(t, "alice", request.GetSubject())
+	assert.Equal(t, "session-1", request.GetSessionID())
+	assert.Len(t, request.GetClients(), 1)
+	assert.NotNil(t, request.GetExtra())
+	assert.Empty(t, request.GetExtra())
+
+	var requester oauth2.BackChannelLogoutRequester = request
+
+	assert.Equal(t, "alice", requester.GetSubject())
+}
+
+func TestBackChannelLogoutResultSuccess(t *testing.T) {
+	testCases := []struct {
+		name     string
+		result   oauth2.BackChannelLogoutResult
+		expected bool
+	}{
+		{"ShouldSucceedWhenDelivered", oauth2.BackChannelLogoutResult{Status: 200}, true},
+		{"ShouldFailWhenSkipped", oauth2.BackChannelLogoutResult{Skipped: true, Reason: "x"}, false},
+		{"ShouldFailWhenErrored", oauth2.BackChannelLogoutResult{Err: assert.AnError}, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.result.Success())
+		})
+	}
+}

--- a/client.go
+++ b/client.go
@@ -354,6 +354,25 @@ type RPInitiatedLogoutClient interface {
 	GetPostLogoutRedirectURIs() (uris []string)
 }
 
+// BackChannelLogoutClient is a Client which has registered a back-channel logout URI for OpenID Connect
+// Back-Channel Logout.
+//
+// As with post_logout_redirect_uris, this library does not validate the registered backchannel_logout_uri's
+// scheme, host, or exposure to SSRF; validating it at registration time is the integrator's responsibility.
+//
+// See: https://openid.net/specs/openid-connect-backchannel-1_0.html
+type BackChannelLogoutClient interface {
+	Client
+
+	// GetBackChannelLogoutURI returns the client's registered back-channel logout URI. A client with none
+	// registered does not participate in back-channel logout.
+	GetBackChannelLogoutURI() (uri string)
+
+	// GetBackChannelLogoutSessionRequired returns true when the client requires the 'sid' claim in the Logout
+	// Token. When it does and no session identifier is available the client is not notified.
+	GetBackChannelLogoutSessionRequired() (required bool)
+}
+
 // JWTProfileClient represents a client with can handle RFC9068 responses; i.e. the JWT Profile for OAuth 2.0 Access
 // Tokens.
 type JWTProfileClient interface {
@@ -489,7 +508,6 @@ type DefaultClient struct {
 }
 
 type DefaultJARClient struct {
-	*DefaultClient
 	JSONWebKeysURI                                   string              `json:"jwks_uri"`
 	JSONWebKeys                                      *jose.JSONWebKeySet `json:"jwks"`
 	TokenEndpointAuthMethod                          string              `json:"token_endpoint_auth_method"`
@@ -507,16 +525,27 @@ type DefaultJARClient struct {
 	IntrospectionEndpointAuthSigningAlg              string              `json:"introspection_endpoint_auth_signing_alg"`
 	RevocationEndpointAuthSigningAlg                 string              `json:"revocation_endpoint_auth_signing_alg"`
 	PushedAuthorizationRequestEndpointAuthSigningAlg string              `json:"pushed_authorization_request_endpoint_auth_signing_alg"`
+
+	*DefaultClient
 }
 
 type DefaultResponseModeClient struct {
-	*DefaultClient
 	ResponseModes []ResponseModeType `json:"response_modes"`
+
+	*DefaultClient
 }
 
 type DefaultRPInitiatedLogoutClient struct {
-	*DefaultClient
 	PostLogoutRedirectURIs []string `json:"post_logout_redirect_uris"`
+
+	*DefaultClient
+}
+
+type DefaultBackChannelLogoutClient struct {
+	BackChannelLogoutURI             string `json:"backchannel_logout_uri"`
+	BackChannelLogoutSessionRequired bool   `json:"backchannel_logout_session_required"`
+
+	*DefaultClient
 }
 
 func (c *DefaultClient) GetID() string {
@@ -673,9 +702,18 @@ func (c *DefaultRPInitiatedLogoutClient) GetPostLogoutRedirectURIs() (uris []str
 	return c.PostLogoutRedirectURIs
 }
 
+func (c *DefaultBackChannelLogoutClient) GetBackChannelLogoutURI() (uri string) {
+	return c.BackChannelLogoutURI
+}
+
+func (c *DefaultBackChannelLogoutClient) GetBackChannelLogoutSessionRequired() (required bool) {
+	return c.BackChannelLogoutSessionRequired
+}
+
 var (
 	_ Client                  = (*DefaultClient)(nil)
 	_ ResponseModeClient      = (*DefaultResponseModeClient)(nil)
 	_ JARClient               = (*DefaultJARClient)(nil)
 	_ RPInitiatedLogoutClient = (*DefaultRPInitiatedLogoutClient)(nil)
+	_ BackChannelLogoutClient = (*DefaultBackChannelLogoutClient)(nil)
 )

--- a/client_test.go
+++ b/client_test.go
@@ -66,3 +66,26 @@ func TestDefaultRPInitiatedLogoutClient(t *testing.T) {
 	_, ok := any(&DefaultClient{}).(RPInitiatedLogoutClient)
 	assert.False(t, ok, "DefaultClient must not satisfy RPInitiatedLogoutClient")
 }
+
+func TestDefaultBackChannelLogoutClient(t *testing.T) {
+	client := &DefaultBackChannelLogoutClient{
+		DefaultClient:                    &DefaultClient{ID: "rp-1"},
+		BackChannelLogoutURI:             "https://rp.example/backchannel-logout",
+		BackChannelLogoutSessionRequired: true,
+	}
+
+	assert.Equal(t, "rp-1", client.GetID())
+	assert.Equal(t, "https://rp.example/backchannel-logout", client.GetBackChannelLogoutURI())
+	assert.True(t, client.GetBackChannelLogoutSessionRequired())
+
+	var iface BackChannelLogoutClient = client
+
+	assert.Equal(t, "https://rp.example/backchannel-logout", iface.GetBackChannelLogoutURI())
+}
+
+func TestDefaultBackChannelLogoutClientDefaults(t *testing.T) {
+	client := &DefaultBackChannelLogoutClient{DefaultClient: &DefaultClient{ID: "rp-2"}}
+
+	assert.Equal(t, "", client.GetBackChannelLogoutURI())
+	assert.False(t, client.GetBackChannelLogoutSessionRequired())
+}

--- a/config.go
+++ b/config.go
@@ -109,6 +109,28 @@ type IDTokenValidationStrategyProvider interface {
 	GetIDTokenValidationStrategy(ctx context.Context) (strategy TokenValidationStrategy)
 }
 
+// BackChannelLogoutTokenStrategyProvider returns the provider for configuring the Back-Channel Logout token
+// strategy, which generates the Logout Tokens delivered to Relying Parties.
+type BackChannelLogoutTokenStrategyProvider interface {
+	// GetBackChannelLogoutTokenStrategy returns the Back-Channel Logout token strategy. Has no default and may
+	// be nil.
+	GetBackChannelLogoutTokenStrategy(ctx context.Context) (strategy BackChannelLogoutTokenStrategy)
+}
+
+// BackChannelLogoutLifespanProvider returns the provider for configuring the Logout Token lifespan.
+type BackChannelLogoutLifespanProvider interface {
+	// GetBackChannelLogoutLifespan returns the Logout Token lifespan. Defaults to 5 minutes.
+	GetBackChannelLogoutLifespan(ctx context.Context) (lifespan time.Duration)
+}
+
+// BackChannelLogoutConcurrencyProvider returns the provider for configuring how many Back-Channel Logout
+// requests are delivered concurrently.
+type BackChannelLogoutConcurrencyProvider interface {
+	// GetBackChannelLogoutConcurrency returns the maximum number of Back-Channel Logout requests delivered
+	// concurrently. Defaults to 10.
+	GetBackChannelLogoutConcurrency(ctx context.Context) (n int)
+}
+
 // IntrospectionIssuerProvider returns the provider for configuring the Introspection issuer.
 type IntrospectionIssuerProvider interface {
 	// GetIntrospectionIssuer returns the Introspection token issuer.

--- a/config_default.go
+++ b/config_default.go
@@ -19,8 +19,10 @@ import (
 )
 
 const (
-	defaultPARPrefix          = consts.PrefixRequestURI
-	defaultPARContextLifetime = 5 * time.Minute
+	defaultPARPrefix                    = consts.PrefixRequestURI
+	defaultPARContextLifetime           = 5 * time.Minute
+	defaultBackChannelLogoutLifespan    = 5 * time.Minute
+	defaultBackChannelLogoutConcurrency = 10
 )
 
 type Config struct {
@@ -61,6 +63,17 @@ type Config struct {
 	// IDTokenValidationStrategy validates ID Tokens presented to the authorization server by a client, such as the
 	// 'id_token_hint' of an RP-Initiated Logout request. Has no default.
 	IDTokenValidationStrategy TokenValidationStrategy
+
+	// BackChannelLogoutTokenStrategy generates the Logout Tokens delivered to Relying Parties for OpenID
+	// Connect Back-Channel Logout. Has no default.
+	BackChannelLogoutTokenStrategy BackChannelLogoutTokenStrategy
+
+	// BackChannelLogoutLifespan is the lifespan of a Logout Token. Defaults to 5 minutes.
+	BackChannelLogoutLifespan time.Duration
+
+	// BackChannelLogoutConcurrency is the maximum number of Back-Channel Logout requests delivered
+	// concurrently. Defaults to 10.
+	BackChannelLogoutConcurrency int
 
 	// HashCost sets the cost of the password hashing cost. Defaults to 12.
 	HashCost int
@@ -387,6 +400,26 @@ func (c *Config) GetIDTokenIssuer(ctx context.Context) string {
 
 func (c *Config) GetIDTokenValidationStrategy(ctx context.Context) (strategy TokenValidationStrategy) {
 	return c.IDTokenValidationStrategy
+}
+
+func (c *Config) GetBackChannelLogoutTokenStrategy(ctx context.Context) (strategy BackChannelLogoutTokenStrategy) {
+	return c.BackChannelLogoutTokenStrategy
+}
+
+func (c *Config) GetBackChannelLogoutLifespan(ctx context.Context) (lifespan time.Duration) {
+	if c.BackChannelLogoutLifespan <= 0 {
+		return defaultBackChannelLogoutLifespan
+	}
+
+	return c.BackChannelLogoutLifespan
+}
+
+func (c *Config) GetBackChannelLogoutConcurrency(ctx context.Context) (n int) {
+	if c.BackChannelLogoutConcurrency <= 0 {
+		return defaultBackChannelLogoutConcurrency
+	}
+
+	return c.BackChannelLogoutConcurrency
 }
 
 func (c *Config) GetAuthorizationServerIdentificationIssuer(ctx context.Context) (issuer string) {
@@ -816,6 +849,9 @@ var (
 	_ IDTokenLifespanProvider                         = (*Config)(nil)
 	_ IDTokenIssuerProvider                           = (*Config)(nil)
 	_ IDTokenValidationStrategyProvider               = (*Config)(nil)
+	_ BackChannelLogoutTokenStrategyProvider          = (*Config)(nil)
+	_ BackChannelLogoutLifespanProvider               = (*Config)(nil)
+	_ BackChannelLogoutConcurrencyProvider            = (*Config)(nil)
 	_ AuthorizationServerIssuerIdentificationProvider = (*Config)(nil)
 	_ JWKSFetcherStrategyProvider                     = (*Config)(nil)
 	_ ClientAuthenticationStrategyProvider            = (*Config)(nil)

--- a/config_default_test.go
+++ b/config_default_test.go
@@ -7,6 +7,7 @@ package oauth2
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -27,4 +28,32 @@ type testTokenValidationStrategy struct{}
 
 func (s *testTokenValidationStrategy) ValidateIDToken(ctx context.Context, request Requester, token string, opts ...IDTokenValidationOpt) (claims jwt.MapClaims, err error) {
 	return nil, nil
+}
+
+func TestConfigBackChannelLogoutDefaults(t *testing.T) {
+	config := &Config{}
+
+	assert.Nil(t, config.GetBackChannelLogoutTokenStrategy(t.Context()))
+	assert.Equal(t, time.Minute*5, config.GetBackChannelLogoutLifespan(t.Context()))
+	assert.Equal(t, 10, config.GetBackChannelLogoutConcurrency(t.Context()))
+}
+
+func TestConfigBackChannelLogoutOverrides(t *testing.T) {
+	config := &Config{
+		BackChannelLogoutLifespan:    time.Minute * 2,
+		BackChannelLogoutConcurrency: 3,
+	}
+
+	assert.Equal(t, time.Minute*2, config.GetBackChannelLogoutLifespan(t.Context()))
+	assert.Equal(t, 3, config.GetBackChannelLogoutConcurrency(t.Context()))
+}
+
+func TestConfigBackChannelLogoutNonPositiveFallsBackToDefaults(t *testing.T) {
+	config := &Config{
+		BackChannelLogoutLifespan:    -time.Second,
+		BackChannelLogoutConcurrency: -1,
+	}
+
+	assert.Equal(t, time.Minute*5, config.GetBackChannelLogoutLifespan(t.Context()))
+	assert.Equal(t, 10, config.GetBackChannelLogoutConcurrency(t.Context()))
 }

--- a/fosite.go
+++ b/fosite.go
@@ -140,6 +140,9 @@ func (a *RFC8628UserAuthorizeEndpointHandlers) Append(h RFC8628UserAuthorizeEndp
 type Configurator interface {
 	IDTokenIssuerProvider
 	IDTokenValidationStrategyProvider
+	BackChannelLogoutTokenStrategyProvider
+	BackChannelLogoutLifespanProvider
+	BackChannelLogoutConcurrencyProvider
 	IDTokenLifespanProvider
 	AuthorizationServerIssuerIdentificationProvider
 	AllowedPromptsProvider

--- a/handler/openid/strategy.go
+++ b/handler/openid/strategy.go
@@ -15,9 +15,10 @@ type OpenIDConnectTokenStrategy interface {
 	GenerateIDToken(ctx context.Context, lifespan time.Duration, request oauth2.Requester) (token string, err error)
 }
 
-type OpenIDConnectBackChannelLogoutTokenStrategy interface {
-	GenerateBackChannelLogoutToken(ctx context.Context, client oauth2.Client, lifespan time.Duration, subject, sid string, audience []string, extra map[string]any) (token string, err error)
-}
+// OpenIDConnectBackChannelLogoutTokenStrategy is an alias of oauth2.BackChannelLogoutTokenStrategy. The
+// interface lives in the root package because *Fosite methods need it and the root package cannot import this
+// one.
+type OpenIDConnectBackChannelLogoutTokenStrategy = oauth2.BackChannelLogoutTokenStrategy
 
 // TokenValidationStrategy is an alias of oauth2.TokenValidationStrategy. The interface lives in the root package
 // because *Fosite methods need it and the root package cannot import this one.

--- a/handler/openid/strategy_jwt.go
+++ b/handler/openid/strategy_jwt.go
@@ -19,18 +19,25 @@ import (
 	"authelia.com/provider/oauth2/x/errorsx"
 )
 
-const defaultExpiryTime = time.Hour
+const (
+	defaultExpiryTime                  = time.Hour
+	defaultBackChannelLogoutExpiryTime = 5 * time.Minute
+)
 
+// The Session represents the structure that a valid OpenID Connect 1.0 session has.
 type Session interface {
 	// IDTokenClaims returns a pointer to claims which will be modified in-place by handlers.
 	// Session should store this pointer and return always the same pointer.
 	IDTokenClaims() *jwt.IDTokenClaims
+
 	// IDTokenHeaders returns a pointer to header values which will be modified in-place by handlers.
 	// Session should store this pointer and return always the same pointer.
 	IDTokenHeaders() *jwt.Headers
 
+	// SetRequestedAt sets when this request was originally requested.
 	SetRequestedAt(rat time.Time)
 
+	// GetRequestedAt returns when this request was originally requested.
 	GetRequestedAt() (rat time.Time)
 
 	oauth2.Session
@@ -279,13 +286,23 @@ func (h DefaultStrategy) GenerateIDToken(ctx context.Context, lifespan time.Dura
 
 func (h DefaultStrategy) GenerateBackChannelLogoutToken(ctx context.Context, client oauth2.Client, lifespan time.Duration, subject, sid string, audience []string, extra map[string]any) (token string, err error) {
 	if lifespan == 0 {
-		lifespan = defaultExpiryTime
+		lifespan = defaultBackChannelLogoutExpiryTime
 	}
 
 	claims := jwt.NewLogoutTokenClaims(subject, audience, sid, extra)
 
+	// REQUIRED. The 'iss' claim. LogoutTokenClaims.ToMap deletes 'iss' when empty and the JWT strategy injects
+	// no claims of its own, so the issuer must be set here as it is for ID Tokens.
+	if len(claims.Issuer) == 0 {
+		claims.Issuer = h.Config.GetIDTokenIssuer(ctx)
+	}
+
 	if claims.ExpirationTime == nil || claims.ExpirationTime.IsZero() {
 		claims.ExpirationTime = jwt.NewNumericDate(time.Now().UTC().Add(lifespan))
+	}
+
+	if claims.ExpirationTime.Before(time.Now().UTC()) {
+		return "", errorsx.WithStack(oauth2.ErrServerError.WithDebug("Failed to generate Logout Token because expiry claim can not be in the past."))
 	}
 
 	token, _, err = h.Encode(

--- a/handler/openid/strategy_test.go
+++ b/handler/openid/strategy_test.go
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2026 Authelia
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package openid_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"authelia.com/provider/oauth2"
+	"authelia.com/provider/oauth2/handler/openid"
+	"authelia.com/provider/oauth2/internal/gen"
+	"authelia.com/provider/oauth2/token/jwt"
+)
+
+func TestDefaultStrategyImplementsBackChannelLogoutTokenStrategy(t *testing.T) {
+	var strategy oauth2.BackChannelLogoutTokenStrategy = &openid.DefaultStrategy{}
+
+	assert.NotNil(t, strategy)
+}
+
+func TestGenerateBackChannelLogoutTokenSetsRequiredClaims(t *testing.T) {
+	config := &oauth2.Config{IDTokenIssuer: "https://op.example/", MinParameterEntropy: 8}
+
+	jwtStrategy := &jwt.DefaultStrategy{Config: config, Issuer: jwt.NewDefaultIssuerRS256Unverified(gen.MustRSAKey())}
+
+	strategy := &openid.DefaultStrategy{Strategy: jwtStrategy, Config: config}
+
+	token, err := strategy.GenerateBackChannelLogoutToken(
+		t.Context(), &oauth2.DefaultClient{ID: "rp-1"}, time.Minute*5, "alice", "session-1", []string{"rp-1"}, nil,
+	)
+
+	require.NoError(t, err)
+
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3)
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+
+	claims := map[string]any{}
+	require.NoError(t, json.Unmarshal(payload, &claims))
+
+	assert.Equal(t, "https://op.example/", claims["iss"])
+	assert.Equal(t, []any{"rp-1"}, claims["aud"])
+	assert.NotEmpty(t, claims["iat"])
+	assert.NotEmpty(t, claims["exp"])
+	assert.NotEmpty(t, claims["jti"])
+
+	assert.Equal(t, "alice", claims["sub"])
+	assert.Equal(t, "session-1", claims["sid"])
+	assert.NotContains(t, claims, "nonce")
+}
+
+func TestGenerateBackChannelLogoutTokenDefaultsToFiveMinuteLifespan(t *testing.T) {
+	config := &oauth2.Config{IDTokenIssuer: "https://op.example/", MinParameterEntropy: 8}
+
+	jwtStrategy := &jwt.DefaultStrategy{Config: config, Issuer: jwt.NewDefaultIssuerRS256Unverified(gen.MustRSAKey())}
+
+	strategy := &openid.DefaultStrategy{Strategy: jwtStrategy, Config: config}
+
+	before := time.Now().UTC()
+
+	token, err := strategy.GenerateBackChannelLogoutToken(
+		t.Context(), &oauth2.DefaultClient{ID: "rp-1"}, 0, "alice", "session-1", []string{"rp-1"}, nil,
+	)
+
+	require.NoError(t, err)
+
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3)
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+
+	claims := map[string]any{}
+	require.NoError(t, json.Unmarshal(payload, &claims))
+
+	exp, ok := claims["exp"].(float64)
+	require.True(t, ok)
+
+	expiresAt := time.Unix(int64(exp), 0).UTC()
+
+	assert.WithinDuration(t, before.Add(5*time.Minute), expiresAt, 5*time.Second)
+	assert.Less(t, expiresAt.Sub(before), time.Hour)
+}
+
+func TestGenerateBackChannelLogoutTokenRejectsNegativeLifespan(t *testing.T) {
+	config := &oauth2.Config{IDTokenIssuer: "https://op.example/", MinParameterEntropy: 8}
+
+	jwtStrategy := &jwt.DefaultStrategy{Config: config, Issuer: jwt.NewDefaultIssuerRS256Unverified(gen.MustRSAKey())}
+
+	strategy := &openid.DefaultStrategy{Strategy: jwtStrategy, Config: config}
+
+	token, err := strategy.GenerateBackChannelLogoutToken(
+		t.Context(), &oauth2.DefaultClient{ID: "rp-1"}, -time.Hour, "alice", "session-1", []string{"rp-1"}, nil,
+	)
+
+	require.Error(t, err)
+	assert.Empty(t, token)
+	assert.ErrorIs(t, err, oauth2.ErrServerError)
+}

--- a/internal/consts/form_parameters.go
+++ b/internal/consts/form_parameters.go
@@ -45,6 +45,7 @@ const (
 	FormParameterLogoutHint                                = "logout_hint"
 	FormParameterPostLogoutRedirectURI                     = "post_logout_redirect_uri"
 	FormParameterUILocales                                 = "ui_locales"
+	FormParameterLogoutToken                               = "logout_token"
 	FormParameterRequestedTokenType                        = "requested_token_type"
 	FormParameterIssuedTokenType                           = "issued_token_type" //nolint:gosec // This is a credential type, not a credential.
 	FormParameterSubjectTokenType                          = "subject_token_type"

--- a/oauth2.go
+++ b/oauth2.go
@@ -638,3 +638,14 @@ type TokenValidationStrategy interface {
 	// Implementations must therefore tolerate Requester.GetClient returning nil.
 	ValidateIDToken(ctx context.Context, request Requester, token string, opts ...IDTokenValidationOpt) (claims jwt.MapClaims, err error)
 }
+
+// BackChannelLogoutTokenStrategy generates the Logout Tokens delivered to Relying Parties for OpenID Connect
+// Back-Channel Logout 1.0.
+//
+// See: https://openid.net/specs/openid-connect-backchannel-1_0.html
+type BackChannelLogoutTokenStrategy interface {
+	// GenerateBackChannelLogoutToken returns a signed Logout Token for the given client. The audience should
+	// name exactly the client the token is delivered to, so that each Relying Party receives a token with its
+	// own 'jti'.
+	GenerateBackChannelLogoutToken(ctx context.Context, client Client, lifespan time.Duration, subject, sid string, audience []string, extra map[string]any) (token string, err error)
+}

--- a/token/jwt/claims_id_token.go
+++ b/token/jwt/claims_id_token.go
@@ -26,6 +26,7 @@ type IDTokenClaims struct {
 	IssuedAt                            *NumericDate   `json:"iat"`
 	AuthTime                            *NumericDate   `json:"auth_time,omitempty"`
 	Nonce                               string         `json:"nonce,omitempty"`
+	SessionID                           string         `json:"sid,omitempty"`
 	AuthenticationContextClassReference string         `json:"acr,omitempty"`
 	AuthenticationMethodsReferences     []string       `json:"amr,omitempty"`
 	AuthorizedParty                     string         `json:"azp,omitempty"`
@@ -214,6 +215,8 @@ func (c *IDTokenClaims) UnmarshalJSON(data []byte) error {
 			}
 		case ClaimNonce:
 			c.Nonce, ok = value.(string)
+		case ClaimSessionID:
+			c.SessionID, ok = value.(string)
 		case ClaimAuthenticationContextClassReference:
 			c.AuthenticationContextClassReference, ok = value.(string)
 		case ClaimAuthenticationMethodsReference:
@@ -298,6 +301,12 @@ func (c *IDTokenClaims) ToMap() map[string]any {
 		delete(ret, ClaimNonce)
 	}
 
+	if len(c.SessionID) > 0 {
+		ret[ClaimSessionID] = c.SessionID
+	} else {
+		delete(ret, ClaimSessionID)
+	}
+
 	if len(c.AuthenticationContextClassReference) > 0 {
 		ret[ClaimAuthenticationContextClassReference] = c.AuthenticationContextClassReference
 	} else {
@@ -374,6 +383,10 @@ func (c *IDTokenClaims) FromMap(m map[string]any) {
 		case ClaimNonce:
 			if s, ok := v.(string); ok {
 				c.Nonce = s
+			}
+		case ClaimSessionID:
+			if s, ok := v.(string); ok {
+				c.SessionID = s
 			}
 		case ClaimAuthenticationContextClassReference:
 			if s, ok := v.(string); ok {

--- a/token/jwt/claims_id_token_test.go
+++ b/token/jwt/claims_id_token_test.go
@@ -667,3 +667,33 @@ func TestIDTokenClaims_UnmarshalJSON(t *testing.T) {
 		require.Error(t, c.UnmarshalJSON([]byte(`not-json`)))
 	})
 }
+
+func TestIDTokenClaims_SessionIDRoundTripsThroughMap(t *testing.T) {
+	claims := &IDTokenClaims{Subject: "alice", SessionID: "session-1"}
+
+	m := claims.ToMap()
+
+	assert.Equal(t, "session-1", m[ClaimSessionID])
+
+	var decoded IDTokenClaims
+
+	decoded.FromMap(m)
+
+	assert.Equal(t, "session-1", decoded.SessionID)
+	assert.NotContains(t, decoded.Extra, ClaimSessionID)
+}
+
+func TestIDTokenClaims_SessionIDOmittedWhenEmpty(t *testing.T) {
+	claims := &IDTokenClaims{Subject: "alice"}
+
+	assert.NotContains(t, claims.ToMap(), ClaimSessionID)
+}
+
+func TestIDTokenClaims_SessionIDUnmarshalsFromJSON(t *testing.T) {
+	var claims IDTokenClaims
+
+	require.NoError(t, json.Unmarshal([]byte(`{"sub":"alice","sid":"session-1"}`), &claims))
+
+	assert.Equal(t, "session-1", claims.SessionID)
+	assert.NotContains(t, claims.Extra, ClaimSessionID)
+}


### PR DESCRIPTION
This implements the OpenID Connect Back-Channel Logout 1.0 specification as described in https://openid.net/specs/openid-connect-backchannel-1_0.html by allowing a list of clients and the sub/sid claims.