### PR TITLE
fix: cnf claim clobbering

### DIFF
--- a/confirmation.go
+++ b/confirmation.go
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2026 Authelia
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package oauth2
+
+import (
+	"authelia.com/provider/oauth2/token/jwt"
+)
+
+// confirmationMethod is one member of the RFC 7800 'cnf' claim paired with the accessors that move it between a session
+// and a set of token claims.
+//
+// Both directions live in a single entry deliberately. An issuing side without a matching recovery side silently drops
+// the binding whenever a stateless token is introspected, because such a token's own claims are the only record of what
+// it is bound to; that asymmetry is exactly how 'jkt' came to be lost. Pairing them means a confirmation method cannot
+// be half-implemented.
+type confirmationMethod struct {
+	// name is the member name within the 'cnf' claim, for example 'jkt'.
+	name string
+
+	// get returns the binding recorded on session, or an empty string when session records none or does not support a
+	// binding of this kind at all.
+	get func(session Session) string
+
+	// set records value as the binding on session, and does nothing when session does not support a binding of this
+	// kind.
+	set func(session Session, value string)
+}
+
+// confirmationMethods enumerates every RFC 7800 confirmation method this library understands. Adding an entry is all
+// that is required for a binding to be minted into JWT profile access tokens, reported by token introspection, and
+// recovered from a stateless token; the call sites iterate this table and need no change.
+//
+// An RFC 8705 certificate-bound access token belongs here as a jwt.ClaimConfirmationX509SHA256Thumbprint entry backed
+// by a session interface shaped like DPoPBoundSession. Sourcing it from the session rather than from a session's extra
+// claims is what makes it unforgeable, for the reasons given on ApplyConfirmation.
+var confirmationMethods = []confirmationMethod{
+	{
+		name: jwt.ClaimConfirmationJWKThumbprint,
+		get: func(session Session) (jkt string) {
+			if bound, ok := session.(DPoPBoundSession); ok {
+				return bound.GetDPoPJWKThumbprint()
+			}
+
+			return ""
+		},
+		set: func(session Session, value string) {
+			if bound, ok := session.(DPoPBoundSession); ok {
+				bound.SetDPoPJWKThumbprint(value)
+			}
+		},
+	},
+}
+
+// ApplyConfirmation rebuilds the RFC 7800 'cnf' claim in claims from the bindings recorded on session, and is the only
+// supported way to write that claim.
+//
+// The claim is rebuilt rather than merged into, so it asserts exactly the bindings the server established and nothing
+// else. That matters because the claims a token is minted from include the session's extra claims, which are free-form:
+// were the existing value merged into, a 'cnf' placed there would travel into the token, and a resource server reads
+// 'cnf' as evidence that a proof-of-possession check was performed. A 'cnf' that would be left empty is removed
+// entirely, since an empty confirmation asserts nothing while still suggesting the token is bound.
+func ApplyConfirmation(claims map[string]any, session Session) {
+	if claims == nil {
+		return
+	}
+
+	cnf := map[string]any{}
+
+	for _, method := range confirmationMethods {
+		if value := method.get(session); value != "" {
+			cnf[method.name] = value
+		}
+	}
+
+	if len(cnf) == 0 {
+		delete(claims, jwt.ClaimConfirmation)
+
+		return
+	}
+
+	claims[jwt.ClaimConfirmation] = cnf
+}
+
+// RestoreConfirmation records on session the bindings asserted by the RFC 7800 'cnf' claim in claims. It is the inverse
+// of ApplyConfirmation, for a stateless token whose own claims are the only record of what it is bound to.
+//
+// The claims MUST already have been validated, because this trusts them: it is the token's signature that makes 'cnf'
+// evidence of a binding the server established rather than an assertion by whoever presented the token.
+func RestoreConfirmation(claims map[string]any, session Session) {
+	cnf := confirmationClaim(claims)
+
+	for _, method := range confirmationMethods {
+		if value, ok := cnf[method.name].(string); ok && value != "" {
+			method.set(session, value)
+		}
+	}
+}
+
+// GetDPoPConfirmationJWKThumbprint returns the 'jkt' confirmation method of the RFC 7800 'cnf' claim in claims, or an
+// empty string when the claim is absent, is not a JSON object, or carries no JWK thumbprint. It serves callers holding
+// claims but no session, such as a resource server taking the bound thumbprint out of an introspection response to hand
+// to the RFC 9449 ValidateResourceAccess.
+func GetDPoPConfirmationJWKThumbprint(claims map[string]any) (jkt string) {
+	jkt, _ = confirmationClaim(claims)[jwt.ClaimConfirmationJWKThumbprint].(string)
+
+	return jkt
+}
+
+// confirmationClaim returns the RFC 7800 'cnf' claim from claims, or nil when it is absent or is not a JSON object.
+// RFC 7800 Section 3.1 defines 'cnf' as a JSON object, so any other value asserts no confirmation method at all.
+func confirmationClaim(claims map[string]any) map[string]any {
+	switch value := claims[jwt.ClaimConfirmation].(type) {
+	case map[string]any:
+		return value
+	case jwt.MapClaims:
+		return value
+	default:
+		return nil
+	}
+}

--- a/confirmation_test.go
+++ b/confirmation_test.go
@@ -1,0 +1,228 @@
+// SPDX-FileCopyrightText: 2026 Authelia
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package oauth2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"authelia.com/provider/oauth2/token/jwt"
+)
+
+func confirmationSession(jkt string) Session {
+	session := &DefaultSession{}
+	session.SetDPoPJWKThumbprint(jkt)
+
+	return session
+}
+
+// plainSession is a Session that does not implement DPoPBoundSession at all, as distinct from one that implements it
+// and reports no binding.
+type plainSession struct {
+	Session
+}
+
+func TestApplyConfirmation(t *testing.T) {
+	testCases := []struct {
+		name     string
+		claims   map[string]any
+		session  Session
+		expected map[string]any
+	}{
+		{
+			name:     "ShouldAddConfirmationWhenBound",
+			claims:   map[string]any{jwt.ClaimSubject: "peter"},
+			session:  confirmationSession("test-jkt"),
+			expected: map[string]any{jwt.ClaimSubject: "peter", jwt.ClaimConfirmation: map[string]any{jwt.ClaimConfirmationJWKThumbprint: "test-jkt"}},
+		},
+		{
+			name:     "ShouldNotAddConfirmationWhenUnbound",
+			claims:   map[string]any{jwt.ClaimSubject: "peter"},
+			session:  confirmationSession(""),
+			expected: map[string]any{jwt.ClaimSubject: "peter"},
+		},
+		{
+			name:     "ShouldNotAddConfirmationWhenSessionDoesNotSupportBinding",
+			claims:   map[string]any{jwt.ClaimSubject: "peter"},
+			session:  &plainSession{},
+			expected: map[string]any{jwt.ClaimSubject: "peter"},
+		},
+		{
+			name:     "ShouldNotAddConfirmationWhenSessionIsNil",
+			claims:   map[string]any{jwt.ClaimSubject: "peter"},
+			session:  nil,
+			expected: map[string]any{jwt.ClaimSubject: "peter"},
+		},
+		{
+			name:     "ShouldRemoveThumbprintTheSessionDoesNotAssert",
+			claims:   map[string]any{jwt.ClaimConfirmation: map[string]any{jwt.ClaimConfirmationJWKThumbprint: "forged-jkt"}},
+			session:  confirmationSession(""),
+			expected: map[string]any{},
+		},
+		{
+			name:     "ShouldOverwriteThumbprintTheSessionDidNotEstablish",
+			claims:   map[string]any{jwt.ClaimConfirmation: map[string]any{jwt.ClaimConfirmationJWKThumbprint: "forged-jkt"}},
+			session:  confirmationSession("test-jkt"),
+			expected: map[string]any{jwt.ClaimConfirmation: map[string]any{jwt.ClaimConfirmationJWKThumbprint: "test-jkt"}},
+		},
+		{
+			// A confirmation method the session does not record is not the server's assertion to make, whichever RFC
+			// defines it. Once RFC 8705 records 'x5t#S256' on the session it is emitted from there, not from here.
+			name:     "ShouldDiscardConfirmationMethodsNotRecordedOnTheSession",
+			claims:   map[string]any{jwt.ClaimConfirmation: map[string]any{jwt.ClaimConfirmationX509SHA256Thumbprint: "forged-x5t"}},
+			session:  confirmationSession("test-jkt"),
+			expected: map[string]any{jwt.ClaimConfirmation: map[string]any{jwt.ClaimConfirmationJWKThumbprint: "test-jkt"}},
+		},
+		{
+			name:     "ShouldDiscardConfirmationMethodsNotRecordedOnTheSessionWhenUnbound",
+			claims:   map[string]any{jwt.ClaimConfirmation: map[string]any{jwt.ClaimConfirmationX509SHA256Thumbprint: "forged-x5t"}},
+			session:  confirmationSession(""),
+			expected: map[string]any{},
+		},
+		{
+			name:     "ShouldDiscardConfirmationThatIsNotAnObject",
+			claims:   map[string]any{jwt.ClaimConfirmation: "not-an-object"},
+			session:  confirmationSession("test-jkt"),
+			expected: map[string]any{jwt.ClaimConfirmation: map[string]any{jwt.ClaimConfirmationJWKThumbprint: "test-jkt"}},
+		},
+		{
+			name:     "ShouldDiscardConfirmationThatIsNotAnObjectWhenUnbound",
+			claims:   map[string]any{jwt.ClaimConfirmation: "not-an-object"},
+			session:  confirmationSession(""),
+			expected: map[string]any{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ApplyConfirmation(tc.claims, tc.session)
+
+			assert.Equal(t, tc.expected, tc.claims)
+		})
+	}
+
+	t.Run("ShouldHandleNilClaims", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			ApplyConfirmation(nil, confirmationSession("test-jkt"))
+		})
+	})
+}
+
+func TestRestoreConfirmation(t *testing.T) {
+	testCases := []struct {
+		name     string
+		claims   map[string]any
+		expected string
+	}{
+		{
+			name:     "ShouldRestoreThumbprint",
+			claims:   map[string]any{jwt.ClaimConfirmation: map[string]any{jwt.ClaimConfirmationJWKThumbprint: "test-jkt"}},
+			expected: "test-jkt",
+		},
+		{
+			name:     "ShouldRestoreThumbprintFromMapClaims",
+			claims:   map[string]any{jwt.ClaimConfirmation: jwt.MapClaims{jwt.ClaimConfirmationJWKThumbprint: "test-jkt"}},
+			expected: "test-jkt",
+		},
+		{
+			name:     "ShouldRestoreNothingWhenConfirmationAbsent",
+			claims:   map[string]any{jwt.ClaimSubject: "peter"},
+			expected: "",
+		},
+		{
+			name:     "ShouldRestoreNothingWhenConfirmationIsNotAnObject",
+			claims:   map[string]any{jwt.ClaimConfirmation: "not-an-object"},
+			expected: "",
+		},
+		{
+			name:     "ShouldRestoreNothingWhenThumbprintIsNotAString",
+			claims:   map[string]any{jwt.ClaimConfirmation: map[string]any{jwt.ClaimConfirmationJWKThumbprint: 1}},
+			expected: "",
+		},
+		{
+			name:     "ShouldRestoreNothingWhenThumbprintIsEmpty",
+			claims:   map[string]any{jwt.ClaimConfirmation: map[string]any{jwt.ClaimConfirmationJWKThumbprint: ""}},
+			expected: "",
+		},
+		{
+			name:     "ShouldRestoreNothingFromAnotherConfirmationMethod",
+			claims:   map[string]any{jwt.ClaimConfirmation: map[string]any{jwt.ClaimConfirmationX509SHA256Thumbprint: "some-x5t"}},
+			expected: "",
+		},
+		{
+			name:     "ShouldRestoreNothingWhenNilClaims",
+			claims:   nil,
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			session := &DefaultSession{}
+
+			RestoreConfirmation(tc.claims, session)
+
+			assert.Equal(t, tc.expected, session.GetDPoPJWKThumbprint())
+		})
+	}
+
+	t.Run("ShouldHandleSessionThatDoesNotSupportBinding", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			RestoreConfirmation(map[string]any{jwt.ClaimConfirmation: map[string]any{jwt.ClaimConfirmationJWKThumbprint: "test-jkt"}}, &plainSession{})
+		})
+	})
+}
+
+// TestConfirmationRoundTrip asserts that every registered confirmation method survives issuance followed by recovery.
+// It runs over confirmationMethods rather than over 'jkt' alone so that a method added later, such as the RFC 8705
+// 'x5t#S256', is covered the moment it is registered rather than only if someone remembers to write this test again.
+func TestConfirmationRoundTrip(t *testing.T) {
+	require.NotEmpty(t, confirmationMethods)
+
+	for _, method := range confirmationMethods {
+		t.Run(method.name, func(t *testing.T) {
+			source := &DefaultSession{}
+			method.set(source, "round-trip-value")
+
+			require.Equal(t, "round-trip-value", method.get(source), "DefaultSession does not record the '%s' confirmation method; give it the accessors that method's interface requires, as it does for DPoPBoundSession", method.name)
+
+			claims := map[string]any{}
+			ApplyConfirmation(claims, source)
+
+			cnf, ok := claims[jwt.ClaimConfirmation].(map[string]any)
+			require.True(t, ok, "expected cnf to be present and a map, got %#v", claims[jwt.ClaimConfirmation])
+			assert.Equal(t, "round-trip-value", cnf[method.name])
+
+			restored := &DefaultSession{}
+			RestoreConfirmation(claims, restored)
+
+			assert.Equal(t, "round-trip-value", method.get(restored), "the '%s' confirmation method was not recovered from the claims it was written to", method.name)
+		})
+	}
+}
+
+func TestGetDPoPConfirmationJWKThumbprint(t *testing.T) {
+	testCases := []struct {
+		name     string
+		claims   map[string]any
+		expected string
+	}{
+		{"ShouldReturnThumbprint", map[string]any{jwt.ClaimConfirmation: map[string]any{jwt.ClaimConfirmationJWKThumbprint: "test-jkt"}}, "test-jkt"},
+		{"ShouldReturnThumbprintFromMapClaims", map[string]any{jwt.ClaimConfirmation: jwt.MapClaims{jwt.ClaimConfirmationJWKThumbprint: "test-jkt"}}, "test-jkt"},
+		{"ShouldReturnEmptyWhenAbsent", map[string]any{}, ""},
+		{"ShouldReturnEmptyWhenNilClaims", nil, ""},
+		{"ShouldReturnEmptyWhenNotAnObject", map[string]any{jwt.ClaimConfirmation: "not-an-object"}, ""},
+		{"ShouldReturnEmptyWhenNoThumbprint", map[string]any{jwt.ClaimConfirmation: map[string]any{jwt.ClaimConfirmationX509SHA256Thumbprint: "some-x5t"}}, ""},
+		{"ShouldReturnEmptyWhenThumbprintNotAString", map[string]any{jwt.ClaimConfirmation: map[string]any{jwt.ClaimConfirmationJWKThumbprint: 1}}, ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, GetDPoPConfirmationJWKThumbprint(tc.claims))
+		})
+	}
+}

--- a/handler/oauth2/introspector_jwt.go
+++ b/handler/oauth2/introspector_jwt.go
@@ -85,6 +85,23 @@ func AccessTokenJWTToRequest(token *jwt.Token) oauth2.Requester {
 		}
 	}
 
+	session := &JWTSession{
+		JWTClaims: &claims,
+		JWTHeader: &jwt.Headers{
+			Extra: token.Header,
+		},
+		ExpiresAt: map[oauth2.TokenType]time.Time{
+			oauth2.AccessToken: claims.ExpiresAt,
+		},
+		Subject: claims.Subject,
+	}
+
+	// A stateless token's claims are the only record of what it is bound to. Without recovering those bindings the
+	// reconstructed session reports the token as unbound, and since this request replaces the caller's session on
+	// oauth2.(*Request).Merge, introspection would then omit 'cnf' entirely and a resource server would accept a bound
+	// token as a bearer token. The token's signature was verified by the caller before this point.
+	oauth2.RestoreConfirmation(mapClaims, session)
+
 	return &oauth2.Request{
 		RequestedAt: requestedAt,
 		Client: &oauth2.DefaultClient{
@@ -93,16 +110,7 @@ func AccessTokenJWTToRequest(token *jwt.Token) oauth2.Requester {
 		// We do not really know which scopes were requested, so we set them to granted.
 		RequestedScope: claims.Scope,
 		GrantedScope:   claims.Scope,
-		Session: &JWTSession{
-			JWTClaims: &claims,
-			JWTHeader: &jwt.Headers{
-				Extra: token.Header,
-			},
-			ExpiresAt: map[oauth2.TokenType]time.Time{
-				oauth2.AccessToken: claims.ExpiresAt,
-			},
-			Subject: claims.Subject,
-		},
+		Session:        session,
 		// We do not really know which audiences were requested, so we set them to granted.
 		RequestedAudience: claims.Audience,
 		GrantedAudience:   claims.Audience,

--- a/handler/oauth2/introspector_jwt_test.go
+++ b/handler/oauth2/introspector_jwt_test.go
@@ -150,6 +150,60 @@ func TestIntrospectJWT(t *testing.T) {
 	}
 }
 
+func TestIntrospectJWTRecoversDPoPBinding(t *testing.T) {
+	config := &oauth2.Config{
+		EnforceJWTProfileAccessTokens: true,
+		GlobalSecret:                  []byte("foofoofoofoofoofoofoofoofoofoofoo"),
+	}
+
+	strategy := &JWTProfileCoreStrategy{
+		HMACCoreStrategy: NewHMACCoreStrategy(config, "authelia_%s_"),
+		Strategy: &jwt.DefaultStrategy{
+			Config: config,
+			Issuer: jwt.NewDefaultIssuerRS256Unverified(gen.MustRSAKey()),
+		},
+		Config: config,
+	}
+
+	validator := &StatelessJWTValidator{
+		StatelessJWTStrategy: strategy,
+		Config: &oauth2.Config{
+			ScopeStrategy: oauth2.HierarchicScopeStrategy,
+		},
+	}
+
+	testCases := []struct {
+		name     string
+		jkt      string
+		expected string
+	}{
+		{"ShouldRecoverBindingWhenDPoPBound", "test-jkt", "test-jkt"},
+		{"ShouldReportUnboundWhenNotDPoPBound", "", ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := jwtValidCase(oauth2.AccessToken)
+
+			if tc.jkt != "" {
+				r.GetSession().(oauth2.DPoPBoundSession).SetDPoPJWKThumbprint(tc.jkt)
+			}
+
+			tokenString, _, err := strategy.GenerateAccessToken(t.Context(), r)
+			require.NoError(t, err)
+
+			areq := oauth2.NewAccessRequest(nil)
+
+			_, err = validator.IntrospectToken(t.Context(), tokenString, oauth2.AccessToken, areq, []string{})
+			require.NoError(t, err)
+
+			bound, ok := areq.GetSession().(oauth2.DPoPBoundSession)
+			require.True(t, ok, "expected the merged session to support DPoP binding, got %T", areq.GetSession())
+			assert.Equal(t, tc.expected, bound.GetDPoPJWKThumbprint())
+		})
+	}
+}
+
 func BenchmarkIntrospectJWT(b *testing.B) {
 	config := &oauth2.Config{}
 

--- a/handler/oauth2/strategy_jwt_profile.go
+++ b/handler/oauth2/strategy_jwt_profile.go
@@ -190,13 +190,9 @@ func (s *JWTProfileCoreStrategy) GenerateJWT(ctx context.Context, tokenType oaut
 
 	mapClaims := claims.ToMapClaims()
 
-	if dpop, ok := request.GetSession().(oauth2.DPoPBoundSession); ok {
-		if jkt := dpop.GetDPoPJWKThumbprint(); jkt != "" {
-			mapClaims[jwt.ClaimConfirmation] = map[string]any{
-				jwt.ClaimConfirmationJWKThumbprint: jkt,
-			}
-		}
-	}
+	// The claims above include the session's extra claims, which may carry a 'cnf' of their own. This rebuilds the
+	// claim from the session so the token asserts only the bindings the server actually established.
+	oauth2.ApplyConfirmation(mapClaims, request.GetSession())
 
 	return s.Encode(ctx, mapClaims, jwt.WithHeaders(header), jwt.WithJWTProfileAccessTokenClient(client))
 }

--- a/handler/oauth2/strategy_jwt_profile_test.go
+++ b/handler/oauth2/strategy_jwt_profile_test.go
@@ -334,6 +334,78 @@ func TestGenerateJWTIncludesCnf(t *testing.T) {
 
 		assert.NotContains(t, payload, jwt.ClaimConfirmation)
 	})
+
+	// The session's extra claims are merged into the token's claims, so a 'cnf.jkt' placed there must not be able to
+	// assert a binding no DPoP proof was ever checked against.
+	t.Run("ShouldNotAllowExtraClaimsToForgeCnfWhenNotDPoPBound", func(t *testing.T) {
+		r := jwtValidCase(oauth2.AccessToken)
+		r.GetSession().(*JWTSession).JWTClaims.Extra[jwt.ClaimConfirmation] = map[string]any{
+			jwt.ClaimConfirmationJWKThumbprint: "forged-jkt",
+		}
+
+		token, _, err := strategy.GenerateAccessToken(t.Context(), r)
+		require.NoError(t, err)
+
+		parts := strings.Split(token, ".")
+		require.Len(t, parts, 3, "%s - %v", token, parts)
+
+		rawPayload, err := base64.RawURLEncoding.DecodeString(parts[1])
+		require.NoError(t, err)
+
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(rawPayload, &payload))
+
+		assert.NotContains(t, payload, jwt.ClaimConfirmation)
+	})
+
+	t.Run("ShouldNotAllowExtraClaimsToForgeCnfWhenDPoPBound", func(t *testing.T) {
+		r := jwtValidCase(oauth2.AccessToken)
+		r.GetSession().(*JWTSession).JWTClaims.Extra[jwt.ClaimConfirmation] = map[string]any{
+			jwt.ClaimConfirmationJWKThumbprint: "forged-jkt",
+		}
+		r.GetSession().(oauth2.DPoPBoundSession).SetDPoPJWKThumbprint("test-jkt")
+
+		token, _, err := strategy.GenerateAccessToken(t.Context(), r)
+		require.NoError(t, err)
+
+		parts := strings.Split(token, ".")
+		require.Len(t, parts, 3, "%s - %v", token, parts)
+
+		rawPayload, err := base64.RawURLEncoding.DecodeString(parts[1])
+		require.NoError(t, err)
+
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(rawPayload, &payload))
+
+		cnf, ok := payload[jwt.ClaimConfirmation].(map[string]any)
+		require.True(t, ok, "expected cnf claim to be present and a map, got %#v", payload[jwt.ClaimConfirmation])
+		assert.Equal(t, "test-jkt", cnf[jwt.ClaimConfirmationJWKThumbprint])
+	})
+
+	t.Run("ShouldNotAllowExtraClaimsToSupplyOtherConfirmationMethods", func(t *testing.T) {
+		r := jwtValidCase(oauth2.AccessToken)
+		r.GetSession().(*JWTSession).JWTClaims.Extra[jwt.ClaimConfirmation] = map[string]any{
+			jwt.ClaimConfirmationX509SHA256Thumbprint: "forged-x5t",
+		}
+		r.GetSession().(oauth2.DPoPBoundSession).SetDPoPJWKThumbprint("test-jkt")
+
+		token, _, err := strategy.GenerateAccessToken(t.Context(), r)
+		require.NoError(t, err)
+
+		parts := strings.Split(token, ".")
+		require.Len(t, parts, 3, "%s - %v", token, parts)
+
+		rawPayload, err := base64.RawURLEncoding.DecodeString(parts[1])
+		require.NoError(t, err)
+
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(rawPayload, &payload))
+
+		cnf, ok := payload[jwt.ClaimConfirmation].(map[string]any)
+		require.True(t, ok, "expected cnf claim to be present and a map, got %#v", payload[jwt.ClaimConfirmation])
+		assert.Equal(t, "test-jkt", cnf[jwt.ClaimConfirmationJWKThumbprint])
+		assert.NotContains(t, cnf, jwt.ClaimConfirmationX509SHA256Thumbprint)
+	})
 }
 
 func TestSplitN(t *testing.T) {

--- a/internal/consts/claim.go
+++ b/internal/consts/claim.go
@@ -40,6 +40,7 @@ const (
 	ClaimEvents                              = "events"
 	ClaimConfirmation                        = "cnf"
 	ClaimConfirmationJWKThumbprint           = "jkt"
+	ClaimConfirmationX509SHA256Thumbprint    = "x5t#S256"
 	ClaimHTTPMethod                          = "htm"
 	ClaimHTTPURI                             = "htu"
 	ClaimDPoPAccessTokenHash                 = "ath"

--- a/introspection_response_writer.go
+++ b/introspection_response_writer.go
@@ -234,13 +234,7 @@ func (f *Fosite) WriteIntrospectionResponse(ctx context.Context, rw http.Respons
 	if r.GetAccessRequester().GetSession().GetSubject() != "" {
 		response[jwt.ClaimSubject] = r.GetAccessRequester().GetSession().GetSubject()
 	}
-	if dpop, ok := r.GetAccessRequester().GetSession().(DPoPBoundSession); ok {
-		if jkt := dpop.GetDPoPJWKThumbprint(); jkt != "" {
-			response[jwt.ClaimConfirmation] = map[string]any{
-				jwt.ClaimConfirmationJWKThumbprint: jkt,
-			}
-		}
-	}
+	ApplyConfirmation(response, r.GetAccessRequester().GetSession())
 	if aud := JoinGrantedAudienceAndResource(r.GetAccessRequester().GetGrantedAudience(), r.GetAccessRequester().GetGrantedResource()); len(aud) > 0 {
 		response[jwt.ClaimAudience] = aud
 	}

--- a/token/jwt/consts.go
+++ b/token/jwt/consts.go
@@ -73,6 +73,7 @@ const (
 	ClaimEventBackChannelLogout              = consts.ClaimEventBackChannelLogout
 	ClaimConfirmation                        = consts.ClaimConfirmation
 	ClaimConfirmationJWKThumbprint           = consts.ClaimConfirmationJWKThumbprint
+	ClaimConfirmationX509SHA256Thumbprint    = consts.ClaimConfirmationX509SHA256Thumbprint
 	ClaimHTTPMethod                          = consts.ClaimHTTPMethod
 	ClaimHTTPURI                             = consts.ClaimHTTPURI
 	ClaimDPoPAccessTokenHash                 = consts.ClaimDPoPAccessTokenHash


### PR DESCRIPTION
This fixes a future issue where the DPoP implementation would clobber other confirmations. Additionally if the imeplementer did some form of manual confirmation it would break. This resolves that issue.