### PR TITLE
fix(rfc9101): missing metadata values

### DIFF
--- a/authorize_request_handler.go
+++ b/authorize_request_handler.go
@@ -167,8 +167,18 @@ func (f *Fosite) authorizeRequestParametersFromJAR(ctx context.Context, request 
 		nrequest, nrequestURI int
 	)
 
+	// The 'require_signed_request_object' authorization server and client metadata values indicate the authorization
+	// request must be protected as a Request Object provided by either the 'request' or 'request_uri' parameter.
+	//
+	// See: https://www.rfc-editor.org/rfc/rfc9101#section-9.2 and https://www.rfc-editor.org/rfc/rfc9101#section-9.3
+	required := f.requireSignedRequestObject(ctx, request.Client, isPARRequest)
+
 	switch nrequest, nrequestURI = len(request.Form.Get(consts.FormParameterRequest)), len(request.Form.Get(consts.FormParameterRequestURI)); {
 	case nrequest+nrequestURI == 0:
+		if required {
+			return errorsx.WithStack(ErrInvalidRequest.WithHintf(hintRequestObjectRequired, hintRequestObjectPrefix(openid)).WithDebugf("The OAuth 2.0 client with id '%s' is subject to a policy which requires a signed request object but neither the 'request' nor 'request_uri' parameter was included in the request.", request.GetClient().GetID()))
+		}
+
 		return nil
 	case nrequest > 0 && nrequestURI > 0:
 		return errorsx.WithStack(ErrInvalidRequest.WithHintf("%s parameters 'request' and 'request_uri' were both used, but only one may be used in any given request.", hintRequestObjectPrefix(openid)))
@@ -206,7 +216,12 @@ func (f *Fosite) authorizeRequestParametersFromJAR(ctx context.Context, request 
 
 	switch alg = client.GetRequestObjectSigningAlg(); alg {
 	case consts.JSONWebTokenAlgNone:
-		break
+		// A client explicitly registered with a 'request_object_signing_alg' of 'none' can only ever produce an
+		// unsigned request object as the registered value is strictly enforced by the header validation below, so this
+		// requirement can never be satisfied by such a client.
+		if required {
+			return errorsx.WithStack(ErrInvalidRequest.WithHintf(hintRequestObjectRequiredSigned, hintRequestObjectPrefix(openid)).WithDebugf("The OAuth 2.0 client with id '%s' is subject to a policy which requires a signed request object but the client is registered with a 'request_object_signing_alg' value of 'none'.", request.GetClient().GetID()))
+		}
 	case "":
 		algAny = true
 	case consts.JSONWebTokenAlgHMACSHA256, consts.JSONWebTokenAlgHMACSHA384, consts.JSONWebTokenAlgHMACSHA512:
@@ -378,6 +393,30 @@ func (f *Fosite) authorizeRequestParametersFromJAR(ctx context.Context, request 
 	request.Form.Set(consts.FormParameterScope, strings.Join(claimScope, " "))
 
 	return nil
+}
+
+// requireSignedRequestObject determines if the 'require_signed_request_object' policy applies to this request. It
+// applies when either the authorization server metadata value of the same name is set, or when the individual client
+// is registered with the client metadata value of the same name. The policy is skipped for requests made directly to
+// the Pushed Authorization Request endpoint if the authorization server is configured to do so.
+//
+// See: https://www.rfc-editor.org/rfc/rfc9101#section-9.2 and https://www.rfc-editor.org/rfc/rfc9101#section-9.3
+func (f *Fosite) requireSignedRequestObject(ctx context.Context, client Client, isPARRequest bool) (require bool) {
+	config, hasConfig := f.Config.(JWTSecuredAuthorizationRequestConfigProvider)
+
+	if isPARRequest && hasConfig && config.GetRequireSignedRequestObjectSkipPushedAuthorizationRequests(ctx) {
+		return false
+	}
+
+	if hasConfig && config.GetRequireSignedRequestObject(ctx) {
+		return true
+	}
+
+	if jarc, ok := client.(JARClient); ok && jarc.GetRequireSignedRequestObject() {
+		return true
+	}
+
+	return false
 }
 
 func hintRequestObjectPrefix(openid bool) string {

--- a/authorize_request_handler_jar_required_test.go
+++ b/authorize_request_handler_jar_required_test.go
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText: 2026 Authelia
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package oauth2
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"net/url"
+	"testing"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"authelia.com/provider/oauth2/internal/consts"
+	"authelia.com/provider/oauth2/token/jwt"
+)
+
+func TestAuthorizeRequestParametersFromJARRequireSignedRequestObject(t *testing.T) {
+	keyRSA, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	jwkPublicSigRSA := &jose.JSONWebKey{
+		Key:       keyRSA.Public(),
+		KeyID:     "rs256-sig",
+		Algorithm: string(jose.RS256),
+		Use:       consts.JSONWebTokenUseSignature,
+	}
+
+	jwkPrivateSigRSA := &jose.JSONWebKey{
+		Key:       keyRSA,
+		KeyID:     "rs256-sig",
+		Algorithm: string(jose.RS256),
+		Use:       consts.JSONWebTokenUseSignature,
+	}
+
+	jwkNone := &jose.JSONWebKey{
+		Key: jwt.UnsafeAllowNoneSignatureType,
+	}
+
+	jwksPublic := &jose.JSONWebKeySet{Keys: []jose.JSONWebKey{*jwkPublicSigRSA}}
+	jwksPrivate := &jose.JSONWebKeySet{Keys: []jose.JSONWebKey{*jwkPrivateSigRSA}}
+
+	claims := jwt.MapClaims{
+		consts.FormParameterScope:        consts.ScopeOpenID,
+		consts.FormParameterState:        "some-state-value-that-is-long-enough",
+		consts.FormParameterClientID:     "foo",
+		consts.FormParameterResponseType: consts.ResponseTypeAuthorizationCodeFlow,
+		consts.ClaimIssuer:               "foo",
+		consts.ClaimAudience:             []string{"https://auth.example.com"},
+	}
+
+	assertionSigned := mustGenerateRequestObjectJWS(t, claims, nil, jwkPrivateSigRSA)
+	assertionNone := mustGenerateRequestObjectJWS(t, claims, nil, jwkNone)
+
+	baseForm := func(extra url.Values) url.Values {
+		form := url.Values{
+			consts.FormParameterScope:        {consts.ScopeOpenID},
+			consts.FormParameterClientID:     {"foo"},
+			consts.FormParameterResponseType: {consts.ResponseTypeAuthorizationCodeFlow},
+		}
+
+		for k, v := range extra {
+			form[k] = v
+		}
+
+		return form
+	}
+
+	testCases := []struct {
+		name           string
+		serverRequires bool
+		skipPAR        bool
+		par            bool
+		client         Client
+		have           url.Values
+		err            error
+		errString      string
+	}{
+		{
+			name:           "ShouldPassAbsentRequestObjectWhenNotRequired",
+			serverRequires: false,
+			client:         &DefaultJARClient{JSONWebKeys: jwksPublic, DefaultClient: &DefaultClient{ID: "foo"}},
+			have:           baseForm(nil),
+		},
+		{
+			name:           "ShouldFailAbsentRequestObjectForPARWhenSkipDisabled",
+			serverRequires: true,
+			skipPAR:        false,
+			par:            true,
+			client:         &DefaultJARClient{JSONWebKeys: jwksPublic, DefaultClient: &DefaultClient{ID: "foo"}},
+			have:           baseForm(nil),
+			err:            ErrInvalidRequest,
+		},
+		{
+			name:           "ShouldPassAbsentRequestObjectForPARWhenSkipEnabledAndRequiredByServer",
+			serverRequires: true,
+			skipPAR:        true,
+			par:            true,
+			client:         &DefaultJARClient{JSONWebKeys: jwksPublic, DefaultClient: &DefaultClient{ID: "foo"}},
+			have:           baseForm(nil),
+		},
+		{
+			name:           "ShouldPassAbsentRequestObjectForPARWhenSkipEnabledAndRequiredByClient",
+			serverRequires: false,
+			skipPAR:        true,
+			par:            true,
+			client:         &DefaultJARClient{JSONWebKeys: jwksPublic, RequireSignedRequestObject: true, DefaultClient: &DefaultClient{ID: "foo"}},
+			have:           baseForm(nil),
+		},
+		{
+			name:           "ShouldFailAbsentRequestObjectAtAuthorizeEndpointWhenSkipEnabled",
+			serverRequires: true,
+			skipPAR:        true,
+			par:            false,
+			client:         &DefaultJARClient{JSONWebKeys: jwksPublic, DefaultClient: &DefaultClient{ID: "foo"}},
+			have:           baseForm(nil),
+			err:            ErrInvalidRequest,
+		},
+		{
+			name:           "ShouldFailAbsentRequestObjectWhenRequiredByServer",
+			serverRequires: true,
+			client:         &DefaultJARClient{JSONWebKeys: jwksPublic, DefaultClient: &DefaultClient{ID: "foo"}},
+			have:           baseForm(nil),
+			err:            ErrInvalidRequest,
+			errString:      "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. OpenID Connect 1.0 requests must be protected as a Request Object provided by either the 'request' or 'request_uri' parameter, but neither parameter was included in this request. The OAuth 2.0 client with id 'foo' is subject to a policy which requires a signed request object but neither the 'request' nor 'request_uri' parameter was included in the request.",
+		},
+		{
+			name:           "ShouldFailAbsentRequestObjectWhenRequiredByClient",
+			serverRequires: false,
+			client:         &DefaultJARClient{JSONWebKeys: jwksPublic, RequireSignedRequestObject: true, DefaultClient: &DefaultClient{ID: "foo"}},
+			have:           baseForm(nil),
+			err:            ErrInvalidRequest,
+			errString:      "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. OpenID Connect 1.0 requests must be protected as a Request Object provided by either the 'request' or 'request_uri' parameter, but neither parameter was included in this request. The OAuth 2.0 client with id 'foo' is subject to a policy which requires a signed request object but neither the 'request' nor 'request_uri' parameter was included in the request.",
+		},
+		{
+			name:           "ShouldFailRegisteredAlgNoneWhenRequired",
+			serverRequires: false,
+			client:         &DefaultJARClient{JSONWebKeys: jwksPublic, RequestObjectSigningAlg: consts.JSONWebTokenAlgNone, RequireSignedRequestObject: true, DefaultClient: &DefaultClient{ID: "foo"}},
+			have:           baseForm(url.Values{consts.FormParameterRequest: {assertionNone}}),
+			err:            ErrInvalidRequest,
+			errString:      "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. OpenID Connect 1.0 requests must be protected as a signed Request Object, but the OAuth 2.0 Client is registered with a 'request_object_signing_alg' value of 'none'. The OAuth 2.0 client with id 'foo' is subject to a policy which requires a signed request object but the client is registered with a 'request_object_signing_alg' value of 'none'.",
+		},
+		{
+			name:           "ShouldFailUnsignedRequestObjectWhenRequiredAndAlgUnregistered",
+			serverRequires: true,
+			client:         &DefaultJARClient{JSONWebKeys: jwksPublic, DefaultClient: &DefaultClient{ID: "foo"}},
+			have:           baseForm(url.Values{consts.FormParameterRequest: {assertionNone}}),
+			err:            ErrInvalidRequestObject,
+		},
+		{
+			name:           "ShouldPassSignedRequestObjectWhenRequiredByServer",
+			serverRequires: true,
+			client:         &DefaultJARClient{JSONWebKeys: jwksPublic, RequestObjectSigningAlg: "RS256", DefaultClient: &DefaultClient{ID: "foo"}},
+			have:           baseForm(url.Values{consts.FormParameterRequest: {assertionSigned}}),
+		},
+		{
+			name:           "ShouldPassSignedRequestObjectWhenRequiredByClient",
+			serverRequires: false,
+			client:         &DefaultJARClient{JSONWebKeys: jwksPublic, RequestObjectSigningAlg: "RS256", RequireSignedRequestObject: true, DefaultClient: &DefaultClient{ID: "foo"}},
+			have:           baseForm(url.Values{consts.FormParameterRequest: {assertionSigned}}),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &AuthorizeRequest{
+				Request: Request{
+					Client: tc.client,
+					Form:   tc.have,
+				},
+			}
+
+			config := &Config{
+				JWKSFetcherStrategy:        NewDefaultJWKSFetcherStrategy(),
+				IDTokenIssuer:              "https://auth.example.com",
+				RequireSignedRequestObject: tc.serverRequires,
+				RequireSignedRequestObjectSkipPushedAuthorizationRequests: tc.skipPAR,
+			}
+
+			config.JWTStrategy = &jwt.DefaultStrategy{
+				Config: config,
+				Issuer: jwt.NewDefaultIssuerUnverifiedFromJWKS(jwksPrivate),
+			}
+
+			provider := &Fosite{Config: config}
+
+			actual := provider.authorizeRequestParametersFromJAR(context.Background(), r, tc.par)
+
+			if tc.err != nil {
+				require.Error(t, actual)
+				assert.EqualError(t, actual, tc.err.Error())
+
+				if tc.errString != "" {
+					assert.EqualError(t, ErrorToDebugRFC6749Error(actual), tc.errString)
+				}
+
+				return
+			}
+
+			require.NoError(t, ErrorToDebugRFC6749Error(actual))
+		})
+	}
+}
+
+func TestRequireSignedRequestObjectResolution(t *testing.T) {
+	ctx := context.Background()
+
+	clientPlain := &DefaultClient{ID: "foo"}
+	clientJARFalse := &DefaultJARClient{DefaultClient: &DefaultClient{ID: "foo"}}
+	clientJARTrue := &DefaultJARClient{RequireSignedRequestObject: true, DefaultClient: &DefaultClient{ID: "foo"}}
+
+	configSkipPAR := &Config{RequireSignedRequestObjectSkipPushedAuthorizationRequests: true}
+
+	testCases := []struct {
+		name     string
+		config   Configurator
+		client   Client
+		par      bool
+		expected bool
+	}{
+		{"ShouldNotRequireWithBareClientAndConfig", &Config{}, clientPlain, false, false},
+		{"ShouldNotRequireWithJARClientOptedOut", &Config{}, clientJARFalse, false, false},
+		{"ShouldRequireWithJARClientOptedIn", &Config{}, clientJARTrue, false, true},
+		{"ShouldRequireWithServerPolicy", &Config{RequireSignedRequestObject: true}, clientPlain, false, true},
+		{"ShouldRequireWithServerPolicyOverridingClient", &Config{RequireSignedRequestObject: true}, clientJARFalse, false, true},
+		{"ShouldRequireForPARWhenSkipDisabled", &Config{RequireSignedRequestObject: true}, clientJARTrue, true, true},
+		{"ShouldNotRequireForPARWhenSkipEnabledWithServerPolicy", &Config{RequireSignedRequestObject: true, RequireSignedRequestObjectSkipPushedAuthorizationRequests: true}, clientPlain, true, false},
+		{"ShouldNotRequireForPARWhenSkipEnabledWithClientPolicy", configSkipPAR, clientJARTrue, true, false},
+		{"ShouldRequireAtAuthorizeEndpointWhenSkipEnabled", configSkipPAR, clientJARTrue, false, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := &Fosite{Config: tc.config}
+
+			assert.Equal(t, tc.expected, provider.requireSignedRequestObject(ctx, tc.client, tc.par))
+		})
+	}
+}

--- a/client.go
+++ b/client.go
@@ -165,6 +165,15 @@ type UserInfoClient interface {
 //
 // See: https://www.rfc-editor.org/rfc/rfc9101
 type JARClient interface {
+	// GetRequireSignedRequestObject is equivalent to the 'require_signed_request_object' client metadata value which
+	// indicates where authorization request needs to be protected as a Request Object and provided through either the
+	// 'request' or 'request_uri' parameter. When true a request which does not include one of these parameters MUST be
+	// rejected, and the Request Object MUST be signed; i.e. a 'request_object_signing_alg' value of 'none' is not
+	// sufficient to satisfy this requirement.
+	//
+	// See: https://www.rfc-editor.org/rfc/rfc9101#section-9.3
+	GetRequireSignedRequestObject() (require bool)
+
 	// GetRequestObjectSigningKeyID returns the specific key identifier used to satisfy JWS requirements of the request
 	// object specifications. If unspecified the other available parameters will be utilized to select an appropriate
 	// key.
@@ -476,6 +485,7 @@ type DefaultJARClient struct {
 	RevocationEndpointAuthMethod                     string              `json:"revocation_endpoint_auth_method"`
 	PushedAuthorizationRequestEndpointAuthMethod     string              `json:"pushed_authorization_request_endpoint_auth_method"`
 	RequestURIs                                      []string            `json:"request_uris"`
+	RequireSignedRequestObject                       bool                `json:"require_signed_request_object"`
 	RequestObjectSigningKeyID                        string              `json:"request_object_signing_kid"`
 	RequestObjectSigningAlg                          string              `json:"request_object_signing_alg"`
 	RequestObjectEncryptionKeyID                     string              `json:"request_object_encryption_kid"`
@@ -592,6 +602,10 @@ func (c *DefaultJARClient) GetRevocationEndpointAuthSigningAlg() string {
 
 func (c *DefaultJARClient) GetPushedAuthorizationRequestEndpointAuthSigningAlg() (alg string) {
 	return c.PushedAuthorizationRequestEndpointAuthSigningAlg
+}
+
+func (c *DefaultJARClient) GetRequireSignedRequestObject() bool {
+	return c.RequireSignedRequestObject
 }
 
 func (c *DefaultJARClient) GetRequestObjectSigningKeyID() string {

--- a/config.go
+++ b/config.go
@@ -423,6 +423,26 @@ type PushedAuthorizeRequestConfigProvider interface {
 	GetRequirePushedAuthorizationRequests(ctx context.Context) (enforce bool)
 }
 
+// JWTSecuredAuthorizationRequestConfigProvider is the configuration provider for JWT-Secured Authorization
+// Requests (JAR).
+//
+// See: https://www.rfc-editor.org/rfc/rfc9101#section-9.2
+type JWTSecuredAuthorizationRequestConfigProvider interface {
+	// GetRequireSignedRequestObject is equivalent to the 'require_signed_request_object' authorization server metadata
+	// value which indicates if the use of JWT-Secured Authorization Requests is globally required. In this mode a
+	// client cannot pass authorization parameters via the OAuth 2.0 request syntax alone; the request must be
+	// protected as a signed Request Object provided by either the 'request' or 'request_uri' parameter.
+	GetRequireSignedRequestObject(ctx context.Context) (require bool)
+
+	// GetRequireSignedRequestObjectSkipPushedAuthorizationRequests indicates if the requirement enforced by
+	// GetRequireSignedRequestObject, or by the client metadata value of the same name, is skipped for requests made
+	// directly to the Pushed Authorization Request endpoint. A Pushed Authorization Request is submitted via an
+	// authenticated back-channel request which provides similar integrity guarantees to a Request Object, so some
+	// deployments may consider it a sufficient substitute. This does not affect requests made to the authorization
+	// endpoint.
+	GetRequireSignedRequestObjectSkipPushedAuthorizationRequests(ctx context.Context) (skip bool)
+}
+
 // AuthorizeErrorFieldResponseStrategyProvider returns the provider for the strategy used to write authorization
 // endpoint errors that cannot be delivered via a response_mode handler.
 type AuthorizeErrorFieldResponseStrategyProvider interface {

--- a/config_default.go
+++ b/config_default.go
@@ -249,6 +249,16 @@ type Config struct {
 	// RequirePushedAuthorizationRequests requires pushed authorization request for /authorize
 	RequirePushedAuthorizationRequests bool
 
+	// RequireSignedRequestObject requires all authorization requests be protected as a signed Request Object provided
+	// by either the 'request' or 'request_uri' parameter. This is equivalent to the 'require_signed_request_object'
+	// authorization server metadata value.
+	RequireSignedRequestObject bool
+
+	// RequireSignedRequestObjectSkipPushedAuthorizationRequests skips the signed Request Object requirement for
+	// requests made directly to the Pushed Authorization Request endpoint. This applies to the requirement from both
+	// the authorization server and client metadata values.
+	RequireSignedRequestObjectSkipPushedAuthorizationRequests bool
+
 	RFC8693TokenTypes map[string]RFC8693TokenType
 
 	DefaultRequestedTokenType string
@@ -657,11 +667,24 @@ func (c *Config) GetPushedAuthorizeContextLifespan(ctx context.Context) time.Dur
 	return c.PushedAuthorizeContextLifespan
 }
 
-// EnforcePushedAuthorize indicates if PAR is enforced. In this mode, a client
+// GetRequirePushedAuthorizationRequests indicates if PAR is enforced. In this mode, a client
 // cannot pass authorize parameters at the 'authorize' endpoint. The 'authorize' endpoint
 // must contain the PAR request_uri.
 func (c *Config) GetRequirePushedAuthorizationRequests(ctx context.Context) bool {
 	return c.RequirePushedAuthorizationRequests
+}
+
+// GetRequireSignedRequestObject indicates if JWT-Secured Authorization Requests are enforced. In this mode, a client
+// cannot pass authorization parameters via the OAuth 2.0 request syntax alone; the request must be protected as a
+// signed Request Object provided by either the 'request' or 'request_uri' parameter.
+func (c *Config) GetRequireSignedRequestObject(ctx context.Context) bool {
+	return c.RequireSignedRequestObject
+}
+
+// GetRequireSignedRequestObjectSkipPushedAuthorizationRequests indicates if the signed Request Object requirement is
+// skipped for requests made directly to the Pushed Authorization Request endpoint.
+func (c *Config) GetRequireSignedRequestObjectSkipPushedAuthorizationRequests(ctx context.Context) bool {
+	return c.RequireSignedRequestObjectSkipPushedAuthorizationRequests
 }
 
 func (c *Config) GetRFC8693TokenTypes(ctx context.Context) map[string]RFC8693TokenType {

--- a/errors.go
+++ b/errors.go
@@ -302,6 +302,8 @@ const (
 	hintRequestObjectPrefixJAR                      = "OAuth 2.0 JWT-Secured Authorization Request"
 	hintRequestObjectRequiredRequestSyntaxParameter = "%s parameter '%s' must be accompanied by the '%s' parameter in the request syntax."
 	hintRequestObjectFetchRequestURI                = "%s request failed to fetch request parameters from the provided 'request_uri'."
+	hintRequestObjectRequired                       = "%s requests must be protected as a Request Object provided by either the 'request' or 'request_uri' parameter, but neither parameter was included in this request."
+	hintRequestObjectRequiredSigned                 = "%s requests must be protected as a signed Request Object, but the OAuth 2.0 Client is registered with a 'request_object_signing_alg' value of 'none'."
 	hintRequestObjectValidate                       = "%s request failed with an error attempting to validate the request object."
 	hintRequestObjectInvalidAuthorizationClaim      = "%s request included a request object which excluded claims that are required or included claims that did not match the OAuth 2.0 request syntax or are generally not permitted."
 	debugRequestObjectValueMismatch                 = "The OAuth 2.0 client with id '%s' included a request object with a '%s' claim with a value of '%s' which is required to match the value '%s' in the parameter with the same name from the OAuth 2.0 request syntax."

--- a/fosite.go
+++ b/fosite.go
@@ -192,6 +192,7 @@ type Configurator interface {
 	RevocationHandlersProvider
 	PushedAuthorizeRequestHandlersProvider
 	PushedAuthorizeRequestConfigProvider
+	JWTSecuredAuthorizationRequestConfigProvider
 	RFC8693ConfigProvider
 	RFC8628DeviceAuthorizeEndpointHandlersProvider
 	RFC8628UserAuthorizeEndpointHandlersProvider


### PR DESCRIPTION
This adds the missing metadata values from the authorization server and clients.