### PR TITLE
feat: introspection bearer token usage audience

### DIFF
--- a/config.go
+++ b/config.go
@@ -348,6 +348,15 @@ type AllowedJWTAssertionAudiencesProvider interface {
 	GetAllowedJWTAssertionAudiences(ctx context.Context) (audiences []string)
 }
 
+// AllowedIntrospectionAudiencesProvider is a provider used in contexts where the permitted audiences for an Access
+// Token used to authenticate a request to the introspection endpoint is required to validate a request.
+type AllowedIntrospectionAudiencesProvider interface {
+	// GetAllowedIntrospectionAudiences returns the permitted audience list for introspection authentication. An empty
+	// list indicates the audience of an Access Token used to authenticate a request to the introspection endpoint is
+	// not restricted.
+	GetAllowedIntrospectionAudiences(ctx context.Context) (audiences []string)
+}
+
 // AuthorizeEndpointHandlersProvider returns the provider for configuring the authorize endpoint handlers.
 type AuthorizeEndpointHandlersProvider interface {
 	// GetAuthorizeEndpointHandlers returns the authorize endpoint handlers.

--- a/config_default.go
+++ b/config_default.go
@@ -121,6 +121,11 @@ type Config struct {
 	// (see http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth), this value MUST be set.
 	AllowedJWTAssertionAudiences []string
 
+	// AllowedIntrospectionAudiences is a list of audiences permitted for an Access Token used to authenticate a request
+	// to the introspection endpoint. When set, such an Access Token MUST have at least one of these values within its
+	// granted audience or granted RFC 8707 resource indicators. Defaults to empty which does not restrict the audience.
+	AllowedIntrospectionAudiences []string
+
 	// JWKSFetcherStrategy is responsible for fetching JSON Web Keys from remote URLs. This is required when the private_key_jwt
 	// client authentication method is used. Defaults to oauth2.DefaultJWKSFetcherStrategy.
 	JWKSFetcherStrategy jwt.JWKSFetcherStrategy
@@ -352,6 +357,10 @@ func (c *Config) GetHTTPClient(ctx context.Context) *retryablehttp.Client {
 
 func (c *Config) GetAllowedJWTAssertionAudiences(ctx context.Context) []string {
 	return c.AllowedJWTAssertionAudiences
+}
+
+func (c *Config) GetAllowedIntrospectionAudiences(ctx context.Context) (audiences []string) {
+	return c.AllowedIntrospectionAudiences
 }
 
 func (c *Config) GetFormPostHTMLTemplate(ctx context.Context) *template.Template {
@@ -861,6 +870,7 @@ var (
 	_ FormPostHTMLTemplateProvider                    = (*Config)(nil)
 	_ FormPostResponseProvider                        = (*Config)(nil)
 	_ AllowedJWTAssertionAudiencesProvider            = (*Config)(nil)
+	_ AllowedIntrospectionAudiencesProvider           = (*Config)(nil)
 	_ HTTPClientProvider                              = (*Config)(nil)
 	_ HMACHashingProvider                             = (*Config)(nil)
 	_ AuthorizeEndpointHandlersProvider               = (*Config)(nil)

--- a/fosite.go
+++ b/fosite.go
@@ -190,6 +190,7 @@ type Configurator interface {
 	FormPostHTMLTemplateProvider
 	FormPostResponseProvider
 	AllowedJWTAssertionAudiencesProvider
+	AllowedIntrospectionAudiencesProvider
 	AuthorizeEndpointHandlersProvider
 	TokenEndpointHandlersProvider
 	TokenIntrospectionHandlersProvider

--- a/introspection_request_handler.go
+++ b/introspection_request_handler.go
@@ -7,6 +7,7 @@ package oauth2
 import (
 	"context"
 	"net/http"
+	"slices"
 	"strings"
 
 	"golang.org/x/text/language"
@@ -151,12 +152,45 @@ func (f *Fosite) handleNewIntrospectionRequestClientAuthentication(ctx context.C
 			return nil, errorsx.WithStack(ErrRequestUnauthorized.WithHintf("HTTP Authorization header did not provide a token of type 'access_token', got type '%s'.", use))
 		}
 
+		if err = f.handleNewIntrospectionRequestAudience(ctx, ar); err != nil {
+			return nil, err
+		}
+
 		client = ar.GetClient()
 	} else if client, _, err = f.AuthenticateClientWithAuthHandler(ctx, r, r.PostForm, f.Config.GetIntrospectionEndpointClientAuthStrategy(ctx)); err != nil {
 		return nil, errorsx.WithStack(ErrRequestUnauthorized.WithHint("The request either did not include a known client authentication method, or contained invalid authentication details.").WithWrap(err).WithDebugError(err))
 	}
 
 	return client, nil
+}
+
+// handleNewIntrospectionRequestAudience validates the audience of the Access Token used to authenticate a request to
+// the introspection endpoint against the audiences permitted by the AllowedIntrospectionAudiencesProvider. The granted
+// audience and the granted RFC 8707 resource indicators are both considered, and the token must carry at least one of
+// the permitted values. A token with no audience at all is therefore rejected. When no audiences are configured the
+// endpoint does not restrict which Access Tokens may be used to authenticate.
+func (f *Fosite) handleNewIntrospectionRequestAudience(ctx context.Context, ar AccessRequester) (err error) {
+	allowed := f.Config.GetAllowedIntrospectionAudiences(ctx)
+
+	if len(allowed) == 0 {
+		return nil
+	}
+
+	audience := JoinGrantedAudienceAndResource(ar.GetGrantedAudience(), ar.GetGrantedResource())
+
+	for _, aud := range audience {
+		if slices.Contains(allowed, aud) {
+			return nil
+		}
+	}
+
+	outer := ErrRequestUnauthorized.WithHint("The Access Token used to authenticate the request does not have an audience which is permitted at the introspection endpoint.")
+
+	if len(audience) == 0 {
+		return errorsx.WithStack(outer.WithDebugf("The Access Token used to authenticate the request was expected to have an audience which matches one of the values '%s' but it does not have an audience.", strings.Join(allowed, "', '")))
+	}
+
+	return errorsx.WithStack(outer.WithDebugf("The Access Token used to authenticate the request was expected to have an audience which matches one of the values '%s' but the audience had the values '%s'.", strings.Join(allowed, "', '"), strings.Join(audience, "', '")))
 }
 
 type IntrospectionResponse struct {

--- a/introspection_request_handler_test.go
+++ b/introspection_request_handler_test.go
@@ -7,6 +7,7 @@ package oauth2_test
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
@@ -227,6 +228,152 @@ func TestNewIntrospectionRequest(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, tc.isActive, res.IsActive())
 			}
+		})
+	}
+}
+
+func TestNewIntrospectionRequestAllowedAudiences(t *testing.T) {
+	testCases := []struct {
+		name     string
+		allowed  []string
+		audience []string
+		resource []string
+		err      string
+	}{
+		{
+			name:     "ShouldPassWithoutConfiguredAudiencesGivenNoTokenAudience",
+			allowed:  nil,
+			audience: nil,
+			resource: nil,
+		},
+		{
+			name:     "ShouldPassWithoutConfiguredAudiencesGivenTokenAudience",
+			allowed:  nil,
+			audience: []string{"https://app.example.com"},
+			resource: nil,
+		},
+		{
+			name:     "ShouldPassWithEmptyConfiguredAudiences",
+			allowed:  []string{},
+			audience: []string{"https://app.example.com"},
+			resource: nil,
+		},
+		{
+			name:     "ShouldPassWithMatchingAudience",
+			allowed:  []string{"https://introspection.example.com"},
+			audience: []string{"https://introspection.example.com"},
+			resource: nil,
+		},
+		{
+			name:     "ShouldPassWithMatchingResource",
+			allowed:  []string{"https://introspection.example.com"},
+			audience: nil,
+			resource: []string{"https://introspection.example.com"},
+		},
+		{
+			name:     "ShouldPassWithOneMatchingAudienceOfSeveral",
+			allowed:  []string{"https://introspection.example.com"},
+			audience: []string{"https://app.example.com", "https://introspection.example.com"},
+			resource: nil,
+		},
+		{
+			name:     "ShouldPassWithOneMatchingConfiguredAudienceOfSeveral",
+			allowed:  []string{"https://other.example.com", "https://introspection.example.com"},
+			audience: []string{"https://introspection.example.com"},
+			resource: nil,
+		},
+		{
+			name:     "ShouldFailWithoutTokenAudience",
+			allowed:  []string{"https://introspection.example.com"},
+			audience: nil,
+			resource: nil,
+			err:      "The request could not be authorized. The Access Token used to authenticate the request does not have an audience which is permitted at the introspection endpoint. The Access Token used to authenticate the request was expected to have an audience which matches one of the values 'https://introspection.example.com' but it does not have an audience.",
+		},
+		{
+			name:     "ShouldFailWithMismatchedAudience",
+			allowed:  []string{"https://introspection.example.com"},
+			audience: []string{"https://app.example.com"},
+			resource: []string{"https://api.example.com"},
+			err:      "The request could not be authorized. The Access Token used to authenticate the request does not have an audience which is permitted at the introspection endpoint. The Access Token used to authenticate the request was expected to have an audience which matches one of the values 'https://introspection.example.com' but the audience had the values 'https://app.example.com', 'https://api.example.com'.",
+		},
+		{
+			name:     "ShouldFailWithPartiallyMatchingAudiencePrefix",
+			allowed:  []string{"https://introspection.example.com"},
+			audience: []string{"https://introspection.example.com.evil.com"},
+			resource: nil,
+			err:      "The request could not be authorized. The Access Token used to authenticate the request does not have an audience which is permitted at the introspection endpoint. The Access Token used to authenticate the request was expected to have an audience which matches one of the values 'https://introspection.example.com' but the audience had the values 'https://introspection.example.com.evil.com'.",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			validator := mock.NewMockTokenIntrospector(ctrl)
+			ctx := gomock.AssignableToTypeOf(context.WithValue(t.Context(), ContextKey("test"), nil))
+
+			config := &Config{AllowedIntrospectionAudiences: tc.allowed}
+
+			f := compose.ComposeAllEnabled(config, storage.NewExampleStore(), nil).(*Fosite)
+
+			config.TokenIntrospectionHandlers = TokenIntrospectionHandlers{validator}
+
+			validator.EXPECT().
+				IntrospectToken(ctx, "some-token", gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, _ string, _ TokenUse, requester AccessRequester, _ []string) (TokenUse, error) {
+					for _, aud := range tc.audience {
+						requester.GrantAudience(aud)
+					}
+
+					for _, resource := range tc.resource {
+						requester.GrantResource(resource)
+					}
+
+					return AccessToken, nil
+				})
+
+			// The introspected token is only reached when the authenticating token passes the audience check.
+			validator.EXPECT().
+				IntrospectToken(ctx, "introspect-token", gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(AccessToken, nil).
+				AnyTimes()
+
+			httpreq := &http.Request{
+				Method: http.MethodPost,
+				Header: http.Header{
+					consts.HeaderAuthorization: []string{"bearer some-token"},
+				},
+				PostForm: url.Values{
+					"token": []string{"introspect-token"},
+				},
+			}
+
+			res, err := f.NewIntrospectionRequest(t.Context(), httpreq, &DefaultSession{})
+
+			if tc.err == "" {
+				require.NoError(t, err)
+				assert.True(t, res.IsActive())
+
+				return
+			}
+
+			assert.EqualError(t, ErrorToDebugRFC6749Error(err), tc.err)
+			assert.False(t, res.IsActive())
+
+			require.True(t, errors.Is(err, ErrRequestUnauthorized))
+
+			rfc := ErrorToRFC6749Error(err)
+
+			assert.Equal(t, http.StatusUnauthorized, rfc.CodeField)
+
+			// The failure must be written out as an error rather than masked as an inactive token response.
+			rw := httptest.NewRecorder()
+
+			f.WriteIntrospectionError(t.Context(), rw, err)
+
+			assert.Equal(t, http.StatusUnauthorized, rw.Code)
+			assert.JSONEq(t, `{"error":"request_unauthorized","error_description":"The request could not be authorized. The Access Token used to authenticate the request does not have an audience which is permitted at the introspection endpoint."}`, rw.Body.String())
 		})
 	}
 }


### PR DESCRIPTION
This allows an implementer to lock down the bearer token usage of the introspection endpoint with specific audiences.